### PR TITLE
[ME-1331] Fix Nil Pointer in Socket Context

### DIFF
--- a/internal/border0/socket.go
+++ b/internal/border0/socket.go
@@ -92,6 +92,8 @@ func NewSocket(ctx context.Context, border0API api.API, nameOrID string) (*Socke
 		return nil, err
 	}
 
+	sckCtx, sckCancel := context.WithCancel(ctx)
+
 	return &Socket{
 		SocketID:                       socketFromApi.SocketID,
 		SocketType:                     socketFromApi.SocketType,
@@ -103,6 +105,9 @@ func NewSocket(ctx context.Context, border0API api.API, nameOrID string) (*Socke
 		readyChan:                      make(chan bool),
 		Organization:                   org,
 		acceptChan:                     make(chan connWithError),
+
+		context: sckCtx,
+		cancel:  sckCancel,
 	}, nil
 }
 
@@ -130,7 +135,6 @@ func (s *Socket) WithProxy(proxyHost string) error {
 }
 
 func (s *Socket) Listen() (net.Listener, error) {
-	s.context, s.cancel = context.WithCancel(context.Background())
 	s.border0API.StartRefreshAccessTokenJob(s.context)
 
 	if s.ConnectorAuthenticationEnabled {


### PR DESCRIPTION
# [[ME-1331](https://mysocket.atlassian.net/browse/ME-1331)] Fix Nil Pointer in Socket Context

Fixes a bug in connector where if the `sck.IsClosed()` is called prior to `sck.Listen()` -- we run into a nil pointer dereference.

Example stack trace:

```
Apr 25 14:41:27 rpi4-0 fcbdb9c34245[649]: 2023/04/25 21:41:27 creating a socket: mysql-6b7a3589p3306-pi4-0
Apr 25 14:41:27 rpi4-0 fcbdb9c34245[649]: 2023/04/25 21:41:27 creating a socket: mysql-6b3f6e94p3306-pi4-0
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]: panic: runtime error: invalid memory address or nil pointer dereference
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x18b83f0]
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]: 
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]: goroutine 21 [running]:
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]: github.com/borderzero/border0-cli/internal/border0.(*Socket).IsClosed(...)
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]:         /home/runner/work/border0-cli/border0-cli/internal/border0/socket.go:641
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]: github.com/borderzero/border0-cli/internal/ssh.(*Connection).IsClosed(...)
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]:         /home/runner/work/border0-cli/border0-cli/internal/ssh/connect.go:37
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]: github.com/borderzero/border0-cli/internal/connector/core.(*ConnectorCore).IsSocketConnected(0x40002c2180?, {0x4000a0df20?, 0x40005a0190?})
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]:         /home/runner/work/border0-cli/border0-cli/internal/connector/core/core.go:70 +0x60
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]: github.com/borderzero/border0-cli/internal/connector/core.(*ConnectorCore).HandleUpdates(0x40002c2180, {0x259c410?, 0x40005a0190?}, {0x4001358000?, 0x0?, 0x0?})
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]:         /home/runner/work/border0-cli/border0-cli/internal/connector/core/core.go:147 +0xf0
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]: github.com/borderzero/border0-cli/internal/connector.(*ConnectorService).StartSocketWorker.func1()
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]:         /home/runner/work/border0-cli/border0-cli/internal/connector/service.go:189 +0xa0
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]: golang.org/x/sync/errgroup.(*Group).Go.func1()
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]:         /home/runner/go/pkg/mod/golang.org/x/sync@v0.1.0/errgroup/errgroup.go:75 +0x5c
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]: created by golang.org/x/sync/errgroup.(*Group).Go
Apr 25 14:41:28 rpi4-0 fcbdb9c34245[649]:         /home/runner/go/pkg/mod/golang.org/x/sync@v0.1.0/errgroup/errgroup.go:72 +0x9c
```

See that prior to this change the `sck.Listen()` method sets the `context` and `cancel` fields in the `Socket` object; such that if `sck.IsClosed()` (which reads the value of `sck.context`) is called prior to `sck.Listen()`, the program will panic because the `context` field has not been set yet (and thus is nil).

This change sets the `context` and `cancel` fields of the `Socket`object in the `Socket` constructor (`NewSocket(...)`) -- such that by the time `sck.IsClosed()` it is guaranteed that the `context` field is defined regardless of whether `sck.Listen()` has been called or not.

Fixes:
- https://mysocket.atlassian.net/browse/ME-1331

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The bug was reproduced locally and is no longer present after the change.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1331]: https://mysocket.atlassian.net/browse/ME-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ