### PR TITLE
[ME-1331] Use fresh context for socket state

### DIFF
--- a/internal/border0/socket.go
+++ b/internal/border0/socket.go
@@ -92,7 +92,7 @@ func NewSocket(ctx context.Context, border0API api.API, nameOrID string) (*Socke
 		return nil, err
 	}
 
-	sckCtx, sckCancel := context.WithCancel(ctx)
+	sckContext, sckCancel := context.WithCancel(context.Background())
 
 	return &Socket{
 		SocketID:                       socketFromApi.SocketID,
@@ -106,7 +106,7 @@ func NewSocket(ctx context.Context, border0API api.API, nameOrID string) (*Socke
 		Organization:                   org,
 		acceptChan:                     make(chan connWithError),
 
-		context: sckCtx,
+		context: sckContext,
 		cancel:  sckCancel,
 	}, nil
 }


### PR DESCRIPTION
## [[ME-1331](https://mysocket.atlassian.net/browse/ME-1331)] Use fresh context for socket state

In https://github.com/borderzero/border0-cli/pull/71 the socket's context was changed to use the context passed to the constructor as the parent context. This behaviour is undesirable because cancelling the parent context SHOULD NOT cancel the socket's context.

This change moves us back to using `context.Background()` (a fresh context object) as the parent context argument in the `context.WithCancel()` function.

Note that all invocations of the socket constructor function are called with `context.Background()` as the `ctx` argument, so there is no real danger in the current behaviour -- this is more of a correctness change.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1331

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1331]: https://mysocket.atlassian.net/browse/ME-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ