### PR TITLE
[Connector] use sockets without pre created tunnels

### DIFF
--- a/internal/connector/core/core.go
+++ b/internal/connector/core/core.go
@@ -63,7 +63,7 @@ func (c *ConnectorCore) IsSocketConnected(key string) bool {
 
 func (c *ConnectorCore) TunnelConnnect(ctx context.Context, socket models.Socket) error {
 	session := ssh.NewConnection(c.logger, ssh.WithRetry(3))
-	c.connectedTunnels.m.Store(socket.ConnectorData.Key(), session)
+	c.connectedTunnels.m.Store(socket.SocketID, session)
 
 	// improve the error handling
 	userID, _, err := http.GetUserIDFromAccessToken(c.border0API.GetAccessToken())
@@ -84,13 +84,6 @@ func (c *ConnectorCore) TunnelConnnect(ctx context.Context, socket models.Socket
 	socket = *socketFromApi
 	socket.BuildConnectorDataByTags()
 
-	if len(socket.Tunnels) == 0 {
-		c.logger.Info("tunnel is empty, cannot connect to a tunnel")
-		return err
-	}
-
-	tunnel := socket.Tunnels[0]
-
 	var caCertPool *x509.CertPool
 	if socket.ConnectorAuthenticationEnabled {
 		caCertPool = x509.NewCertPool()
@@ -103,9 +96,9 @@ func (c *ConnectorCore) TunnelConnnect(ctx context.Context, socket models.Socket
 		}
 	}
 
-	err = session.Connect(ctx, *userID, socket.SocketID, tunnel.TunnelID, socket.ConnectorData.Port, socket.ConnectorData.TargetHostname, "", "", "", false, false, org.Certificates["ssh_public_key"], c.border0API.GetAccessToken(), "", socket.ConnectorAuthenticationEnabled, caCertPool)
+	err = session.Connect(ctx, *userID, socket.SocketID, "", socket.ConnectorData.Port, socket.ConnectorData.TargetHostname, "", "", "", false, false, org.Certificates["ssh_public_key"], c.border0API.GetAccessToken(), "", socket.ConnectorAuthenticationEnabled, caCertPool)
 	if err != nil {
-		c.connectedTunnels.Delete(socket.ConnectorData.Key())
+		c.connectedTunnels.Delete(socket.SocketID)
 		return err
 	}
 
@@ -120,11 +113,12 @@ func (c *ConnectorCore) HandleUpdates(ctx context.Context, sockets []models.Sock
 	}
 
 	for _, socket := range sockets {
-		if !c.IsSocketConnected(socket.ConnectorData.Key()) {
+		if !c.IsSocketConnected(socket.SocketID) {
+			fmt.Println(socket.SocketID)
 			c.logger.Info("found new socket to connect")
 
 			c.connectChan <- connectTunnelData{
-				key:    socket.ConnectorData.Key(),
+				key:    socket.SocketID,
 				socket: socket,
 				action: "connect"}
 		}
@@ -388,14 +382,6 @@ func (c *ConnectorCore) CreateSocketAndTunnel(ctx context.Context, s *models.Soc
 		log.Println(err)
 		return nil, err
 	}
-
-	tunnel, err := c.border0API.CreateTunnel(ctx, createdSocket.SocketID)
-	if err != nil {
-		log.Println(err)
-		return nil, err
-	}
-
-	createdSocket.Tunnels = append(createdSocket.Tunnels, *tunnel)
 
 	NewPolicyManager(c.logger, c.border0API).ApplyPolicies(ctx, *createdSocket, s.PolicyNames)
 	createdSocket.PolicyNames = s.PolicyNames

--- a/internal/connector/core/core_test.go
+++ b/internal/connector/core/core_test.go
@@ -16,14 +16,8 @@ import (
 
 func TestConnectorCore_SocketsCoreHandler(t *testing.T) {
 	socket := factories.SocketFactory.MustCreate().(*models.Socket)
-	tunnel := &models.Tunnel{
-		TunnelID:     "tunnel-id",
-		LocalPort:    100,
-		TunnelServer: "",
-	}
 
 	expectedSocket := *socket
-	expectedSocket.Tunnels = append(expectedSocket.Tunnels, *tunnel)
 	staticSocketPlugins := &discover.StaticSocketFinder{}
 	cfg := validConfig()
 
@@ -45,7 +39,6 @@ func TestConnectorCore_SocketsCoreHandler(t *testing.T) {
 				socket.PluginName = staticSocketPlugins.Name()
 				socket.BuildConnectorDataAndTags(cfg.Connector.Name)
 				api.EXPECT().CreateSocket(mock.Anything, mock.Anything).Return(socket, nil)
-				api.EXPECT().CreateTunnel(mock.Anything, mock.Anything).Return(tunnel, nil)
 			},
 		},
 	}


### PR DESCRIPTION

# Description

- with tunnelless sockets we don't need to pre create the tunnels
- this improves the socket connected engine using a socket_id instead of a pre generated key from the information tags

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
