### PR TITLE
bugfix: preference should ignore org with <nil> subdomain

### DIFF
--- a/client/preference/data.go
+++ b/client/preference/data.go
@@ -78,6 +78,10 @@ func (d *Data) Org(orgID string) *Org {
 }
 
 func (d *Data) SetOrg(input *Org) {
+	if input == nil || input.ID == "<nil>" || input.Subdomain == "<nil>" {
+		return
+	}
+
 	id := input.ID
 
 	if foundOrg, exists := d.Orgs[id]; exists {
@@ -88,22 +92,22 @@ func (d *Data) SetOrg(input *Org) {
 	d.Orgs[id] = *input
 }
 
-func (d *Data) RecentlyUsedOrgs(howMany int) Orgs {
+func (d *Data) RecentlyUsedOrgs(numOfOrgs int) Orgs {
 	var orgs []Org
 	for _, org := range d.Orgs {
-		if org.Subdomain != "" {
+		if org.Subdomain != "" && org.Subdomain != "<nil>" {
 			orgs = append(orgs, org)
 		}
 	}
-	// descending sort orgs list by last used time
+	// descending sort orgs list by the last used time
 	// most recently used orgs are at the top
 	sort.Slice(orgs, func(i, j int) bool {
 		return orgs[i].LastUsed.After(orgs[j].LastUsed)
 	})
-	if len(orgs) > howMany {
-		return orgs[:howMany]
+	if numOfOrgs <= 0 || numOfOrgs >= len(orgs) {
+		return orgs
 	}
-	return orgs
+	return orgs[:numOfOrgs]
 }
 
 func (d *Data) GetOrSuggestSocket(dnsName string, socketType string) *Socket {

--- a/client/preference/data_test.go
+++ b/client/preference/data_test.go
@@ -1,0 +1,143 @@
+package preference
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Data_SetOrg(t *testing.T) {
+	now := time.Now()
+	fiveDaysAgo := now.AddDate(0, 0, -5)
+	testOrg := Org{
+		ID:        "123",
+		Subdomain: "test",
+		LastUsed:  fiveDaysAgo,
+	}
+
+	tests := []struct {
+		name           string
+		givenData      Data
+		givenOrgToSet  *Org
+		wantOrgsLength int
+	}{
+		{
+			name:           "nil input",
+			givenData:      Data{},
+			givenOrgToSet:  nil,
+			wantOrgsLength: 0,
+		},
+		{
+			name:      "input has <nil> id and subdomain",
+			givenData: Data{},
+			givenOrgToSet: &Org{
+				ID:        "<nil>",
+				Subdomain: "<nil>",
+			},
+			wantOrgsLength: 0,
+		},
+		{
+			name: "update existing org's last used field",
+			givenData: Data{
+				Orgs: map[string]Org{
+					testOrg.ID: testOrg,
+				},
+			},
+			givenOrgToSet: &Org{
+				ID:        testOrg.ID,
+				Subdomain: testOrg.Subdomain,
+			},
+			wantOrgsLength: 1,
+		},
+		{
+			name: "add new org to the list",
+			givenData: Data{
+				Orgs: map[string]Org{
+					testOrg.ID: testOrg,
+				},
+			},
+			givenOrgToSet: &Org{
+				ID:        "456",
+				Subdomain: "test2",
+			},
+			wantOrgsLength: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.givenData.SetOrg(test.givenOrgToSet)
+
+			require.Equal(t, test.wantOrgsLength, len(test.givenData.Orgs))
+
+			if test.wantOrgsLength > 0 {
+				gotOrg := test.givenData.Org(test.givenOrgToSet.ID)
+
+				assert.Equal(t, test.givenOrgToSet.ID, gotOrg.ID)
+				assert.Equal(t, test.givenOrgToSet.Subdomain, gotOrg.Subdomain)
+				assert.True(t, gotOrg.LastUsed.After(now))
+			}
+		})
+	}
+}
+
+func Test_Data_RecentlyUsedOrgs(t *testing.T) {
+	testOrg123 := Org{
+		ID:        "123",
+		Subdomain: "test",
+		LastUsed:  time.Now().AddDate(0, 0, -5),
+	}
+	testOrg456 := Org{
+		ID:        "456",
+		Subdomain: "test2",
+		LastUsed:  time.Now(),
+	}
+	testData := Data{
+		Orgs: map[string]Org{
+			testOrg123.ID: testOrg123,
+			testOrg456.ID: testOrg456,
+			"<nil>": {
+				ID:        "<nil>",
+				Subdomain: "<nil>",
+				LastUsed:  time.Time{},
+			},
+			"": {
+				ID:        "",
+				Subdomain: "",
+				LastUsed:  time.Time{},
+			},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		given int
+		want  Orgs
+	}{
+		{
+			name:  "return all orgs",
+			given: -1,
+			want:  Orgs{testOrg456, testOrg123},
+		},
+		{
+			name:  "return only 1 org",
+			given: 1,
+			want:  Orgs{testOrg456},
+		},
+		{
+			name:  "want 3 orgs but only 2 orgs exist",
+			given: 3,
+			want:  Orgs{testOrg456, testOrg123},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotOrgs := testData.RecentlyUsedOrgs(test.given)
+
+			assert.Equal(t, test.want, gotOrgs)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Preference package should ignore org with `<nil>` subdomain. This PR fixes the bug that's illustrated in the following screenshot.

Before the fix:

![Screen Shot 2023-02-13 at 12 13 56 PM](https://user-images.githubusercontent.com/965430/218565143-800d17e5-e759-4584-801c-a81903dc6444.png)

After the fix:

![Screen Shot 2023-02-13 at 12 16 04 PM](https://user-images.githubusercontent.com/965430/218565425-b8b6d40a-7edc-47e6-86b5-fcb8ed2db474.png)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Unit tests
- Compiled the CLI and tested manually with `border0 client login`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
