### PR TITLE
Friendly error message on no available ssh hosts

### DIFF
--- a/internal/client/resources.go
+++ b/internal/client/resources.go
@@ -501,6 +501,10 @@ func PickHost(inputHost string, socketTypes ...string) (models.ClientResource, e
 		hosts = append(hosts, hostToShow)
 	}
 
+	if len(hosts) < 1 {
+		return models.ClientResource{}, fmt.Errorf("No hosts available to connect to\n")
+	}
+
 	var picked string
 	if err = survey.AskOne(&survey.Select{
 		Message: "choose a host:",


### PR DESCRIPTION
# Description

A friendlier error message when not authorized for an ssh socket

### Before

```
$ border0 client ssh
Error: couldn't capture host input: please provide options to select from
Usage:
  border0 client ssh [flags]

Flags:
  -h, --help              help for ssh
      --host string       The ssh border0 target host
  -l, --login string      Same as username, specifies the user login to use on remote machine
  -u, --username string   Specifies the user to log in as on the remote machine(deprecated)
```

### After

```
$ ./border0 client ssh
Error: No hosts available to connect to

Usage:
  border0 client ssh [flags]

Flags:
  -h, --help              help for ssh
      --host string       The ssh border0 target host
  -l, --login string      Same as username, specifies the user login to use on remote machine
  -u, --username string   Specifies the user to log in as on the remote machine(deprecated)
```

Fixes # (issue)
- none, purely aesthetic 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested against staging and production servers

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
