### PR TITLE
Get rid of duplicate URL on 'border0 login' when opening browser fails

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -68,12 +68,15 @@ var loginCmd = &cobra.Command{
 			deviceIdentifier := fmt.Sprint(claims["identifier"])
 
 			url := fmt.Sprintf("%s/login?device_identifier=%v", http.WebUrl(), url.QueryEscape(deviceIdentifier))
-			fmt.Println(`please login with the link below:`)
-			fmt.Println(url)
+			fmt.Printf("Please navigate to the URL below in order to complete the login process:\n%s\n", url)
 
-			if err := open.Run(url); err != nil {
-				fmt.Printf("failed opening browser. Open the url (%s) in a browser\n", url)
-			}
+			// Try opening the system's browser automatically. The error is ignored because the desired behavior of the
+			// handler is the same regardless of whether opening the browser fails or succeeds -- we still print the URL.
+			// This is desirable because in the event opening the browser succeeds, the customer may still accidentally
+			// close the new tab / browser session, or may want to authenticate in a different browser / session. In the
+			// event that opening the browser fails, the customer may still complete authenticating by navigating to the
+			// URL in a different device.
+			_ = open.Run(url)
 
 			// Polling for token
 			i := 1


### PR DESCRIPTION
## Get rid of duplicate URL on 'border0 login' when opening browser fails

TL;DR; There's currently a duplicate message whenever opening the browser fails during the handler for `border0 login`

### Reproducing the Issue:

Need to run the border0 cli in a system without a browser, so I'm running it in a barebones Alpine Linux docker container.
e.g. dockerfile:
```
FROM alpine:latest

RUN apk add --update bash curl && rm -rf /var/cache/apk/*
RUN curl https://download.border0.com/linux_arm64/border0 -o /usr/local/bin/border0
RUN chmod +x /usr/local/bin/border0

CMD ["border0", "login"]
```

After building with `docker build . -t ${IMAGE_NAME}`

`docker run ${IMAGE_NAME}` yields:
```
please login with the link below:
https://portal.border0.com/login?device_identifier=${HIDDEN_CLIENT_GENERATED_DEVICE_IDENTIFIER}
failed opening browser. Open the url (https://portal.border0.com/login?device_identifier=${HIDDEN_CLIENT_GENERATED_DEVICE_IDENTIFIER}) in a browser
```

### After this Change

> Note: to test I had to build the linux binary for the CLI (with `make build-linux`) and include it in the container (instead of downloading latest CLI from upstream) e.g.
> ```
>FROM alpine:latest
> RUN apk add --update bash curl && rm -rf /var/cache/apk/*
> ADD mysocketctl /usr/local/bin/border0
> RUN chmod +x /usr/local/bin/border0
> CMD ["border0", "login"]
> ```

After building with `docker build . -t ${IMAGE_NAME}`

`docker run ${IMAGE_NAME}` yields:

```
Please navigate to the URL below in order to complete the login process:
https://portal.border0.com/login?device_identifier=${HIDDEN_CLIENT_GENERATED_DEVICE_IDENTIFIER}
```