### PR TITLE
[ME-1647] Extend build and release job temp creds duration

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -33,7 +33,7 @@ jobs:
           aws-region: us-east-2
           role-to-assume: ${{ secrets.PROD_BUILD_AND_DEPLOY_ROLE }}
           role-session-name: BuildAndDeploy4border0cli
-          role-duration-seconds: 1200
+          role-duration-seconds: 2400 # 40 minutes
 
       - uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
# [[ME-1647](https://mysocket.atlassian.net/browse/ME-1647)] Extend build and release job temp creds duration

Extends the duration of the temporary credentials used to push built binaries and metadata.

Fixes:
- https://mysocket.atlassian.net/browse/ME-1647

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A - job failed with expired creds after 20 minutes.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1647]: https://mysocket.atlassian.net/browse/ME-1647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ