### PR TITLE
Expanding GH Actions with CloudFront cache invalidator

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,8 +1,13 @@
 name: Build and release
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
+    paths:
+      - 'client'
+      - 'cmd'
+      - 'internal'
 
 permissions:
   id-token: write
@@ -13,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENV: "prod"
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
 
     steps:
       - uses: actions/checkout@v2
@@ -32,22 +38,31 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v1
+
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y python3 python3-boto3
+
       - name: Print Versions
         run: |
            go version
+
       - name: where am i?
         run: |
           pwd
           ls
+
       - name: Run Make release
         run: |
           make all
           make release
           make release-border0
+
+      - name: Invalidate CloudFront cache for download.border0.com
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DISTRIBUTION_ID} --paths "/*"
+
       - name: See dist bin directory
         run: |
           ls -la bin

--- a/.github/workflows/manual-go.yml
+++ b/.github/workflows/manual-go.yml
@@ -1,6 +1,6 @@
 name: Manual Build and release
 
-on: 
+on:
   workflow_dispatch:
 
 permissions:
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ENV: "prod"
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
 
     steps:
       - uses: actions/checkout@v2
@@ -31,22 +32,31 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v1
+
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y python3 python3-boto3
+
       - name: Print Versions
         run: |
            go version
+
       - name: where am i?
         run: |
           pwd
           ls
+
       - name: Run Make release
         run: |
           make all
           make release
           make release-border0
+
+      - name: Invalidate CloudFront cache for download.border0.com
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DISTRIBUTION_ID} --paths "/*"
+
       - name: See dist bin directory
         run: |
           ls -la bin


### PR DESCRIPTION
- Adding secret for CF cache flush
- Expanding GH actions to clear CF cahe after build/release to S3 
- Allowing manual trigger of all actions
- Restricting main push trigger to GO code paths