### PR TITLE
[ME-1684] Fix Network Discoverer Bug (Connector v2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
 	github.com/bluele/factory-go v0.0.1
-	github.com/borderzero/border0-go v0.1.14
+	github.com/borderzero/border0-go v0.1.15
 	github.com/borderzero/border0-proto v1.0.1
-	github.com/borderzero/discovery v0.1.17
+	github.com/borderzero/discovery v0.1.18
 	github.com/brianvoe/gofakeit v3.18.0+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/creack/pty v1.1.18

--- a/go.sum
+++ b/go.sum
@@ -121,10 +121,14 @@ github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
 github.com/borderzero/border0-go v0.1.14 h1:YyeC3GXmWVBbvsqMiyBf3fT41c/wYj/wMZR29+0uEIM=
 github.com/borderzero/border0-go v0.1.14/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
+github.com/borderzero/border0-go v0.1.15 h1:p1XVOmI2cSu8AqtrRKFmbbAeRw6ntievhRiZEYsH1k4=
+github.com/borderzero/border0-go v0.1.15/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/borderzero/border0-proto v1.0.1 h1:55F9gy2RVH4dZdkBkiqgMqr1HBr38uGZ7HvEE3H3KBA=
 github.com/borderzero/border0-proto v1.0.1/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
 github.com/borderzero/discovery v0.1.17 h1:adGbKaH2IIBmbhyaxJO30gyDP+nk8DYvQewy9zfWbFw=
 github.com/borderzero/discovery v0.1.17/go.mod h1:XcuKldfCIyQd/GT7pv7amTbLZOZE6o8CgXwRb6UI6aI=
+github.com/borderzero/discovery v0.1.18 h1:YRC1yVoOaiUgSMQ+mSToNNk9EOv19+mOwuBNmpZXu9E=
+github.com/borderzero/discovery v0.1.18/go.mod h1:XcuKldfCIyQd/GT7pv7amTbLZOZE6o8CgXwRb6UI6aI=
 github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=
 github.com/brianvoe/gofakeit v3.18.0+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/internal/connector_v2/plugin/builder.go
+++ b/internal/connector_v2/plugin/builder.go
@@ -217,9 +217,12 @@ func newNetworkDiscoveryPlugin(ctx context.Context,
 
 	ds := []discovery.Discoverer{}
 	for index, target := range config.Targets {
+		ports := slice.Transform(target.Ports, func(i uint16) string { return fmt.Sprint(i) })
+
 		ds = append(ds, discoverers.NewNetworkDiscoverer(
-			discoverers.WithNetworkDiscovererDiscovererId(fmt.Sprintf("network ( [%d] target = %s )", index, target.Target)),
-			discoverers.WithNetworkDiscovererPorts(slice.Transform(target.Ports, func(i uint16) string { return fmt.Sprint(i) })...),
+			discoverers.WithNetworkDiscovererDiscovererId(fmt.Sprintf("network [%d/%d] ( target = %s )", index+1, len(config.Targets), target.Target)),
+			discoverers.WithNetworkDiscovererTargets(target.Target),
+			discoverers.WithNetworkDiscovererPorts(ports...),
 		))
 	}
 


### PR DESCRIPTION
## [[ME-1684](https://mysocket.atlassian.net/browse/ME-1684)] Fix Network Discoverer Bug (Connector v2)

Wraps up first full pass at end-to-end network discovery. Had a bug where the targets were not being set at all.

Fixes # (issue):
- part of https://mysocket.atlassian.net/browse/ME-1684

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
✔ ~/go/src/github.com/borderzero/border0-cli [ME-1684_fix_network_discovery_bug|✔]
17:41 $ BORDER0_LOG_LEVEL=debug ./border0 connector start --v2
{"level":"info","ts":"2023-07-11T17:42:22-07:00","msg":"starting the connector service"}
{"level":"info","ts":"2023-07-11T17:42:22-07:00","msg":"connecting to connector server","server":"capi.staging.border0.com:443"}
{"level":"info","ts":"2023-07-11T17:42:22-07:00","msg":"new plugin","plugin":"72718bce-7a1c-4e33-84c5-82b149fced07"}
{"level":"debug","ts":"2023-07-11T17:42:30-07:00","msg":"discovery result","plugin_id":"72718bce-7a1c-4e33-84c5-82b149fced07","discoverer_id":"network [1/1] ( target = en0 )","resources":3}
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1684]: https://mysocket.atlassian.net/browse/ME-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ