### PR TITLE
fix: only use root cert to validate certificate chain, and remove deprecated ioutil package

### DIFF
--- a/cmd/client/db/pgcli.go
+++ b/cmd/client/db/pgcli.go
@@ -19,12 +19,10 @@ var pgcliCmd = &cobra.Command{
 		}
 		hostname = pickedHost.Hostname()
 
-		certChainPath, cleanup, err := client.DownloadCertificateChain(hostname)
+		certChainPath, err := client.DownloadCertificateChain(hostname)
 		if err != nil {
-			cleanup()
 			return err
 		}
-		defer cleanup()
 
 		// Let's read preferences from the config file
 		pref, err := preference.Read()

--- a/cmd/client/db/psql.go
+++ b/cmd/client/db/psql.go
@@ -22,12 +22,10 @@ var psqlCmd = &cobra.Command{
 		}
 		hostname = pickedHost.Hostname()
 
-		certChainPath, cleanup, err := client.DownloadCertificateChain(hostname)
+		certChainPath, err := client.DownloadCertificateChain(hostname)
 		if err != nil {
-			cleanup()
 			return err
 		}
-		defer cleanup()
 
 		// Let's read preferences from the config file
 		pref, err := preference.Read()


### PR DESCRIPTION
# Description

This PR fixes the issue where border0 client db can not be used with postgres and custom domains.

Fixes # ME-978

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested locally with both custom domains and default domains.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
