### PR TITLE
ME-1446 connector fix

### DIFF
--- a/cmd/connector.go
+++ b/cmd/connector.go
@@ -334,6 +334,13 @@ var connectorInstallCmd = &cobra.Command{
 				}
 				homedir = u.HomeDir
 			}
+
+			//check of the .border0 directory exists
+			// if not create it
+			if _, err := os.Stat(fmt.Sprintf("%s/.border0", homedir)); os.IsNotExist(err) {
+				os.Mkdir(fmt.Sprintf("%s/.border0", homedir), 0600)
+			}
+
 			// now copy the newly created token file to user's home directory
 			// lets determine the token file path
 			userTokenFile := fmt.Sprintf("%s/.border0/token", homedir)


### PR DESCRIPTION
Make sure the directory exist

# Description

when installing the connector, you sometimes see this error
```
ubuntu@definite-catbird:~$ sudo border0 connector install
Please navigate to the URL below in order to complete the login process:
https://portal.border0.com/login?device_identifier=ImQ3M2Q0YmZiLWEyMzYtNDk2My1hOTE5LTY1ZDQwMDFjN2RkZCI.ZGKdfA.tBa09dFJA88LzRx7tUbT_VzE2zw
Login successful
Error: open /home/ubuntu/.border0/token: no such file or directory
```


Fixes # (issue)
We need to make sure the dir exist

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locallt
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
