### PR TITLE
[ME-1421] Initial Connector (v2) Configuration

### DIFF
--- a/internal/connector_v2/config/README.md
+++ b/internal/connector_v2/config/README.md
@@ -1,0 +1,15 @@
+# config
+
+A package for initializing and manipulating connector (v2) configuration.
+
+> This package is heavily inspired by the AWS "default credential provider chain" concept, as well as Terraform's environment variable mechanism for defining variables.
+
+Variables are sourced using a "standard variable chain", where any configuration mentioned in a configuration file is considered the "base configuration" and any variables defined in the environment override the base configuration.
+
+### Usage
+
+```
+c, err := config.GetConfiguration(ctx)
+// ... handle error ...
+// ... do something useful ...
+```

--- a/internal/connector_v2/config/config.go
+++ b/internal/connector_v2/config/config.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/borderzero/border0-cli/lib/varsource"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	envNameBorder0ConfigFile = "B0_CONFIG_FILE"
+	envNameBorder0Token      = "B0_TOKEN"
+	envNamePrefixBorder0Var  = "B0_VAR_"
+
+	envNameAndValueDelimeter = "="
+
+	defaultCredentialsFilePath = ".border0/config.yml"
+)
+
+// Configuration represents (static) connector configuration
+type Configuration struct {
+	Token     string            `yaml:"token"`
+	Variables map[string]string `yaml:"variables,omitempty"`
+}
+
+// GetConfiguration looks for credentials and variables in the standard variable chain.
+// i.e. environment variabels take priority and override any values in config files.
+func GetConfiguration(ctx context.Context) (*Configuration, error) {
+	vs := varsource.NewDefaultVariableSource()
+	config := &Configuration{}
+
+	// if a non-default config file path is provided via
+	// the environment, use it and error on any failure
+	path := os.Getenv(envNameBorder0ConfigFile)
+	if path != "" {
+		_, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to find configuration file specified via environment variable %s (%s): %v",
+				envNameBorder0ConfigFile,
+				path,
+				err,
+			)
+		}
+		if err = unmarshalConfiguration(path, config); err != nil {
+			return nil, fmt.Errorf(
+				"failed to read configuration file specified via environment variable %s (%s): %v",
+				envNameBorder0ConfigFile,
+				path,
+				err,
+			)
+		}
+	} else { // otherwise use the default configuration file path for config
+		path = fmt.Sprintf("%s/%s", os.Getenv("HOME"), defaultCredentialsFilePath)
+		_, err := os.Stat(path)
+		if err != nil {
+			// when the default config file path is used, we only error out when
+			// the failure is not due to a missing config file. This is because
+			// the token and config might still be present in the environment.
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf(
+					"failed to read default configuration file (%s): %v",
+					defaultCredentialsFilePath,
+					err,
+				)
+			}
+			// pass
+		} else {
+			if err = unmarshalConfiguration(path, config); err != nil {
+				return nil, fmt.Errorf(
+					"failed to read the default configuration file (%s): %v",
+					path,
+					err,
+				)
+			}
+		}
+	}
+
+	// if there is a token in the environment, overwrite that read from config file
+	if os.Getenv(envNameBorder0Token) != "" {
+		config.Token = os.Getenv(envNameBorder0Token)
+	}
+
+	// if there was no token in env nor in config file, error out
+	if config.Token == "" {
+		return nil, errors.New("no Border0 token in credentials chain")
+	}
+
+	// if the token is a pointer to some upstream source, fetch it
+	token, err := vs.GetVariable(ctx, config.Token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process token value: %v", err)
+	}
+	config.Token = token
+
+	// if there were no variables defined in a config file, init empty map
+	if config.Variables == nil {
+		config.Variables = make(map[string]string)
+	}
+
+	// for all environment variables, if any start with the border0 variable prefix
+	// use them to populate the variables map (and overwrite any which are present in the
+	// environment that were present in the config file)
+	for _, kv := range os.Environ() {
+		// split env between key and value... this will *always* have 2 parts
+		kvParts := strings.SplitN(kv, envNameAndValueDelimeter, 2)
+		name, value := kvParts[0], kvParts[1]
+
+		// skip all env vars that do not have the border0 variable prefix
+		if !strings.HasPrefix(name, envNamePrefixBorder0Var) {
+			continue
+		}
+
+		// add variable to configuration variables map
+		config.Variables[strings.TrimPrefix(name, envNamePrefixBorder0Var)] = value
+	}
+
+	// fetch all variables which are pointers to other variables in upstream servies
+	vars, err := vs.GetVariables(ctx, config.Variables)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get upstream variables: %v", err)
+	}
+	config.Variables = vars
+
+	return config, nil
+}
+
+func unmarshalConfiguration(path string, config *Configuration) error {
+	// read config file
+	configFileBytes, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read configuration file at %s: %v", path, err)
+	}
+	// decode config yaml
+	if err = yaml.Unmarshal(configFileBytes, config); err != nil {
+		return fmt.Errorf("failed to decode config file data as yaml: %v", err)
+	}
+	// success!
+	return nil
+}

--- a/lib/varsource/variable_source.go
+++ b/lib/varsource/variable_source.go
@@ -20,6 +20,7 @@ type VariableSource interface {
 	//   "DB_PASSWORD": "df29^%qd3gs8&*&(asd8t\tqe=",
 	// }
 	GetVariables(ctx context.Context, vars map[string]string) (map[string]string, error)
+	GetVariable(ctx context.Context, varDefn string) (string, error)
 }
 
 // NewDefaultVariableSource returns the default VariableSource implementation.


### PR DESCRIPTION
## [[ME-1421](https://mysocket.atlassian.net/browse/ME-1421)] Initial Connector (v2) Configuration

Initial connector V2 configuration package boilerplate

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1421

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally with the following test code:

```
package main

import (
	"context"
	"fmt"
	"log"

	"github.com/borderzero/border0-cli/internal/connector_v2/config"
	"gopkg.in/yaml.v3"
)

func main() {
	connectorConfig, err := config.GetConfiguration(context.Background())
	if err != nil {
		log.Fatalf("failed to get configuration: %v", err)
	}

	byt, err := yaml.Marshal(connectorConfig)
	if err != nil {
		log.Fatalf("failed to marshal config: %v", err)
	}

	fmt.Println(string(byt))
}
```

and the following test config file

```
token: asdfghj987654edfghjki8765
variables:
  DB_USERNAME: user
  DB_PASSWORD: password
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1421]: https://mysocket.atlassian.net/browse/ME-1421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ