### PR TITLE
[ME-1543] fix connector upstream type guessing

### DIFF
--- a/internal/api/models/socket.go
+++ b/internal/api/models/socket.go
@@ -216,6 +216,9 @@ func (s *Socket) SetupTypeAndUpstreamTypeByPortOrTags() {
 			case "https":
 				s.SocketType = "http"
 				s.UpstreamType = "https"
+			case "http":
+				s.SocketType = "http"
+				s.UpstreamType = "http"
 			case "ssh":
 				s.UpstreamType = "ssh"
 			}


### PR DESCRIPTION
# Description

if the socket type / upstream type is not provided we try to guess the value, but we are trying to guess the https types, but not the http one, so adding the http type to the guessing logic will fix the update loop in connector

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
