### PR TITLE
[Connector] Add policies to docker plugin

### DIFF
--- a/internal/connector/discover/docker.go
+++ b/internal/connector/discover/docker.go
@@ -118,7 +118,7 @@ func (s *DockerFinder) buildSocket(connectorName string, group config.ConnectorG
 	socket.TargetPort = int(port)
 	socket.PolicyGroup = group.Group
 	socket.InstanceId = instance.ID
-
+	socket.PolicyNames = group.Policies
 	socket.SocketType = socketData.Type
 	socket.AllowedEmailAddresses = group.AllowedEmailAddresses
 	socket.AllowedEmailDomains = group.AllowedEmailDomains


### PR DESCRIPTION
policies are not attached to sockets in docker plugin, so, plugin needs to add them to the core