### PR TITLE
Friendly error message on ssh handshake

### DIFF
--- a/cmd/client/ssh/ssh.go
+++ b/cmd/client/ssh/ssh.go
@@ -183,6 +183,9 @@ var sshCmd = &cobra.Command{
 		fmt.Printf("\nConnecting to Server: %s:%d as %s \n", hostname, info.Port, sshLoginName)
 		serverConn, chans, reqs, err := ssh.NewClientConn(conn, hostname, sshConfig)
 		if err != nil {
+			if err.Error() == "ssh: handshake failed: EOF" {
+				return fmt.Errorf("ssh handshake failed (EOF): you might be unauthorized for this server\n")
+			}
 			return fmt.Errorf("dial into remote server error: %s", err)
 		}
 		defer serverConn.Close()


### PR DESCRIPTION
# Description

A friendlier error message when not authorized for an ssh socket

```
18:15 $ ./border0 client ssh --host mysshsocket-adrianosela.staging.border0.io

Connecting to Server: mysshsocket-adrianosela.staging.border0.io:11054 as adriano
Error: ssh handshake failed (EOF): you might be unauthorized for this server

Usage:
  border0 client ssh [flags]

Flags:
  -h, --help              help for ssh
      --host string       The ssh border0 target host
  -l, --login string      Same as username, specifies the user login to use on remote machine
  -u, --username string   Specifies the user to log in as on the remote machine(deprecated)
```

Fixes # (issue)
- none, purely aesthetic 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested against staging and production servers

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
