### PR TITLE
[NO MERGE] FEAT: adding suffix_connector_name=true/false in EC2 and Docker plugins

### DIFF
--- a/internal/connector/config/config.go
+++ b/internal/connector/config/config.go
@@ -88,10 +88,11 @@ type NetworkPluginNetwork struct {
 }
 
 type Connector struct {
-	Name         string
-	AwsRegion    string `mapstructure:"aws-region"`
-	SSMAwsRegion string `mapstructure:"ssm-aws-region"`
-	AwsProfile   string `mapstructure:"aws-profile"`
+	Name                string
+	SuffixConnectorName bool   `mapstructure:"suffix_connector_name"`
+	AwsRegion           string `mapstructure:"aws-region"`
+	SSMAwsRegion        string `mapstructure:"ssm-aws-region"`
+	AwsProfile          string `mapstructure:"aws-profile"`
 }
 
 type SocketParams []map[string]SocketConfig

--- a/internal/connector/discover/docker.go
+++ b/internal/connector/discover/docker.go
@@ -113,9 +113,10 @@ func (s *DockerFinder) Find(ctx context.Context, cfg config.Config, state Discov
 							s.Logger.Error("Could not determine container IP... ignoring instance: ", zap.String("instanceName", instanceName))
 							continue
 						}
+						connector := cfg.Connector
 
 						s.Logger.Info("add instance as socket", zap.String("instanceName", instanceName))
-						sockets = append(sockets, s.buildSocket(cfg.Connector.Name, group, metadata, container, instanceName, ip, port))
+						sockets = append(sockets, s.buildSocket(cfg.Connector.Name, group, connector, metadata, container, instanceName, ip, port))
 					} else {
 						s.Logger.Debug("group not mached", zap.String("containerID", container.ID), zap.String("group", group.Group))
 					}
@@ -127,7 +128,7 @@ func (s *DockerFinder) Find(ctx context.Context, cfg config.Config, state Discov
 	return sockets, nil
 }
 
-func (s *DockerFinder) buildSocket(connectorName string, group config.ConnectorGroups, socketData SocketDataTag, instance types.Container, instanceName, ipAddress string, port uint16) models.Socket {
+func (s *DockerFinder) buildSocket(connectorName string, group config.ConnectorGroups, connector config.Connector, socketData SocketDataTag, instance types.Container, instanceName, ipAddress string, port uint16) models.Socket {
 	socket := models.Socket{}
 	socket.TargetPort = int(port)
 	socket.PolicyGroup = group.Group
@@ -148,7 +149,7 @@ func (s *DockerFinder) buildSocket(connectorName string, group config.ConnectorG
 		socket.TargetHostname = ipAddress
 	}
 
-	socket.Name = buildSocketName(instanceName, connectorName, socket.SocketType, socketData.Name)
+	socket.Name = buildSocketName(instanceName, connectorName, socket.SocketType, socketData.Name, connector.SuffixConnectorName)
 	if socket.PrivateSocket {
 		socket.Dnsname = socket.Name
 	}

--- a/internal/connector/discover/ec2.go
+++ b/internal/connector/discover/ec2.go
@@ -73,7 +73,8 @@ func (s *Ec2Discover) Find(ctx context.Context, cfg config.Config, state Discove
 						socketData := parseLabels(*t.Value)
 
 						if socketData.Group == group.Group {
-							socket := s.buildSocket(cfg.Connector.Name, group, socketData, *ti, instanceName)
+							connector := cfg.Connector
+							socket := s.buildSocket(cfg.Connector.Name, group, connector, socketData, *ti, instanceName)
 							sockets = append(sockets, *socket)
 						}
 					}
@@ -85,7 +86,7 @@ func (s *Ec2Discover) Find(ctx context.Context, cfg config.Config, state Discove
 	return sockets, nil
 }
 
-func (s *Ec2Discover) buildSocket(connectorName string, group config.ConnectorGroups, socketData SocketDataTag, instance ec2.Instance, instanceName string) *models.Socket {
+func (s *Ec2Discover) buildSocket(connectorName string, group config.ConnectorGroups, connector config.Connector, socketData SocketDataTag, instance ec2.Instance, instanceName string) *models.Socket {
 	socket := models.Socket{}
 	socket.TargetPort, _ = strconv.Atoi(socketData.Port)
 	socket.PolicyGroup = group.Group
@@ -108,7 +109,7 @@ func (s *Ec2Discover) buildSocket(connectorName string, group config.ConnectorGr
 	socket.PolicyNames = group.Policies
 	socket.CloudAuthEnabled = true
 
-	socket.Name = buildSocketName(instanceName, connectorName, socket.SocketType, socketData.Name, true)
+	socket.Name = buildSocketName(instanceName, connectorName, socket.SocketType, socketData.Name, connector.SuffixConnectorName)
 	if socket.PrivateSocket {
 		socket.Dnsname = socket.Name
 	}

--- a/internal/connector/discover/ec2.go
+++ b/internal/connector/discover/ec2.go
@@ -108,7 +108,7 @@ func (s *Ec2Discover) buildSocket(connectorName string, group config.ConnectorGr
 	socket.PolicyNames = group.Policies
 	socket.CloudAuthEnabled = true
 
-	socket.Name = buildSocketName(instanceName, connectorName, socket.SocketType, socketData.Name)
+	socket.Name = buildSocketName(instanceName, connectorName, socket.SocketType, socketData.Name, true)
 	if socket.PrivateSocket {
 		socket.Dnsname = socket.Name
 	}
@@ -119,25 +119,35 @@ func (s *Ec2Discover) Name() string {
 	return reflect.TypeOf(s).Elem().Name()
 }
 
-func buildSocketName(instanceName, connectorName, socketType, supplyLabelName string) string {
-	var s string
+func buildSocketName(instanceName, connectorName, socketType, supplyLabelName string, SuffixConnectorName bool) string {
+	var tempName string
+	var constructedName string
 	if supplyLabelName != "" {
-		s = supplyLabelName
+		tempName = supplyLabelName
 	} else {
-		s = instanceName
+		tempName = instanceName
 	}
 
-	s = strings.Replace(s, "_", "-", -1)
-	s = strings.Replace(s, ".", "-", -1)
-	s = strings.Replace(s, " ", "-", -1)
+	tempName = strings.Replace(tempName, "_", "-", -1)
+	tempName = strings.Replace(tempName, ".", "-", -1)
+	tempName = strings.Replace(tempName, " ", "-", -1)
 
 	if socketType == "" {
 		// In case Type is empty
 		// Ideally we do the guessing before this, dont want to duplicate code. for now just ignore.
-		return fmt.Sprintf("%v-%v", s, connectorName)
+		if SuffixConnectorName {
+			constructedName = fmt.Sprintf("%v-%v", tempName, connectorName)
+		} else {
+			constructedName = fmt.Sprintf("%v", tempName)
+		}
 	} else {
-		return fmt.Sprintf("%v-%v-%v", socketType, s, connectorName)
+		if SuffixConnectorName {
+			constructedName = fmt.Sprintf("%v-%v-%v", socketType, tempName, connectorName)
+		} else {
+			constructedName = fmt.Sprintf("%v-%v", socketType, tempName)
+		}
 	}
+	return constructedName
 }
 
 func (s *Ec2Discover) WaitSeconds() int64 {


### PR DESCRIPTION
we are adding global connector config option to enable or disabble connector name suffix in sockets
```
connector:
  name: "d0kr"
  suffix_connector_name: true
```
will append "-d0kr" to all sockets created by docker and EC2 plugins

so the new outputs will look like so:
suffix_connector_name: false

```
socket-client@xps15:~$ border0 socket ls
┌──────────────────────────────────────┬────────────────────────┬────────────────────────────────────────────────┬─────────┬──────────┬─────────────────┐
│ SOCKET ID                            │ NAME                   │ DNS NAME                                       │ PORT(S) │ TYPE     │ DESCRIPTION     │
├──────────────────────────────────────┼────────────────────────┼────────────────────────────────────────────────┼─────────┼──────────┼─────────────────┤
│ 1152266b-b357-43c0-a171-7ddb341a6c94 │ http-ngx-srv0          │ http-ngx-srv0-the-greg-rnd.border0.io          │ 80, 443 │ http     │ created by d0kr │
│ 09daa4d6-ce83-4da6-9a84-27b3565deca2 │ http-ngx-srv0-p81      │ http-ngx-srv0-p81-the-greg-rnd.border0.io      │ 80, 443 │ http     │ created by d0kr │
│ 2206730b-8f89-4dc4-9d46-de84f9ebe3d7 │ ssh-ssh-server0        │ ssh-ssh-server0-the-greg-rnd.border0.io        │ 11169   │ ssh      │ created by d0kr │
│ 0655992a-d295-437e-8dd9-87d13891d4ce │ ssh-ssh-server1        │ ssh-ssh-server1-the-greg-rnd.border0.io        │ 17008   │ ssh      │ created by d0kr │
│ cf6c61e6-ce94-4c0f-b553-0e060fefb567 │ database-mysql-server0 │ database-mysql-server0-the-greg-rnd.border0.io │ 31149   │ database │ created by d0kr │
└──────────────────────────────────────┴────────────────────────┴────────────────────────────────────────────────┴─────────┴──────────┴─────────────────┘
```
vs this
suffix_connector_name: true

```
socket-client@xps15:~$ border0 socket ls
┌──────────────────────────────────────┬─────────────────────────────┬─────────────────────────────────────────────────────┬─────────┬──────────┬─────────────────┐
│ SOCKET ID                            │ NAME                        │ DNS NAME                                            │ PORT(S) │ TYPE     │ DESCRIPTION     │
├──────────────────────────────────────┼─────────────────────────────┼─────────────────────────────────────────────────────┼─────────┼──────────┼─────────────────┤
│ 412db641-1605-41d7-a126-02edecaeca56 │ http-ngx-srv0-p81-d0kr      │ http-ngx-srv0-p81-d0kr-the-greg-rnd.border0.io      │ 80, 443 │ http     │ created by d0kr │
│ 5e93378b-fc0e-4ae4-9061-666e95297e7d │ http-ngx-srv0-d0kr          │ http-ngx-srv0-d0kr-the-greg-rnd.border0.io          │ 80, 443 │ http     │ created by d0kr │
│ 90d28b23-a636-4581-b3e6-5d54d3e3479a │ ssh-ssh-server0-d0kr        │ ssh-ssh-server0-d0kr-the-greg-rnd.border0.io        │ 22189   │ ssh      │ created by d0kr │
│ acb2afdf-5dda-4dfc-b6dc-f0f176523f91 │ ssh-ssh-server1-d0kr        │ ssh-ssh-server1-d0kr-the-greg-rnd.border0.io        │ 27635   │ ssh      │ created by d0kr │
│ 2057ae8f-3082-4e68-8168-a78dd28dcd03 │ database-mysql-server0-d0kr │ database-mysql-server0-d0kr-the-greg-rnd.border0.io │ 14609   │ database │ created by d0kr │
└──────────────────────────────────────┴─────────────────────────────┴─────────────────────────────────────────────────────┴─────────┴──────────┴─────────────────┘
```