### PR TITLE
[ME-1673] Docker Discovery Support in Connector V2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
 	github.com/bluele/factory-go v0.0.1
-	github.com/borderzero/border0-go v0.1.8
+	github.com/borderzero/border0-go v0.1.9
 	github.com/borderzero/border0-proto v1.0.0
-	github.com/borderzero/discovery v0.1.11
+	github.com/borderzero/discovery v0.1.13
 	github.com/brianvoe/gofakeit v3.18.0+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/creack/pty v1.1.18

--- a/go.sum
+++ b/go.sum
@@ -119,12 +119,12 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v0.1.8 h1:NjX6egDqXTEjJtEXanF0K10z9GOszFwOvUGHoweBDYg=
-github.com/borderzero/border0-go v0.1.8/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
+github.com/borderzero/border0-go v0.1.9 h1:RzkSN8cOEtW1QFwEG6Kv/9ReCeOAgxOCEqHPDT+toIk=
+github.com/borderzero/border0-go v0.1.9/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/borderzero/border0-proto v1.0.0 h1:Wt8Ix1rghq+Ae22LY6AWiyaJ8XuJAKEIhcn3D48DFvM=
 github.com/borderzero/border0-proto v1.0.0/go.mod h1:Iw+rHiXdZi1xqxSFG7+blVm9Kp5n7xzhVWQn2KHJKj8=
-github.com/borderzero/discovery v0.1.11 h1:qbP1HngLGHIKJH3KVm7lHP3r37Ghc8i7Q/gY3hrSNaY=
-github.com/borderzero/discovery v0.1.11/go.mod h1:RP6kJiIxNbpfW24e6MLR2pAFkTLuWCVnm62wTcyuBzg=
+github.com/borderzero/discovery v0.1.13 h1:Roi/nCFN5CUhKdKQyasD7qMjnoty6CB6fG678+OtBxM=
+github.com/borderzero/discovery v0.1.13/go.mod h1:RP6kJiIxNbpfW24e6MLR2pAFkTLuWCVnm62wTcyuBzg=
 github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=
 github.com/brianvoe/gofakeit v3.18.0+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/internal/connector_v2/plugin/builder.go
+++ b/internal/connector_v2/plugin/builder.go
@@ -184,6 +184,28 @@ func newKubernetesDiscoveryPlugin(ctx context.Context,
 	return newPlugin(pluginId, logger, engine), nil
 }
 
+func newDockerDiscoveryPlugin(ctx context.Context,
+	logger *zap.Logger,
+	pluginId string,
+	config *types.DockerDiscoveryPluginConfiguration,
+) (Plugin, error) {
+	if config == nil {
+		return nil, fmt.Errorf("Received nil docker discovery plugin configuration for plugin %s", pluginId)
+	}
+
+	engine := engines.NewContinuousEngine(
+		engines.WithDiscoverer(
+			discoverers.NewDockerDiscoverer(
+				discoverers.WithDockerDiscovererInclusionContainerLabels(config.IncludeWithLabels),
+				discoverers.WithDockerDiscovererExclusionContainerLabels(config.ExcludeWithLabels),
+			),
+			engines.WithInitialInterval(time.Duration(config.ScanIntervalMinutes)*time.Minute),
+		),
+	)
+
+	return newPlugin(pluginId, logger, engine), nil
+}
+
 // returns slice of aws configurations based on an aws-based plugin's configuration
 func getAwsConfigs(ctx context.Context, awsPluginConfig types.BaseAwsPluginConfiguration) ([]aws.Config, error) {
 	optFns := []func(*config.LoadOptions) error{}

--- a/internal/connector_v2/plugin/plugin.go
+++ b/internal/connector_v2/plugin/plugin.go
@@ -36,6 +36,8 @@ func NewPlugin(
 		return newAwsRdsDiscoveryPlugin(ctx, logger, pluginId, config.AwsRdsDiscoveryPluginConfiguration)
 	case types.PluginTypeKubernetesDiscovery:
 		return newKubernetesDiscoveryPlugin(ctx, logger, pluginId, config.KubernetesDiscoveryPluginConfiguration)
+	case types.PluginTypeDockerDiscovery:
+		return newDockerDiscoveryPlugin(ctx, logger, pluginId, config.DockerDiscoveryPluginConfiguration)
 	default:
 		return nil, fmt.Errorf("plugin type %s is not supported...", pluginType)
 	}


### PR DESCRIPTION
## [[ME-1673](https://mysocket.atlassian.net/browse/ME-1673)] Docker Discovery Support in Connector V2

Adds support for receiving configuration for docker discovery plugins from API

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1673

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally by receiving docker discovery config from API in the border0 staging env.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1673]: https://mysocket.atlassian.net/browse/ME-1673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ