### PR TITLE
[ME-1679] Changes to ECS Discovery (connector v2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
 	github.com/bluele/factory-go v0.0.1
-	github.com/borderzero/border0-go v0.1.12
+	github.com/borderzero/border0-go v0.1.13
 	github.com/borderzero/border0-proto v1.0.1
-	github.com/borderzero/discovery v0.1.15
+	github.com/borderzero/discovery v0.1.16
 	github.com/brianvoe/gofakeit v3.18.0+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/creack/pty v1.1.18

--- a/go.sum
+++ b/go.sum
@@ -121,12 +121,12 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v0.1.12 h1:pdX4IfzUTh6oEgOOm3CR/hrNGp/3DIHJSqRdu/ectAo=
-github.com/borderzero/border0-go v0.1.12/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
+github.com/borderzero/border0-go v0.1.13 h1:aeIp91gCXP1sdOXYBlrAziZMns3xF9c1o8V+IwHNSJw=
+github.com/borderzero/border0-go v0.1.13/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/borderzero/border0-proto v1.0.1 h1:55F9gy2RVH4dZdkBkiqgMqr1HBr38uGZ7HvEE3H3KBA=
 github.com/borderzero/border0-proto v1.0.1/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
-github.com/borderzero/discovery v0.1.15 h1:0yOsCaGGvTJdI4OApW5ing4/KXIAN0nvgMwQZq6gdLU=
-github.com/borderzero/discovery v0.1.15/go.mod h1:nqeN+XJmVNUyR6NZnQIznsbdOXKmPQffZBU4Oz9yWfY=
+github.com/borderzero/discovery v0.1.16 h1:LAjUer9uJG/O6VN2MONVyU74Qvm4cvL66vJ5SB0wBq4=
+github.com/borderzero/discovery v0.1.16/go.mod h1:nqeN+XJmVNUyR6NZnQIznsbdOXKmPQffZBU4Oz9yWfY=
 github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=
 github.com/brianvoe/gofakeit v3.18.0+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/internal/connector_v2/plugin/builder.go
+++ b/internal/connector_v2/plugin/builder.go
@@ -87,9 +87,8 @@ func newAwsEcsDiscoveryPlugin(
 			discoverers.NewAwsEcsDiscoverer(
 				awsConfig,
 				discoverers.WithAwsEcsDiscovererDiscovererId(fmt.Sprintf("aws ecs ( region = %s )", awsConfig.Region)),
-				discoverers.WithAwsEcsDiscovererIncludedClusterStatuses(config.IncludeWithStatuses...),
-				discoverers.WithAwsEcsDiscovererInclusionClusterTags(config.IncludeWithTags),
-				discoverers.WithAwsEcsDiscovererExclusionClusterTags(config.ExcludeWithTags),
+				discoverers.WithAwsEcsDiscovererInclusionServiceTags(config.IncludeWithTags),
+				discoverers.WithAwsEcsDiscovererExclusionServiceTags(config.ExcludeWithTags),
 			),
 			engines.WithInitialInterval(time.Duration(config.ScanIntervalMinutes)*time.Minute),
 		))


### PR DESCRIPTION
## [[ME-1679](https://mysocket.atlassian.net/browse/ME-1679)] ECS Discovery Plugin Changes

Accounts for changes to ecs discovery (no longer scanning clusters, scanning services)

Fixes # (issue):
- part of https://mysocket.atlassian.net/browse/ME-1679

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Staging API + staging Portal + changes in CLI.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1679]: https://mysocket.atlassian.net/browse/ME-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ