### PR TITLE
[ME-1667] K8s Discovery Support in Connector V2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
 	github.com/bluele/factory-go v0.0.1
-	github.com/borderzero/border0-go v0.1.6
+	github.com/borderzero/border0-go v0.1.8
 	github.com/borderzero/border0-proto v1.0.0
-	github.com/borderzero/discovery v0.1.9
+	github.com/borderzero/discovery v0.1.11
 	github.com/brianvoe/gofakeit v3.18.0+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/creack/pty v1.1.18

--- a/go.sum
+++ b/go.sum
@@ -119,12 +119,12 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v0.1.6 h1:B8a1L4UB2eskPr7Utm8JLKbwwytETc7PsOUk4YPcBSs=
-github.com/borderzero/border0-go v0.1.6/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
+github.com/borderzero/border0-go v0.1.8 h1:NjX6egDqXTEjJtEXanF0K10z9GOszFwOvUGHoweBDYg=
+github.com/borderzero/border0-go v0.1.8/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/borderzero/border0-proto v1.0.0 h1:Wt8Ix1rghq+Ae22LY6AWiyaJ8XuJAKEIhcn3D48DFvM=
 github.com/borderzero/border0-proto v1.0.0/go.mod h1:Iw+rHiXdZi1xqxSFG7+blVm9Kp5n7xzhVWQn2KHJKj8=
-github.com/borderzero/discovery v0.1.9 h1:/Hm+2MorWASjEDx1t3YaNugPDRMurQTaoD8EQrFWoew=
-github.com/borderzero/discovery v0.1.9/go.mod h1:jB1sVlJbD3J9HrRaXVxjpsEK+adx01AYtyQLZfmxGqQ=
+github.com/borderzero/discovery v0.1.11 h1:qbP1HngLGHIKJH3KVm7lHP3r37Ghc8i7Q/gY3hrSNaY=
+github.com/borderzero/discovery v0.1.11/go.mod h1:RP6kJiIxNbpfW24e6MLR2pAFkTLuWCVnm62wTcyuBzg=
 github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=
 github.com/brianvoe/gofakeit v3.18.0+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/internal/connector_v2/plugin/plugin.go
+++ b/internal/connector_v2/plugin/plugin.go
@@ -34,6 +34,8 @@ func NewPlugin(
 		return newAwsEcsDiscoveryPlugin(ctx, logger, pluginId, config.AwsEcsDiscoveryPluginConfiguration)
 	case types.PluginTypeAwsRdsDiscovery:
 		return newAwsRdsDiscoveryPlugin(ctx, logger, pluginId, config.AwsRdsDiscoveryPluginConfiguration)
+	case types.PluginTypeKubernetesDiscovery:
+		return newKubernetesDiscoveryPlugin(ctx, logger, pluginId, config.KubernetesDiscoveryPluginConfiguration)
 	default:
 		return nil, fmt.Errorf("plugin type %s is not supported...", pluginType)
 	}


### PR DESCRIPTION
## [ME-1667] K8s Discovery Support in Connector V2

Adds support for kubernetes service discovery (with the kubernetes discovery plugin) to connector v2.

Fixes:
- https://mysocket.atlassian.net/browse/ME-1667

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested by pushing various forms of k8s configuration to the API and having the connector pick up and process the plugin configuration, resulting in discovered resources.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1667]: https://mysocket.atlassian.net/browse/ME-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ