### PR TITLE
Headless client login (device auth code flow)

### DIFF
--- a/internal/client/resources.go
+++ b/internal/client/resources.go
@@ -1,11 +1,11 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"os/user"
@@ -18,28 +18,96 @@ import (
 	"github.com/borderzero/border0-cli/internal/api"
 	"github.com/borderzero/border0-cli/internal/api/models"
 	"github.com/borderzero/border0-cli/internal/enum"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/fatih/color"
 	jwt "github.com/golang-jwt/jwt"
+	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 )
 
-func Login(orgID string) (token string, claims jwt.MapClaims, err error) {
-	if orgID == "" {
+// Login performs an OAuth2.0 client device authorization flow against the API
+func Login(org string) (token string, claims jwt.MapClaims, err error) {
+	if org == "" {
 		err = errors.New("empty org not allowed")
 		return
 	}
 
-	if token == "" {
-		var listener net.Listener
-		listener, err = net.Listen("tcp", "localhost:")
-		if err != nil {
-			err = errors.New("unable to start local http listener")
-			return
-		}
+	bodyBytes, err := json.Marshal(struct {
+		Organization string `json:"organization"`
+		DeviceOS     string `json:"device_os"`
+	}{
+		Organization: org,
+		DeviceOS:     runtime.GOOS,
+	})
+	if err != nil {
+		err = errors.New("unable to encode JSON request")
+		return
+	}
 
-		localPort := listener.Addr().(*net.TCPAddr).Port
-		url := fmt.Sprintf("%s/client/auth/org/%s?port=%d", api.APIURL(), orgID, localPort)
-		token = Launch(url, listener)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/client/device_authorizations", api.APIURL()), bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		err = errors.New("unable to build new http request object")
+		return
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		err = fmt.Errorf("failed to request client device authorization: %s", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("client device authorization request returned non-200 status: %d", resp.StatusCode)
+		return
+	}
+
+	bodyByt, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		err = fmt.Errorf("client device authorization response body could not be read: %s", err)
+		return
+	}
+
+	var deviceAuthorizationReponse *struct {
+		Code string `json:"code"`
+
+		AuthorizationEndpoint               string `json:"authorization_endpoint"`
+		AuthorizationEndpointCodeQueryParam string `json:"authorization_endpoint_code_query_param"`
+
+		TokenEndpoint                string `json:"token_endpoint"`
+		TokenEndpointCodeHeader      string `json:"token_endpoint_code_header"`
+		TokenEndpointPollInterval    uint64 `json:"token_endpoint_poll_interval"`
+		TokenEndpointPollMaxAttempts uint64 `json:"token_endpoint_poll_max_attempts"`
+	}
+	if err = json.Unmarshal(bodyByt, &deviceAuthorizationReponse); err != nil {
+		err = fmt.Errorf("client device authorization response body not the correct shape: %s", err)
+		return
+	}
+
+	url := fmt.Sprintf(
+		"%s%s?%s=%s",
+		api.APIURL(),
+		deviceAuthorizationReponse.AuthorizationEndpoint,
+		deviceAuthorizationReponse.AuthorizationEndpointCodeQueryParam,
+		deviceAuthorizationReponse.Code)
+	fmt.Printf("Please navigate to the URL below in order to complete the login process:\n%s\n", url)
+
+	// Try opening the system's browser automatically. The error is ignored because the desired behavior of the
+	// handler is the same regardless of whether opening the browser fails or succeeds -- we still print the URL.
+	// This is desirable because in the event opening the browser succeeds, the customer may still accidentally
+	// close the new tab / browser session, or may want to authenticate in a different browser / session. In the
+	// event that opening the browser fails, the customer may still complete authenticating by navigating to the
+	// URL in a different device.
+	_ = open.Run(url)
+
+	token, err = pollForToken(
+		org,
+		deviceAuthorizationReponse.Code,
+		deviceAuthorizationReponse.TokenEndpoint,
+		deviceAuthorizationReponse.TokenEndpointCodeHeader,
+		deviceAuthorizationReponse.TokenEndpointPollInterval,
+		deviceAuthorizationReponse.TokenEndpointPollMaxAttempts)
+	if err != nil {
+		err = fmt.Errorf("polling for authorized token failed: %s", err)
+		return
 	}
 
 	parsedJWT, err := jwt.Parse(token, nil)
@@ -54,10 +122,101 @@ func Login(orgID string) (token string, claims jwt.MapClaims, err error) {
 		return
 	}
 
+	if err = saveToken(token); err != nil {
+		err = fmt.Errorf("failed to save token: %s", err)
+		return
+	}
+
+	return token, claims, nil
+}
+
+func pollForToken(
+	org string,
+	code string,
+	tokenEndpoint string,
+	tokenEndpointCodeHeader string,
+	pollIntervalSeconds uint64,
+	pollIntervalMaxAttempts uint64,
+) (string, error) {
+	var token string
+
+	errUnauthorizedForOrg := fmt.Errorf("Authenticated user is not authorized for organization \"%s\"", org)
+	errUnexpectedStatus := errors.New("Unexpected client device authorization status")
+	errStillWaiting := errors.New("Client device authorization flow not (yet) completed")
+
+	retryFn := func() error {
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s%s", api.APIURL(), tokenEndpoint), nil)
+		if err != nil {
+			return fmt.Errorf("failed to build new request: %s", err)
+		}
+		req.Header.Add(tokenEndpointCodeHeader, code)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed request for client device authorization code status: %s", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return errors.New("non 200 back from api")
+		}
+
+		bodyByt, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("could not read response body for device auth: %s", err)
+		}
+
+		var clientDeviceAuthorizationResponse *struct {
+			Status      string `json:"status,omitempty"`
+			ClientToken string `json:"client_token,omitempty"`
+		}
+		if err := json.Unmarshal(bodyByt, &clientDeviceAuthorizationResponse); err != nil {
+			return fmt.Errorf("could not decode response body onto client device authorization object: %s", err)
+		}
+
+		switch clientDeviceAuthorizationResponse.Status {
+		case "authorized":
+			token = clientDeviceAuthorizationResponse.ClientToken
+			return nil
+		case "not_authorized":
+			return backoff.Permanent(errUnauthorizedForOrg)
+		case "waiting":
+			return errStillWaiting
+		default:
+			return errUnexpectedStatus
+		}
+	}
+
+	err := backoff.Retry(retryFn,
+		backoff.WithMaxRetries(
+			backoff.NewConstantBackOff(time.Duration(pollIntervalSeconds)*time.Second),
+			pollIntervalMaxAttempts,
+		),
+	)
+	if err != nil {
+		if errors.Is(err, errUnauthorizedForOrg) {
+			fmt.Println(fmt.Sprintf("Error: %s", err))
+			os.Exit(1)
+		}
+		if errors.Is(err, errUnexpectedStatus) {
+			fmt.Println("Error: An unknown error occured!")
+			os.Exit(1)
+		}
+		if errors.Is(err, errStillWaiting) {
+			fmt.Println(fmt.Sprintf("Error: Device authorization flow timed out after %d seconds", pollIntervalSeconds*pollIntervalMaxAttempts))
+			os.Exit(1)
+		}
+
+		// unhandled error cases are returned and eventually logged
+		return "", err
+	}
+
+	return token, nil
+}
+
+func saveToken(token string) error {
 	currentUser, err := user.Current()
 	if err != nil {
-		err = fmt.Errorf("couldn't get currently logged in operating system user: %w", err)
-		return
+		return fmt.Errorf("couldn't get currently logged in operating system user: %w", err)
 	}
 
 	// Write to client token file
@@ -67,28 +226,24 @@ func Login(orgID string) (token string, claims jwt.MapClaims, err error) {
 	configPath := filepath.Dir(tokenFile)
 	if _, err = os.Stat(configPath); os.IsNotExist(err) {
 		if err = os.Mkdir(configPath, 0700); err != nil {
-			err = fmt.Errorf("failed to create directory %s : %w", configPath, err)
-			return
+			return fmt.Errorf("failed to create directory %s : %w", configPath, err)
 		}
 	}
 
 	f, err := os.Create(tokenFile)
 	if err != nil {
-		err = fmt.Errorf("couldn't write token: %w", err)
-		return
+		return fmt.Errorf("couldn't write token: %w", err)
 	}
 	defer f.Close()
 	if err = os.Chmod(tokenFile, 0600); err != nil {
-		err = fmt.Errorf("couldn't change permission for token file: %w", err)
-		return
+		return fmt.Errorf("couldn't change permission for token file: %w", err)
 	}
 
 	if _, err = f.WriteString(fmt.Sprintf("%s\n", token)); err != nil {
-		err = fmt.Errorf("couldn't write token to file: %w", err)
-		return
+		return fmt.Errorf("couldn't write token to file: %w", err)
 	}
 
-	return token, claims, nil
+	return nil
 }
 
 func IsExistingClientTokenValid(homeDir string) (valid bool, token, email string, err error) {


### PR DESCRIPTION
# Description

This PR introduces new behavior for the `border0 client login` command such that the authorization flow now conforms to the OAuth2.0 device authorization flow https://www.rfc-editor.org/rfc/rfc8628 (and thus supports headless authentication).

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been well tested against the border0 API.

Some scenarios:

#### User not authorized for org

```
✔ ~/go/src/github.com/adrianosela/border0-cli [main|✚ 1]
14:49 $ ./border0 client login
? choose an org: anything
Please navigate to the URL below in order to complete the login process:
https://api.staging.border0.com/api/v1/client/auth/org/anything?device_identifier=${HIDDEN_CODE}
Error: Authenticated user is not authorized for organization "anything"
```

#### Device authorization code flow timed out

```
✔ ~/go/src/github.com/adrianosela/border0-cli [main|✚ 1]
14:49 $ ./border0 client login
? choose an org: anything
Please navigate to the URL below in order to complete the login process:
https://api.staging.border0.com/api/v1/client/auth/org/anything?device_identifier=${HIDDEN_CODE}
Error: Device authorization flow timed out after 240 seconds
```

#### The happy case:

```
✔ ~/go/src/github.com/adrianosela/border0-cli [main|✚ 1]
14:49 $ ./border0 client login
? choose an org: anything
Please navigate to the URL below in order to complete the login process:
https://api.staging.border0.com/api/v1/client/auth/org/anything?device_identifier=${HIDDEN_CODE}
Login successful
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
