### PR TITLE
OPS: update github actions binary artefact version generation logic

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
       CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -35,9 +35,6 @@ jobs:
         with:
           go-version: '1.19.1' # The Go version to download (if necessary) and use.
       - run: go version
-
-      - name: Checkout
-        uses: actions/checkout@v1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,6 +45,12 @@ jobs:
         run: |
            go version
 
+      - name: Generate git repo version string
+        run: |
+          BORDER0_VERSION=$(git describe --long --dirty --tags)
+          echo ${BORDER0_VERSION}
+          echo "BORDER0_VERSION=${BORDER0_VERSION}" >> $GITHUB_ENV
+
       - name: where am i?
         run: |
           pwd

--- a/.github/workflows/manual-go.yml
+++ b/.github/workflows/manual-go.yml
@@ -15,7 +15,7 @@ jobs:
       CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -29,9 +29,6 @@ jobs:
         with:
           go-version: '1.19.1' # The Go version to download (if necessary) and use.
       - run: go version
-
-      - name: Checkout
-        uses: actions/checkout@v1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/manual-go.yml
+++ b/.github/workflows/manual-go.yml
@@ -39,6 +39,12 @@ jobs:
         run: |
            go version
 
+      - name: Generate git repo version string
+        run: |
+          BORDER0_VERSION=$(git describe --long --dirty --tags)
+          echo ${BORDER0_VERSION}
+          echo "BORDER0_VERSION=${BORDER0_VERSION}" >> $GITHUB_ENV
+
       - name: where am i?
         run: |
           pwd

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BINARY_NAME=mysocketctl
 BUCKET=pub-mysocketctl-bin
 
 DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
-VERSION := $(shell git describe --long --dirty --tags)
+VERSION=$(BORDER0_VERSION)
 FLAGS := -ldflags "-X github.com/borderzero/border0-cli/cmd.version=$(VERSION) -X github.com/borderzero/border0-cli/cmd.date=$(DATE)"
 
 all: lint moddownload test build


### PR DESCRIPTION
We are changing the way binary artefact versioning is generated and used thru the build process.
Previously the version string was being generated with each invocation of make command, we are changing that.
The version is now created at the beginning of the Github action and stored in environment variable for make command to reuse thtu the build process.