### PR TITLE
FEAT: add BORDER0_ token environment variables

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -81,8 +81,12 @@ func APIURL() string {
 }
 
 func getToken() (string, error) {
+	if os.Getenv("BORDER0_ADMIN_TOKEN") != "" {
+		return os.Getenv("BORDER0_ADMIN_TOKEN"), nil
+	}
+
 	if _, err := os.Stat(tokenfile()); os.IsNotExist(err) {
-		return "", errors.New("please login first (no token found)")
+		return "", errors.New("API: please login first (no token found)")
 	}
 	content, err := ioutil.ReadFile(tokenfile())
 	if err != nil {

--- a/internal/client/resources.go
+++ b/internal/client/resources.go
@@ -111,6 +111,10 @@ func IsExistingClientTokenValid(homeDir string) (valid bool, token, email string
 }
 
 func GetClientToken(homeDir string) (string, error) {
+	if os.Getenv("BORDER0_CLIENT_TOKEN") != "" {
+		return os.Getenv("BORDER0_CLIENT_TOKEN"), nil
+	}
+
 	tokenFile := ClientTokenFile(homeDir)
 	if _, err := os.Stat(tokenFile); os.IsNotExist(err) {
 		fmt.Println(tokenFile)

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -440,6 +440,10 @@ func GetLatestBinary(osname string, osarch string) (string, []byte, error) {
 }
 
 func GetToken() (string, error) {
+	if os.Getenv("BORDER0_ADMIN_TOKEN") != "" {
+		return os.Getenv("BORDER0_ADMIN_TOKEN"), nil
+	}
+
 	if _, err := os.Stat(tokenfile()); os.IsNotExist(err) {
 		return "", errors.New("please login first (no token found)")
 	}


### PR DESCRIPTION
we are adding 2 envarionemnt variables for admin and client tokens BORDER0_ADMIN_TOKEN - access adming tokens, more details: https://docs.border0.com/docs/creating-access-token BORDER0_CLIENT_TOKEN - curently in development, this is client side token for frontend socket access

sample usage with docker:
```
docker run -e BORDER0_ADMIN_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ey<...>J9.qJ75mbolje96zpD9gnOnhCKTSBoEjIGDdMMeteZ7RJQ" border0:latest /code/border0 socket connect --type ssh --name border0-bastion --sshserver
```

or with docker-compose:

```
border0_bastion:
  build:
    context: "."
    dockerfile: "Dockerfile.border0_bastion"
  container_name: "border0_bastion"
  environment:
    - BORDER0_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ey<...>J9.qJ75mbolje96zpD9gnOnhCKTSBoEjIGDdMMeteZ7RJQ
```