### PR TITLE
[ME-1011] Custom IDPs: Display Name Support

### DIFF
--- a/cmd/idp/cmd_idp_add_googleworkspace.go
+++ b/cmd/idp/cmd_idp_add_googleworkspace.go
@@ -12,6 +12,7 @@ import (
 var (
 	// flags
 	idpAddGoogleWorkspaceName         string
+	idpAddGoogleWorkspaceDisplayName  string
 	idpAddGoogleWorkspaceLogoURL      string
 	idpAddGoogleWorkspaceDomain       string
 	idpAddGoogleWorkspaceClientID     string
@@ -35,9 +36,10 @@ func getIDPAddGoogleWorkspaceCmdHandler() func(cmd *cobra.Command, args []string
 
 		reqBody := identityProvider{
 			identityProviderSummary: identityProviderSummary{
-				Name:    &idpAddGoogleWorkspaceName,
-				Type:    &identityProviderTypeGoogleWorkspace,
-				LogoURL: &idpAddGoogleWorkspaceLogoURL,
+				Name:        &idpAddGoogleWorkspaceName,
+				DisplayName: &idpAddGoogleWorkspaceDisplayName,
+				Type:        &identityProviderTypeGoogleWorkspace,
+				LogoURL:     &idpAddGoogleWorkspaceLogoURL,
 			},
 			GoogleWorkspaceIdentityProviderConfiguration: &googleConfig{
 				GoogleWorkspaceDomain: &idpAddGoogleWorkspaceDomain,

--- a/cmd/idp/cmd_idp_add_oidc.go
+++ b/cmd/idp/cmd_idp_add_oidc.go
@@ -12,6 +12,7 @@ import (
 var (
 	// flags
 	idpAddOIDCName         string
+	idpAddOIDCDisplayName  string
 	idpAddOIDCLogoURL      string
 	idpAddOIDCDiscoveryURL string
 	idpAddOIDCClientID     string
@@ -40,9 +41,10 @@ func getIDPAddOIDCCmdHandler() func(cmd *cobra.Command, args []string) {
 
 		reqBody := identityProvider{
 			identityProviderSummary: identityProviderSummary{
-				Name:    &idpAddOIDCName,
-				Type:    &identityProviderTypeOIDC,
-				LogoURL: &idpAddOIDCLogoURL,
+				Name:        &idpAddOIDCName,
+				DisplayName: &idpAddOIDCDisplayName,
+				Type:        &identityProviderTypeOIDC,
+				LogoURL:     &idpAddOIDCLogoURL,
 			},
 			OIDCIdentityProviderConfiguation: &oidcConfig{
 				DiscoveryURL: &idpAddOIDCDiscoveryURL,

--- a/cmd/idp/cmd_idp_add_oktaworkforce.go
+++ b/cmd/idp/cmd_idp_add_oktaworkforce.go
@@ -12,6 +12,7 @@ import (
 var (
 	// flags
 	idpAddOktaWorkforceName         string
+	idpAddOktaWorkforceDisplayName  string
 	idpAddOktaWorkforceLogoURL      string
 	idpAddOktaWorkforceDomain       string
 	idpAddOktaWorkforceClientID     string
@@ -35,9 +36,10 @@ func getIDPAddOktaWorkforceCmdHandler() func(cmd *cobra.Command, args []string) 
 
 		reqBody := identityProvider{
 			identityProviderSummary: identityProviderSummary{
-				Name:    &idpAddOktaWorkforceName,
-				Type:    &identityProviderTypeOktaWorkforce,
-				LogoURL: &idpAddOktaWorkforceLogoURL,
+				Name:        &idpAddOktaWorkforceName,
+				DisplayName: &idpAddOktaWorkforceDisplayName,
+				Type:        &identityProviderTypeOktaWorkforce,
+				LogoURL:     &idpAddOktaWorkforceLogoURL,
 			},
 			OktaWorkforceIdentityProviderConfiguration: &oktaConfig{
 				OktaDomain:   &idpAddOktaWorkforceDomain,

--- a/cmd/idp/cmd_idp_add_saml.go
+++ b/cmd/idp/cmd_idp_add_saml.go
@@ -13,6 +13,7 @@ import (
 var (
 	// flags
 	idpAddSAMLName                          string
+	idpAddSAMLDisplayName                   string
 	idpAddSAMLLogoURL                       string
 	idpAddSAMLSignInURL                     string
 	idpAddSAMLCertificateFilename           string
@@ -55,9 +56,10 @@ func getIDPAddSAMLCmdHandler() func(cmd *cobra.Command, args []string) {
 
 		reqBody := identityProvider{
 			identityProviderSummary: identityProviderSummary{
-				Name:    &idpAddSAMLName,
-				Type:    &identityProviderTypeSAML,
-				LogoURL: &idpAddSAMLLogoURL,
+				Name:        &idpAddSAMLName,
+				DisplayName: &idpAddSAMLDisplayName,
+				Type:        &identityProviderTypeSAML,
+				LogoURL:     &idpAddSAMLLogoURL,
 			},
 			SAMLIdentityProviderConfiguration: &samlConfig{
 				SignInURL:                     &idpAddSAMLSignInURL,

--- a/cmd/idp/cmd_idp_enable.go
+++ b/cmd/idp/cmd_idp_enable.go
@@ -32,7 +32,7 @@ func getIDPEnableCmdHandler() func(cmd *cobra.Command, args []string) {
 		}
 
 		if (idpEnableName != "" && (idpEnableGoogle || idpEnableGithub)) ||
-			(idpDisableName == "" && !idpDisableGoogle && !idpDisableGithub) ||
+			(idpEnableName == "" && !idpEnableGoogle && !idpEnableGithub) ||
 			(idpEnableGoogle && idpEnableGithub) {
 			cmd.Help()
 			util.FailPretty("one (and only one) of --google, --github, or --name must set")

--- a/cmd/idp/cmd_idp_list.go
+++ b/cmd/idp/cmd_idp_list.go
@@ -58,7 +58,7 @@ func getIDPListCmdHandler() func(cmd *cobra.Command, args []string) {
 
 		// init custom providers table
 		custom := table.NewWriter()
-		custom.AppendHeader(table.Row{"Name", "Type", "Enabled"})
+		custom.AppendHeader(table.Row{"Name", "DisplayName", "Type", "Enabled"})
 
 		for _, provider := range resp.List {
 			if provider.Enabled != nil && provider.LogoURL != nil && provider.Name != nil && provider.Type != nil {
@@ -66,10 +66,10 @@ func getIDPListCmdHandler() func(cmd *cobra.Command, args []string) {
 					global.AppendRow(table.Row{*provider.Name, *provider.Enabled})
 					continue
 				}
-				custom.AppendRow(table.Row{*provider.Name, *provider.Type, *provider.Enabled})
+				custom.AppendRow(table.Row{*provider.Name, *provider.DisplayName, *provider.Type, *provider.Enabled})
 			} else {
 				// better than panic or empty fields
-				log.Println("WARNING: Some fields for an identity provider were unexpectedly empty, contact support@border0.com")
+				log.Println(fmt.Sprintf("%s Some fields for an identity provider were unexpectedly empty, contact support@border0.com", warningBanner))
 			}
 		}
 

--- a/cmd/idp/cmd_idp_show.go
+++ b/cmd/idp/cmd_idp_show.go
@@ -52,6 +52,9 @@ func getIDPShowCmdHandler() func(cmd *cobra.Command, args []string) {
 		if resp.Name != nil {
 			tb.AppendRow(table.Row{"Name", *resp.Name})
 		}
+		if resp.DisplayName != nil {
+			tb.AppendRow(table.Row{"Display Name", *resp.DisplayName})
+		}
 		if resp.Type != nil {
 			tb.AppendRow(table.Row{"Type", *resp.Type})
 		}

--- a/cmd/idp/cmd_idp_update_googleworkspace.go
+++ b/cmd/idp/cmd_idp_update_googleworkspace.go
@@ -12,6 +12,7 @@ import (
 var (
 	// flags
 	idpUpdateGoogleWorkspaceName         string
+	idpUpdateGoogleWorkspaceDisplayName  string
 	idpUpdateGoogleWorkspaceLogoURL      string
 	idpUpdateGoogleWorkspaceDomain       string
 	idpUpdateGoogleWorkspaceClientID     string
@@ -40,9 +41,10 @@ func getIDPUpdateGoogleWorkspaceCmdHandler() func(cmd *cobra.Command, args []str
 
 		reqBody := identityProvider{
 			identityProviderSummary: identityProviderSummary{
-				Name:    &idpUpdateGoogleWorkspaceName,
-				Type:    &identityProviderTypeGoogleWorkspace,
-				LogoURL: logo,
+				Name:        &idpUpdateGoogleWorkspaceName,
+				DisplayName: &idpUpdateGoogleWorkspaceDisplayName,
+				Type:        &identityProviderTypeGoogleWorkspace,
+				LogoURL:     logo,
 			},
 			GoogleWorkspaceIdentityProviderConfiguration: &googleConfig{
 				GoogleWorkspaceDomain: &idpUpdateGoogleWorkspaceDomain,

--- a/cmd/idp/cmd_idp_update_oidc.go
+++ b/cmd/idp/cmd_idp_update_oidc.go
@@ -12,6 +12,7 @@ import (
 var (
 	// flags
 	idpUpdateOIDCName         string
+	idpUpdateOIDCDisplayName  string
 	idpUpdateOIDCLogoURL      string
 	idpUpdateOIDCDiscoveryURL string
 	idpUpdateOIDCClientID     string
@@ -41,9 +42,10 @@ func getIDPUpdateOIDCCmdHandler() func(cmd *cobra.Command, args []string) {
 
 		reqBody := identityProvider{
 			identityProviderSummary: identityProviderSummary{
-				Name:    &idpUpdateOIDCName,
-				Type:    &identityProviderTypeOIDC,
-				LogoURL: logo,
+				Name:        &idpUpdateOIDCName,
+				DisplayName: &idpUpdateOIDCDisplayName,
+				Type:        &identityProviderTypeOIDC,
+				LogoURL:     logo,
 			},
 			OIDCIdentityProviderConfiguation: &oidcConfig{
 				DiscoveryURL: &idpUpdateOIDCDiscoveryURL,

--- a/cmd/idp/cmd_idp_update_oktaworkforce.go
+++ b/cmd/idp/cmd_idp_update_oktaworkforce.go
@@ -12,6 +12,7 @@ import (
 var (
 	// flags
 	idpUpdateOktaWorkforceName         string
+	idpUpdateOktaWorkforceDisplayName  string
 	idpUpdateOktaWorkforceLogoURL      string
 	idpUpdateOktaWorkforceDomain       string
 	idpUpdateOktaWorkforceClientID     string
@@ -40,9 +41,10 @@ func getIDPUpdateOktaWorkforceCmdHandler() func(cmd *cobra.Command, args []strin
 
 		reqBody := identityProvider{
 			identityProviderSummary: identityProviderSummary{
-				Name:    &idpUpdateOktaWorkforceName,
-				Type:    &identityProviderTypeOktaWorkforce,
-				LogoURL: logo,
+				Name:        &idpUpdateOktaWorkforceName,
+				DisplayName: &idpUpdateOktaWorkforceDisplayName,
+				Type:        &identityProviderTypeOktaWorkforce,
+				LogoURL:     logo,
 			},
 			OktaWorkforceIdentityProviderConfiguration: &oktaConfig{
 				OktaDomain:   &idpUpdateOktaWorkforceDomain,

--- a/cmd/idp/cmd_idp_update_saml.go
+++ b/cmd/idp/cmd_idp_update_saml.go
@@ -13,6 +13,7 @@ import (
 var (
 	// flags
 	idpUpdateSAMLName                          string
+	idpUpdateSAMLDisplayName                   string
 	idpUpdateSAMLLogoURL                       string
 	idpUpdateSAMLSignInURL                     string
 	idpUpdateSAMLCertificateFilename           string
@@ -65,9 +66,10 @@ func getIDPUpdateSAMLCmdHandler() func(cmd *cobra.Command, args []string) {
 
 		reqBody := identityProvider{
 			identityProviderSummary: identityProviderSummary{
-				Name:    &idpUpdateSAMLName,
-				Type:    &identityProviderTypeSAML,
-				LogoURL: logo,
+				Name:        &idpUpdateSAMLName,
+				DisplayName: &idpUpdateSAMLDisplayName,
+				Type:        &identityProviderTypeSAML,
+				LogoURL:     logo,
 			},
 			SAMLIdentityProviderConfiguration: &samlConfig{
 				SignInURL:                     &idpUpdateSAMLSignInURL,

--- a/cmd/idp/common.go
+++ b/cmd/idp/common.go
@@ -50,10 +50,11 @@ type samlConfig struct {
 }
 
 type identityProviderSummary struct {
-	Name    *string `json:"name,omitempty"`
-	Type    *string `json:"type,omitempty"`
-	Enabled *bool   `json:"enabled,omitempty"`
-	LogoURL *string `json:"logo_url,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	DisplayName *string `json:"display_name,omitempty"`
+	Type        *string `json:"type,omitempty"`
+	Enabled     *bool   `json:"enabled,omitempty"`
+	LogoURL     *string `json:"logo_url,omitempty"`
 }
 
 type identityProvider struct {

--- a/cmd/idp/root_idp_add.go
+++ b/cmd/idp/root_idp_add.go
@@ -17,6 +17,7 @@ func getIDPAddCmdRoot() *cobra.Command {
 		addIdentityProviderCmdRoot,
 		getIDPAddOIDCCmd(),
 		flag{name: "name", shorthand: "n", target: &idpAddOIDCName, kind: reflect.String, value: "", usage: "the name for the new identity provider", require: true},
+		flag{name: "display-name", shorthand: "m", target: &idpAddOIDCDisplayName, kind: reflect.String, value: "", usage: "the display name for the new identity provider", require: false},
 		flag{name: "logo-url", shorthand: "l", target: &idpAddOIDCLogoURL, kind: reflect.String, value: "", usage: "the url of the logo to be displayed on the organization's login page for the identity provider", require: false},
 
 		flag{name: "discovery-url", shorthand: "d", target: &idpAddOIDCDiscoveryURL, kind: reflect.String, value: "", usage: "the url where the oidc provider's discovery document is hosted", require: true},
@@ -30,6 +31,7 @@ func getIDPAddCmdRoot() *cobra.Command {
 		addIdentityProviderCmdRoot,
 		getIDPAddSAMLCmd(),
 		flag{name: "name", shorthand: "n", target: &idpAddSAMLName, kind: reflect.String, value: "", usage: "the name for the new identity provider", require: true},
+		flag{name: "display-name", shorthand: "m", target: &idpAddSAMLDisplayName, kind: reflect.String, value: "", usage: "the display name for the new identity provider", require: false},
 		flag{name: "logo-url", shorthand: "l", target: &idpAddSAMLLogoURL, kind: reflect.String, value: "", usage: "the url of the logo to be displayed on the organization's login page for the identity provider", require: false},
 
 		flag{name: "sign-in-url", shorthand: "u", target: &idpAddSAMLSignInURL, kind: reflect.String, value: "", usage: "sign-in URL for saml provider", require: true},
@@ -46,6 +48,7 @@ func getIDPAddCmdRoot() *cobra.Command {
 		addIdentityProviderCmdRoot,
 		getIDPAddOktaWorkforceCmd(),
 		flag{name: "name", shorthand: "n", target: &idpAddOktaWorkforceName, kind: reflect.String, value: "", usage: "the name for the new identity provider", require: true},
+		flag{name: "display-name", shorthand: "m", target: &idpAddOktaWorkforceDisplayName, kind: reflect.String, value: "", usage: "the display name for the new identity provider", require: false},
 		flag{name: "logo-url", shorthand: "l", target: &idpAddOktaWorkforceLogoURL, kind: reflect.String, value: "", usage: "the url of the logo to be displayed on the organization's login page for the identity provider", require: false},
 
 		flag{name: "okta-domain", shorthand: "d", target: &idpAddOktaWorkforceDomain, kind: reflect.String, value: "", usage: "the domain of your okta workforce account e.g. \"${namespace}.okta.com\"", require: true},
@@ -58,6 +61,7 @@ func getIDPAddCmdRoot() *cobra.Command {
 		addIdentityProviderCmdRoot,
 		getIDPAddGoogleWorkspaceCmd(),
 		flag{name: "name", shorthand: "n", target: &idpAddGoogleWorkspaceName, kind: reflect.String, value: "", usage: "the name for the new identity provider", require: true},
+		flag{name: "display-name", shorthand: "m", target: &idpAddGoogleWorkspaceDisplayName, kind: reflect.String, value: "", usage: "the display name for the new identity provider", require: false},
 		flag{name: "logo-url", shorthand: "l", target: &idpAddGoogleWorkspaceLogoURL, kind: reflect.String, value: "", usage: "the url of the logo to be displayed on the organization's login page for the identity provider", require: false},
 
 		flag{name: "workspace-domain", shorthand: "d", target: &idpAddGoogleWorkspaceDomain, kind: reflect.String, value: "", usage: "the domain of your google workspace account", require: true},

--- a/cmd/idp/root_idp_update.go
+++ b/cmd/idp/root_idp_update.go
@@ -16,7 +16,8 @@ func getIDPUpdateCmdRoot() *cobra.Command {
 	addCommandWithFlags(
 		addIdentityProviderCmdRoot,
 		getIDPUpdateOIDCCmd(),
-		flag{name: "name", shorthand: "n", target: &idpUpdateOIDCName, kind: reflect.String, value: "", usage: "the name of the identity provider to add", require: true},
+		flag{name: "name", shorthand: "n", target: &idpUpdateOIDCName, kind: reflect.String, value: "", usage: "the name of the identity provider to update", require: true},
+		flag{name: "display-name", shorthand: "m", target: &idpUpdateOIDCDisplayName, kind: reflect.String, value: "", usage: "the display name for the identity provider", require: false},
 		flag{name: "logo-url", shorthand: "l", target: &idpUpdateOIDCLogoURL, kind: reflect.String, value: "", usage: "the url of the logo to be displayed on the organization's login page for the identity provider", require: false},
 
 		flag{name: "discovery-url", shorthand: "d", target: &idpUpdateOIDCDiscoveryURL, kind: reflect.String, value: "", usage: "the url where the oidc provider's discovery document is hosted", require: false},
@@ -29,7 +30,8 @@ func getIDPUpdateCmdRoot() *cobra.Command {
 	addCommandWithFlags(
 		addIdentityProviderCmdRoot,
 		getIDPUpdateSAMLCmd(),
-		flag{name: "name", shorthand: "n", target: &idpUpdateSAMLName, kind: reflect.String, value: "", usage: "the name for the new identity provider", require: true},
+		flag{name: "name", shorthand: "n", target: &idpUpdateSAMLName, kind: reflect.String, value: "", usage: "the name of the identity provider to update", require: true},
+		flag{name: "display-name", shorthand: "m", target: &idpUpdateSAMLDisplayName, kind: reflect.String, value: "", usage: "the display name for the identity provider", require: false},
 		flag{name: "logo-url", shorthand: "l", target: &idpUpdateSAMLLogoURL, kind: reflect.String, value: "", usage: "the url of the logo to be displayed on the organization's login page for the identity provider", require: false},
 
 		flag{name: "sign-in-url", shorthand: "u", target: &idpUpdateSAMLSignInURL, kind: reflect.String, value: "", usage: "sign-in URL for saml provider", require: false},
@@ -45,7 +47,8 @@ func getIDPUpdateCmdRoot() *cobra.Command {
 	addCommandWithFlags(
 		addIdentityProviderCmdRoot,
 		getUpdateOktaWorkforceIdentityProviderCmd(),
-		flag{name: "name", shorthand: "n", target: &idpUpdateOktaWorkforceName, kind: reflect.String, value: "", usage: "the name for the new identity provider", require: true},
+		flag{name: "name", shorthand: "n", target: &idpUpdateOktaWorkforceName, kind: reflect.String, value: "", usage: "the name of the identity provider to update", require: true},
+		flag{name: "display-name", shorthand: "m", target: &idpUpdateOktaWorkforceDisplayName, kind: reflect.String, value: "", usage: "the display name for the identity provider", require: false},
 		flag{name: "logo-url", shorthand: "l", target: &idpUpdateOktaWorkforceLogoURL, kind: reflect.String, value: "", usage: "the url of the logo to be displayed on the organization's login page for the identity provider", require: false},
 
 		flag{name: "okta-domain", shorthand: "d", target: &idpUpdateOktaWorkforceDomain, kind: reflect.String, value: "", usage: "the domain of your okta workforce account e.g. \"${namespace}.okta.com\"", require: false},
@@ -57,7 +60,8 @@ func getIDPUpdateCmdRoot() *cobra.Command {
 	addCommandWithFlags(
 		addIdentityProviderCmdRoot,
 		getUpdateGoogleWorkspaceIdentityProviderCmd(),
-		flag{name: "name", shorthand: "n", target: &idpUpdateGoogleWorkspaceName, kind: reflect.String, value: "", usage: "the name for the new identity provider", require: true},
+		flag{name: "name", shorthand: "n", target: &idpUpdateGoogleWorkspaceName, kind: reflect.String, value: "", usage: "the name of the identity provider to update", require: true},
+		flag{name: "display-name", shorthand: "m", target: &idpUpdateGoogleWorkspaceDisplayName, kind: reflect.String, value: "", usage: "the display name for the identity provider", require: false},
 		flag{name: "logo-url", shorthand: "l", target: &idpUpdateGoogleWorkspaceLogoURL, kind: reflect.String, value: "", usage: "the url of the logo to be displayed on the organization's login page for the identity provider", require: false},
 
 		flag{name: "workspace-domain", shorthand: "d", target: &idpUpdateGoogleWorkspaceDomain, kind: reflect.String, value: "", usage: "the domain of your google workspace account", require: false},


### PR DESCRIPTION
## [[ME-1011](https://mysocket.atlassian.net/browse/ME-1011)] Custom IDPs: Display Name Support

- Adds support for setting/updating/getting/listing display names for identity providers; which need not be unique and are of a much more permissive format than names.
- Fixes a bug in the `enable` command where it was checking flags for the disable command instead of its own.
- Fixes the description of the update flags where they had copy-pasta fails from the add command's flags

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1011

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Against a local api with the changes here: https://github.com/mysocketio/api/pull/749

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1011]: https://mysocket.atlassian.net/browse/ME-1011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ