### PR TITLE
ME-921: github actions to trigger desktop app build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,3 +70,36 @@ jobs:
         run: |
           ls -la bin
           pwd
+
+      # cross repo workflow trigger
+      # it tells mysocketio/client repo to run build_and_release.yml workflow, which re-download cli and
+      # packs the latest cli into the desktop app installer bundles, this trigger does not bump the version,
+      # so it only ensures new desktop app downloads include the updated cli binary
+      - name: Trigger client repo to rebuild
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.CLIENT_REPO_ACTIONS_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'mysocketio',
+              repo: 'client',
+              workflow_id: 'build_and_release.yml',
+              ref: 'main'
+            })
+
+      # cross repo workflow trigger
+      # it tells mysocketio/client repo to run bump_version_and_create_pr.yml workflow, which automatically
+      # bump the version in wails.json, and create a PR, this trigger bumps version in desktop app repo, once
+      # the PR is merged, a new build and release will be triggered, existing users will be notified for the
+      # new version, and new downloads will also include the updated cli binary
+      - name: Trigger client repo to create PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.CLIENT_REPO_ACTIONS_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'mysocketio',
+              repo: 'client',
+              workflow_id: 'bump_version_and_create_pr.yml',
+              ref: 'main'
+            })

--- a/.github/workflows/manual-go.yml
+++ b/.github/workflows/manual-go.yml
@@ -64,3 +64,36 @@ jobs:
         run: |
           ls -la bin
           pwd
+
+      # cross repo workflow trigger
+      # it tells mysocketio/client repo to run build_and_release.yml workflow, which re-download cli and
+      # packs the latest cli into the desktop app installer bundles, this trigger does not bump the version,
+      # so it only ensures new desktop app downloads include the updated cli binary
+      - name: Trigger client repo to rebuild
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.CLIENT_REPO_ACTIONS_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'mysocketio',
+              repo: 'client',
+              workflow_id: 'build_and_release.yml',
+              ref: 'main'
+            })
+
+      # cross repo workflow trigger
+      # it tells mysocketio/client repo to run bump_version_and_create_pr.yml workflow, which automatically
+      # bump the version in wails.json, and create a PR, this trigger bumps version in desktop app repo, once
+      # the PR is merged, a new build and release will be triggered, existing users will be notified for the
+      # new version, and new downloads will also include the updated cli binary
+      - name: Trigger client repo to create PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.CLIENT_REPO_ACTIONS_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'mysocketio',
+              repo: 'client',
+              workflow_id: 'bump_version_and_create_pr.yml',
+              ref: 'main'
+            })


### PR DESCRIPTION
# Description

on build and release in this cli repo
- trigger `mysocketio/client` repo to build and release, that will ensure the latest cli gets bundled into desktop app packages
- trigger `mysocketio/client` repo to create a new pr to bump the desktop app version, once the pr gets merged, existing desktop app users will get notified to download the new version with the latest cli bundled

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested both github workflow steps in a separate github repo, and successfully get both cross repo workflows triggered.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
