### PR TITLE
[ME-1421] Config Variable Sources Framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,12 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2
 	github.com/aws/aws-sdk-go v1.44.238
-	github.com/aws/aws-sdk-go-v2 v1.17.8
+	github.com/aws/aws-sdk-go-v2 v1.18.0
 	github.com/aws/aws-sdk-go-v2/config v1.18.19
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.9
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/iam v1.19.10
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.8
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.7
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
@@ -60,8 +61,8 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.18 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.1 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.27 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.32 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,9 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:W
 github.com/aws/aws-sdk-go v1.44.238 h1:qSWVXr/y/SsYyuvwVHYQpzcMKa2UzOjKgqPp7BTGfbo=
 github.com/aws/aws-sdk-go v1.44.238/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.17.7/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
-github.com/aws/aws-sdk-go-v2 v1.17.8 h1:GMupCNNI7FARX27L7GjCJM8NgivWbRgpjNI/hOQjFS8=
 github.com/aws/aws-sdk-go-v2 v1.17.8/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
+github.com/aws/aws-sdk-go-v2 v1.18.0 h1:882kkTpSFhdgYRKVZ/VCgf7sd0ru57p2JCxz4/oN5RY=
+github.com/aws/aws-sdk-go-v2 v1.18.0/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2/config v1.18.19 h1:AqFK6zFNtq4i1EYu+eC7lcKHYnZagMn6SW171la0bGw=
 github.com/aws/aws-sdk-go-v2/config v1.18.19/go.mod h1:XvTmGMY8d52ougvakOv1RpiTLPz9dlG/OQHsKU/cMmY=
 github.com/aws/aws-sdk-go-v2/credentials v1.13.18 h1:EQMdtHwz0ILTW1hoP+EwuWhwCG1hD6l3+RWFQABET4c=
@@ -80,11 +81,13 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.1/go.mod h1:lfUx8puBRdM5lVVM
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.9 h1:ckp1AJVEHjX7GOmwVoKdisytYBqrqXQPLfWgQdadkj0=
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.2.9/go.mod h1:bDkLO+jHnK4QVuo+anSvxu+xzQEE8doNaXYE2IZY0zA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.31/go.mod h1:QT0BqUvX1Bh2ABdTGnjqEjvjzrCfIniM9Sc8zn9Yndo=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32 h1:dpbVNUjczQ8Ae3QKHbpHBpfvaVkRdesxpTOe9pTouhU=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.32/go.mod h1:RudqOgadTWdcS3t/erPQo24pcVEoYyqj/kKW5Vya21I=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33 h1:kG5eQilShqmJbv11XL1VpyDbaEJzWxd4zRiCG30GSn4=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33/go.mod h1:7i0PF1ME/2eUPFcjkVIwq+DOygHEoK92t5cDqNgYbIw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.25/go.mod h1:zBHOPwhBc3FlQjQJE/D3IfPWiWaQmT06Vq9aNukDo0k=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26 h1:QH2kOS3Ht7x+u0gHCh06CXL/h6G8LQJFpZfFBYBNboo=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.26/go.mod h1:vq86l7956VgFr0/FWQ2BWnK07QC3WYsepKzy33qqY5U=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.27 h1:vFQlirhuM8lLlpI7imKOMsjdQLuN9CPi+k44F/OFVsk=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.27/go.mod h1:UrHnn3QV/d0pBZ6QBAEQcqFLf8FAzLmoUfPVIueOvoM=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.32 h1:p5luUImdIqywn6JpQsW3tq5GNOxKmOnEpybzPx+d1lk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.32/go.mod h1:XGhIBZDEgfqmFIugclZ6FU7v75nHhBDtzuB4xB/tEi4=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.25.1 h1:7nTa8MOSCXkxn59+vHMEqngJ+twtmh+J87NXrR5PN0I=
@@ -93,6 +96,8 @@ github.com/aws/aws-sdk-go-v2/service/iam v1.19.10 h1:mNCARLwZyWdk7070h4Sb9plb947
 github.com/aws/aws-sdk-go-v2/service/iam v1.19.10/go.mod h1:KeyeWNh9U2iztqp7JsK2PvnAupYWNZFp8A6ItqAQay4=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.25 h1:5LHn8JQ0qvjD9L9JhMtylnkcw7j05GDZqM9Oin6hpr0=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.25/go.mod h1:/95IA+0lMnzW6XzqYJRpjjsAbKEORVeO0anQqjd2CNU=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.8 h1:eB91eEYUlh8+O2dXr189W8GJJd+/T8N/c5HocH2KzVo=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.8/go.mod h1:3ARttS6G6U3auEdKfaN4GlnfS9UxYE9nqub1+0YGycA=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.36.0 h1:L1gK0SF7Filotf8Jbhiq0Y+rKVs/W1av8MH0+AXPrAg=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.36.0/go.mod h1:nCdeJmEFby1HKwKhDdKdVxPOJQUNht7Ngw+ejzbzvDU=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.6 h1:5V7DWLBd7wTELVz5bPpwzYy/sikk0gsgZfj40X+l5OI=

--- a/lib/varsource/README.md
+++ b/lib/varsource/README.md
@@ -1,0 +1,29 @@
+# varsource
+
+A package for sourcing variable values from multiple upstreams. 
+
+Currently supported upstreams include:
+
+- `env:` an environment variable value
+- `file:` the contents of a file
+- `aws:ssm:` an AWS Systems Manager Parameter Store parameter value
+- `aws:secretsmanager:` an AWS Secrets Manager secret value
+
+### Usage
+
+```
+vs := varsource.NewDefaultVariableSource()
+	
+vars, err := vs.GetVariables(ctx, map[string]string{
+	"DB_USERNAME": "${env:DB_USERNAME}",
+	"DB_PASSWORD": "${aws:secretsmanager:my-password}",
+}
+if err != nil {
+	log.Fatalf("failed to fetch variables: %v", err)
+}
+
+username := vars["DB_USERNAME"]
+password := vars["DB_PASSWORD"]
+
+// ... do something useful ...
+```

--- a/lib/varsource/variable_source.go
+++ b/lib/varsource/variable_source.go
@@ -1,0 +1,33 @@
+package varsource
+
+import "context"
+
+// VariableSource represents the necessary functionality of a source of variables.
+type VariableSource interface {
+	// GetVariables takes a map of variable-name to variable-definition
+	// and returns a map of variable-name to variable-value. i.e. returns
+	// the same map except that the variable definitions are replaced with
+	// the actual variable values.
+	//
+	// For example:
+	// {
+	//   "DB_USERNAME": "${env:DB_USERNAME}",
+	//   "DB_PASSWORD": "${file:~/.creds/password.txt}",
+	// }
+	// would be translated to:
+	// {
+	//   "DB_USERNAME": "database-user-xyz",
+	//   "DB_PASSWORD": "df29^%qd3gs8&*&(asd8t\tqe=",
+	// }
+	GetVariables(ctx context.Context, vars map[string]string) (map[string]string, error)
+}
+
+// NewDefaultVariableSource returns the default VariableSource implementation.
+func NewDefaultVariableSource() VariableSource {
+	return NewMultipleUpstreamVariableSource(
+		WithEnvVariableUpstream(),
+		WithFileVariableUpstream(),
+		WithAWSSSMVariableUpstream(),
+		WithAWSSecretsManagerVariableUpstream(),
+	)
+}

--- a/lib/varsource/variable_source_multiple_upstream.go
+++ b/lib/varsource/variable_source_multiple_upstream.go
@@ -1,0 +1,130 @@
+package varsource
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	prefixAWSSecretsManager = "aws:secretsmanager:"
+	prefixAWSSSM            = "aws:ssm:"
+	prefixEnv               = "env:"
+	prefixFile              = "file:"
+)
+
+// variableUpstream represents functioanlity of an upstream source of variable values
+type variableUpstream interface {
+	GetVariable(ctx context.Context, varDefn string) (string, error)
+}
+
+// MultipleUpstreamVariableSource is a VariableSource with multiple possible upstreams
+type MultipleUpstreamVariableSource struct {
+	prefixes  []string
+	upstreams map[string]variableUpstream
+}
+
+// ensures MultipleUpstreamVariableSource implements VariableSource at compile-time
+var _ VariableSource = (*MultipleUpstreamVariableSource)(nil)
+
+// Option represents a constructor option to set configuration settings (e.g.
+// an entry in the upstreams map) for a new MultipleUpstreamVariableSource
+type Option func(muvs *MultipleUpstreamVariableSource)
+
+// WithEnvVariableUpstream is the Option to set the environment
+// variable upstream source in a new MultipleUpstreamVariableSource
+func WithEnvVariableUpstream() Option {
+	return func(m *MultipleUpstreamVariableSource) {
+		m.upstreams[prefixEnv] = &envVariableUpstream{}
+	}
+}
+
+// WithFileVariableUpstream is the Option to set the
+// file contents source in a new MultipleUpstreamVariableSource
+func WithFileVariableUpstream() Option {
+	return func(m *MultipleUpstreamVariableSource) {
+		m.upstreams[prefixFile] = &fileVariableUpstream{}
+	}
+}
+
+// WithAWSSSMVariableUpstream is the Option to set the aws ssm
+// parameter store upstream source in a new MultipleUpstreamVariableSource
+func WithAWSSSMVariableUpstream() Option {
+	return func(m *MultipleUpstreamVariableSource) {
+		m.upstreams[prefixAWSSSM] = &awsSSMVariableUpstream{}
+	}
+}
+
+// WithAWSSecretsManagerVariableUpstream is the Option to set the aws
+// secrets manager upstream source in a new MultipleUpstreamVariableSource
+func WithAWSSecretsManagerVariableUpstream() Option {
+	return func(m *MultipleUpstreamVariableSource) {
+		m.upstreams[prefixAWSSecretsManager] = &awsSecretsmanagerVariableUpstream{}
+	}
+}
+
+// NewMultipleUpstreamVariableSource is the MultipleUpstreamVariableSource constructor. It returns
+// a newly-initialized MultipleUpstreamVariableSource with all the given upstream sources set.
+func NewMultipleUpstreamVariableSource(opts ...Option) *MultipleUpstreamVariableSource {
+	varSource := &MultipleUpstreamVariableSource{
+		prefixes:  []string{},
+		upstreams: make(map[string]variableUpstream),
+	}
+	for _, opt := range opts {
+		opt(varSource)
+	}
+	for prefix := range varSource.upstreams {
+		varSource.prefixes = append(varSource.prefixes, prefix)
+	}
+	// NOTE: we sort the prefixes slice by decreasing length of string (in order to do longest-prefix-match in GetVariables)
+	sort.Slice(varSource.prefixes, func(i, j int) bool { return len(varSource.prefixes[i]) > len(varSource.prefixes[j]) })
+	return varSource
+}
+
+// GetVariables takes a map of variable names to variable definitions
+// and returns a map of variable name to variable values. i.e. returns
+// fetches the variable values based on the variable definitions and
+// returns the same map populated with values instead of definitions.
+func (vs *MultipleUpstreamVariableSource) GetVariables(ctx context.Context, vars map[string]string) (map[string]string, error) {
+	processed := make(map[string]string)
+	for varName, varDefn := range vars {
+		// if the variable definition is an escaped variable definition
+		// e.g. "\${env:USERNAME}" simply remove the escaping and skip processing
+		if strings.HasPrefix(varDefn, `\${`) {
+			processed[varName] = strings.TrimPrefix(varDefn, `\`)
+			continue
+		}
+
+		// if the variable definition does not have start and end curly braces
+		// (i.e. is not of the form ${VARIABLE}) we simply skip processing (i.e. assume
+		// that the variable definition is the variable value - does not need fetching)
+		if !(strings.HasPrefix(varDefn, "${") && strings.HasSuffix(varDefn, "}")) {
+			processed[varName] = varDefn
+			continue
+		}
+
+		// remove the upstream variable indicators (the curly braces)
+		upstreamVarDefn := strings.TrimSuffix(strings.TrimPrefix(varDefn, "${"), "}")
+
+		// iterate over the sorted prefixes (in order of longest
+		// to shortest prefix) breaking after the first match
+		// (e.g. 'aws:ssm:' would match before 'aws:')
+		prefixMatchedUpstream := false
+		for _, prefix := range vs.prefixes {
+			if strings.HasPrefix(upstreamVarDefn, prefix) {
+				value, err := vs.upstreams[prefix].GetVariable(ctx, strings.TrimPrefix(upstreamVarDefn, prefix))
+				if err != nil {
+					return nil, fmt.Errorf("failed to get variable \"%s\": %v", varName, err)
+				}
+				processed[varName] = value
+				prefixMatchedUpstream = true
+				break
+			}
+		}
+		if !prefixMatchedUpstream {
+			return nil, fmt.Errorf("no upstream variable source available for variable definition \"%s\"", varDefn)
+		}
+	}
+	return processed, nil
+}

--- a/lib/varsource/variable_upstream_aws_secretsmanager.go
+++ b/lib/varsource/variable_upstream_aws_secretsmanager.go
@@ -1,0 +1,61 @@
+package varsource
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+)
+
+// interface with only the secretsmanager API functionality we need
+type secretsmanagerAPI interface {
+	GetSecretValue(
+		ctx context.Context,
+		params *secretsmanager.GetSecretValueInput,
+		optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+// returns a newly initialized AWS Secrets Manager client
+func getSecretsManagerClient(ctx context.Context, optFns ...func(*config.LoadOptions) error) (secretsmanagerAPI, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS configuration: %v", err)
+	}
+	return secretsmanager.NewFromConfig(cfg), nil
+}
+
+// variableUpstream implementation for fetching values from aws secrets manager
+type awsSecretsmanagerVariableUpstream struct {
+	secretsmanagerClient secretsmanagerAPI
+}
+
+// ensure awsSecretsmanagerVariableUpstream implements variableUpstream at compile-time
+var _ variableUpstream = (*awsSecretsmanagerVariableUpstream)(nil)
+
+// GetVariable gets a variable from AWS Secrets Manager
+func (vg *awsSecretsmanagerVariableUpstream) GetVariable(ctx context.Context, varDefn string) (string, error) {
+	// initialize client if not yet initialized
+	if vg.secretsmanagerClient == nil {
+		secretsManagerClient, err := getSecretsManagerClient(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to initialize new SSM client: %v", err)
+		}
+		vg.secretsmanagerClient = secretsManagerClient
+	}
+
+	// compute secret id and fetch it via the ssm api
+	secretID := varDefn // FIXME: allow specifying non-default region
+	getSecretValueOutput, err := vg.secretsmanagerClient.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(secretID),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get secretsmanager secret \"%s\": %v", secretID, err)
+	}
+	if getSecretValueOutput.SecretString == nil {
+		return "", fmt.Errorf("retrieved secretsmanager secret \"%s\" came back with a nil value", secretID)
+	}
+	return *getSecretValueOutput.SecretString, nil
+}

--- a/lib/varsource/variable_upstream_aws_ssm.go
+++ b/lib/varsource/variable_upstream_aws_ssm.go
@@ -1,0 +1,62 @@
+package varsource
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+)
+
+// interface with only the ssm API functionality we need
+type ssmAPI interface {
+	GetParameter(
+		ctx context.Context,
+		params *ssm.GetParameterInput,
+		optFns ...func(*ssm.Options),
+	) (*ssm.GetParameterOutput, error)
+}
+
+// returns a newly initialized AWS SSM client
+func getSSMClient(ctx context.Context, optFns ...func(*config.LoadOptions) error) (ssmAPI, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS configuration: %v", err)
+	}
+	return ssm.NewFromConfig(cfg), nil
+}
+
+// variableUpstream implementation for fetching values from aws ssm
+type awsSSMVariableUpstream struct {
+	ssmClient ssmAPI
+}
+
+// ensure awsSSMVariableUpstream implements variableUpstream at compile-time
+var _ variableUpstream = (*awsSSMVariableUpstream)(nil)
+
+// GetVariable gets a variable from AWS SSM
+func (vg *awsSSMVariableUpstream) GetVariable(ctx context.Context, varDefn string) (string, error) {
+	// initialize client if not yet initialized
+	if vg.ssmClient == nil {
+		ssmClient, err := getSSMClient(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to initialize new SSM client: %v", err)
+		}
+		vg.ssmClient = ssmClient
+	}
+
+	// compute parameter name and fetch it via the ssm api
+	parameterName := varDefn // FIXME: allow specifying non-default region
+	getParameterOutput, err := vg.ssmClient.GetParameter(ctx, &ssm.GetParameterInput{
+		Name:           aws.String(parameterName),
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get ssm parameter \"%s\": %v", parameterName, err)
+	}
+	if getParameterOutput.Parameter == nil || getParameterOutput.Parameter.Value == nil {
+		return "", fmt.Errorf("retrieved ssm parameter \"%s\" came back with a nil value", parameterName)
+	}
+	return *getParameterOutput.Parameter.Value, nil
+}

--- a/lib/varsource/variable_upstream_env.go
+++ b/lib/varsource/variable_upstream_env.go
@@ -1,0 +1,23 @@
+package varsource
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// variableUpstream implementation for fetching values from environment variables
+type envVariableUpstream struct{}
+
+// ensure envVariableUpstream implements variableUpstream at compile-time
+var _ variableUpstream = (*envVariableUpstream)(nil)
+
+// GetVariable gets a variable from the environment
+func (vg *envVariableUpstream) GetVariable(ctx context.Context, varDefn string) (string, error) {
+	envName := varDefn
+	value := os.Getenv(envName)
+	if value != "" {
+		return value, nil
+	}
+	return "", fmt.Errorf("no value in environment for \"%s\"", envName)
+}

--- a/lib/varsource/variable_upstream_file.go
+++ b/lib/varsource/variable_upstream_file.go
@@ -1,0 +1,24 @@
+package varsource
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// variableUpstream implementation for fetching values from a file
+type fileVariableUpstream struct{}
+
+// ensure fileVariableUpstream implements variableUpstream at compile-time
+var _ variableUpstream = (*fileVariableUpstream)(nil)
+
+// GetVariable gets a variable from a file
+func (vg *fileVariableUpstream) GetVariable(ctx context.Context, varDefn string) (string, error) {
+	filePath := varDefn
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file at path \"%s\"", filePath)
+	}
+	return strings.TrimSuffix(string(data), "\n"), nil
+}


### PR DESCRIPTION
## [[ME-1421](https://mysocket.atlassian.net/browse/ME-1421)] Config Variable Sources Framework

A package for sourcing variable values from multiple upstreams.

Currently supported upstreams include:

- `env:` an environment variable value
- `file:` the contents of a file
- `aws:ssm:` an AWS Systems Manager Parameter Store parameter value
- `aws:secretsmanager:` an AWS Secrets Manager secret value

### Usage

```
vs := varsource.NewDefaultVariableSource()

vars, err := vs.GetVariables(ctx, map[string]string{
	"DB_USERNAME": "${env:DB_USERNAME}",
	"DB_PASSWORD": "${aws:secretsmanager:my-password}",
}
// ... handle error ...

username := vars["DB_USERNAME"]
password := vars["DB_PASSWORD"]

// ... do something useful ...
```

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1421

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally - needs unit tests.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1421]: https://mysocket.atlassian.net/browse/ME-1421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ