### PR TITLE
FIX: add support for upstream_* tags in docker and EC2 plugins

### DIFF
--- a/internal/connector/discover/data_tag.go
+++ b/internal/connector/discover/data_tag.go
@@ -7,18 +7,26 @@ import (
 )
 
 type SocketDataTag struct {
-	Port         string `mapstructure:"port"`
-	Type         string `mapstructure:"type"`
-	Group        string `mapstructure:"group"`
-	Host         string `mapstructure:"host"`
-	Name         string `mapstructure:"name"`
-	UpstreamUser string `mapstructure:"upstream_user"`
-	UpstreamPass string `mapstructure:"upstream_pass"`
-	UpstreamType string `mapstructure:"upstream_type"`
+	Port             string `mapstructure:"port"`
+	Type             string `mapstructure:"type"`
+	Group            string `mapstructure:"group"`
+	Host             string `mapstructure:"host"`
+	Name             string `mapstructure:"name"`
+	UpstreamUsername string `mapstructure:"upstream_username"`
+	UpstreamPassword string `mapstructure:"upstream_password"`
+	UpstreamType     string `mapstructure:"upstream_type"`
 }
 
 // Parse the tag and transform it into a structured data called SocketDataTag
-// example of tag = border0_ssh="port=22,type=ssh,group=allowed_users"
+// examples of tags:
+// border0_ssh="port=22,type=ssh,group=allowed_users"
+// border0_81="type=http,port=81,group=docker_team,name=ngx-srv1-p81"
+// border0_01="type=database,port=3306,group=docker_team,upstream_type=mysql,upstream_user=root,upstream_pass=my-secret-pw,name=my-docker-mysql-db"
+// NOTE: be aware of single and double quoting across different platforms, docker compose for example:
+// labels:
+// - "border0_80=type=http,port=80,group=my_super_ops_team"
+// - "border0_81=type=http,port=81,group=my_super_ops_team,name=ngx-srv0-p81"
+
 func parseLabels(tag string) SocketDataTag {
 	labels := map[string]string{}
 	for _, label := range strings.Split(tag, ",") {

--- a/internal/connector/discover/data_tag.go
+++ b/internal/connector/discover/data_tag.go
@@ -7,11 +7,14 @@ import (
 )
 
 type SocketDataTag struct {
-	Port  string `mapstructure:"port"`
-	Type  string `mapstructure:"type"`
-	Group string `mapstructure:"group"`
-	Host  string `mapstructure:"host"`
-	Name  string `mapstructure:"name"`
+	Port         string `mapstructure:"port"`
+	Type         string `mapstructure:"type"`
+	Group        string `mapstructure:"group"`
+	Host         string `mapstructure:"host"`
+	Name         string `mapstructure:"name"`
+	UpstreamUser string `mapstructure:"upstream_user"`
+	UpstreamPass string `mapstructure:"upstream_pass"`
+	UpstreamType string `mapstructure:"upstream_type"`
 }
 
 // Parse the tag and transform it into a structured data called SocketDataTag

--- a/internal/connector/discover/docker.go
+++ b/internal/connector/discover/docker.go
@@ -115,6 +115,10 @@ func (s *DockerFinder) buildSocket(connectorName string, group config.ConnectorG
 	socket.AllowedEmailAddresses = group.AllowedEmailAddresses
 	socket.AllowedEmailDomains = group.AllowedEmailDomains
 
+	socket.UpstreamType = socketData.UpstreamType
+	socket.UpstreamUsername = socketData.UpstreamUser
+	socket.UpstreamPassword = socketData.UpstreamPass
+
 	socket.PrivateSocket = group.PrivateSocket
 
 	socket.TargetHostname = socketData.Host

--- a/internal/connector/discover/docker.go
+++ b/internal/connector/discover/docker.go
@@ -116,8 +116,8 @@ func (s *DockerFinder) buildSocket(connectorName string, group config.ConnectorG
 	socket.AllowedEmailDomains = group.AllowedEmailDomains
 
 	socket.UpstreamType = socketData.UpstreamType
-	socket.UpstreamUsername = socketData.UpstreamUser
-	socket.UpstreamPassword = socketData.UpstreamPass
+	socket.UpstreamUsername = socketData.UpstreamUsername
+	socket.UpstreamPassword = socketData.UpstreamPassword
 
 	socket.PrivateSocket = group.PrivateSocket
 

--- a/internal/connector/discover/ec2.go
+++ b/internal/connector/discover/ec2.go
@@ -97,8 +97,8 @@ func (s *Ec2Discover) buildSocket(connectorName string, group config.ConnectorGr
 	socket.PrivateSocket = group.PrivateSocket
 
 	socket.UpstreamType = socketData.UpstreamType
-	socket.UpstreamUsername = socketData.UpstreamUser
-	socket.UpstreamPassword = socketData.UpstreamPass
+	socket.UpstreamUsername = socketData.UpstreamUsername
+	socket.UpstreamPassword = socketData.UpstreamPassword
 
 	socket.TargetHostname = socketData.Host
 	if socket.TargetHostname == "" || socket.TargetHostname == "<nil>" {

--- a/internal/connector/discover/ec2.go
+++ b/internal/connector/discover/ec2.go
@@ -96,6 +96,10 @@ func (s *Ec2Discover) buildSocket(connectorName string, group config.ConnectorGr
 	socket.AllowedEmailDomains = group.AllowedEmailDomains
 	socket.PrivateSocket = group.PrivateSocket
 
+	socket.UpstreamType = socketData.UpstreamType
+	socket.UpstreamUsername = socketData.UpstreamUser
+	socket.UpstreamPassword = socketData.UpstreamPass
+
 	socket.TargetHostname = socketData.Host
 	if socket.TargetHostname == "" || socket.TargetHostname == "<nil>" {
 		socket.TargetHostname = *instance.PrivateIpAddress


### PR DESCRIPTION
This implements parsing of ```upstream_*```  tags used in database sockets
labels such as:
```
"border0_01": "type=database,port=3306,group=infra_team,upstream_type=mysql,upstream_username=root,upstream_passpassword=my-secret-pw"
```
create functioning database sockets in Docker and EC2 plugins