### PR TITLE
[ME-1012] CI: Deep clone repo

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16


### PR DESCRIPTION
## [[ME-1012](https://mysocket.atlassian.net/browse/ME-1012)] Deep clone repo in release job

Release job is failing with `fatal: No names found, cannot describe anything.`
See https://stackoverflow.com/questions/4916492/git-describe-fails-with-fatal-no-names-found-cannot-describe-anything

Here we modify the github action that checks out the code to do a deep clone of the repo instead of the default shallow clone (fetches a single commit only).

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1012

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It does not affect the released software, so it'll be tested when its merged.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1012]: https://mysocket.atlassian.net/browse/ME-1012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ