### PR TITLE
fix(ME-1668): enable tls in sqlproxy to support connector auth

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -119,14 +119,10 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v0.1.14 h1:YyeC3GXmWVBbvsqMiyBf3fT41c/wYj/wMZR29+0uEIM=
-github.com/borderzero/border0-go v0.1.14/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/borderzero/border0-go v0.1.15 h1:p1XVOmI2cSu8AqtrRKFmbbAeRw6ntievhRiZEYsH1k4=
 github.com/borderzero/border0-go v0.1.15/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/borderzero/border0-proto v1.0.1 h1:55F9gy2RVH4dZdkBkiqgMqr1HBr38uGZ7HvEE3H3KBA=
 github.com/borderzero/border0-proto v1.0.1/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
-github.com/borderzero/discovery v0.1.17 h1:adGbKaH2IIBmbhyaxJO30gyDP+nk8DYvQewy9zfWbFw=
-github.com/borderzero/discovery v0.1.17/go.mod h1:XcuKldfCIyQd/GT7pv7amTbLZOZE6o8CgXwRb6UI6aI=
 github.com/borderzero/discovery v0.1.18 h1:YRC1yVoOaiUgSMQ+mSToNNk9EOv19+mOwuBNmpZXu9E=
 github.com/borderzero/discovery v0.1.18/go.mod h1:XcuKldfCIyQd/GT7pv7amTbLZOZE6o8CgXwRb6UI6aI=
 github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=

--- a/internal/sqlauthproxy/postgres.go
+++ b/internal/sqlauthproxy/postgres.go
@@ -2,8 +2,14 @@ package sqlauthproxy
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
 	"log"
+	"math/big"
 	"net"
 	"strconv"
 	"strings"
@@ -21,6 +27,7 @@ type postgresHandler struct {
 	Config
 	UpstreamConfig *pgconn.Config
 	awsCredentials aws.CredentialsProvider
+	tlsConfig      *tls.Config
 }
 
 func newPostgresHandler(c Config) (*postgresHandler, error) {
@@ -32,6 +39,15 @@ func newPostgresHandler(c Config) (*postgresHandler, error) {
 		}
 
 		awsCredentials = cfg.Credentials
+	}
+
+	cert, err := generateX509KeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate tls certificate: %s", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
 	}
 
 	var sslSettings []string
@@ -73,21 +89,23 @@ func newPostgresHandler(c Config) (*postgresHandler, error) {
 		Config:         c,
 		UpstreamConfig: config,
 		awsCredentials: awsCredentials,
+		tlsConfig:      tlsConfig,
 	}, nil
 }
 
 func (h postgresHandler) handleClient(c net.Conn) {
 	defer c.Close()
 
-	clientConn := pgproto3.NewBackend(pgproto3.NewChunkReader(c), c)
-
-	startupMessage, err := h.handleClientStartup(clientConn, c)
+	startupMessage, c, err := h.handleClientStartup(c)
 	if err != nil {
 		log.Printf("sqlauthproxy: failed to handle client startup: %s", err)
 		return
 	}
 
+	clientConn := pgproto3.NewBackend(pgproto3.NewChunkReader(c), c)
+
 	if startupMessage == nil {
+		log.Printf("sqlauthproxy: failed to handle client startup")
 		return
 	}
 
@@ -128,27 +146,35 @@ func (h postgresHandler) handleClient(c net.Conn) {
 	border0.ProxyConnection(c, pgconn.Conn)
 }
 
-func (h postgresHandler) handleClientStartup(c *pgproto3.Backend, conn net.Conn) (*pgproto3.StartupMessage, error) {
+func (h postgresHandler) handleClientStartup(conn net.Conn) (*pgproto3.StartupMessage, *tls.Conn, error) {
+	c := pgproto3.NewBackend(pgproto3.NewChunkReader(conn), conn)
+
 	message, err := c.ReceiveStartupMessage()
 	if err != nil {
-		return nil, nil
+		return nil, nil, err
 	}
 
 	switch msg := message.(type) {
 	case *pgproto3.StartupMessage:
-		return msg, nil
-	case *pgproto3.SSLRequest:
-		_, err = conn.Write([]byte("N"))
-		if err != nil {
-			return nil, nil
+		tlsConn, ok := conn.(*tls.Conn)
+		if !ok {
+			return nil, nil, fmt.Errorf("failed to get TLS connection info")
 		}
 
-		return nil, nil
+		return msg, tlsConn, nil
+	case *pgproto3.SSLRequest:
+		_, err = conn.Write([]byte("S"))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		conn = tls.Server(conn, h.tlsConfig)
+		return h.handleClientStartup(conn)
 	case *pgproto3.CancelRequest:
 		conn.Close()
-		return nil, nil
+		return nil, nil, nil
 	default:
-		return nil, fmt.Errorf("invalid startup message (%T)", msg)
+		return nil, nil, fmt.Errorf("invalid startup message (%T)", msg)
 	}
 }
 
@@ -174,4 +200,34 @@ func (h postgresHandler) handleClientAuthRequest(serverSession *pgproto3.Backend
 	}
 
 	return nil
+}
+
+func generateX509KeyPair() (tls.Certificate, error) {
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(now.Unix()),
+		Subject: pkix.Name{
+			CommonName:   "sqlauthproxy",
+			Organization: []string{"border.com"},
+		},
+		NotBefore: now,
+		NotAfter:  now.AddDate(10, 0, 0),
+	}
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	cert, err := x509.CreateCertificate(rand.Reader, template, template,
+		priv.Public(), priv)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	var outCert tls.Certificate
+	outCert.Certificate = append(outCert.Certificate, cert)
+	outCert.PrivateKey = priv
+
+	return outCert, nil
 }

--- a/internal/sqlauthproxy/postgres.go
+++ b/internal/sqlauthproxy/postgres.go
@@ -216,18 +216,16 @@ func generateX509KeyPair() (tls.Certificate, error) {
 
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return tls.Certificate{}, err
+		return tls.Certificate{}, fmt.Errorf("failed to generate private key: %s", err)
 	}
 
-	cert, err := x509.CreateCertificate(rand.Reader, template, template,
-		priv.Public(), priv)
+	cert, err := x509.CreateCertificate(rand.Reader, template, template, priv.Public(), priv)
 	if err != nil {
 		return tls.Certificate{}, err
 	}
 
-	var outCert tls.Certificate
-	outCert.Certificate = append(outCert.Certificate, cert)
-	outCert.PrivateKey = priv
-
-	return outCert, nil
+	return tls.Certificate{
+		Certificate: [][]byte{cert},
+		PrivateKey:  priv,
+	}, nil
 }


### PR DESCRIPTION
# Description

Enable TLS in sqlproxy to support connector auth.

Fixes # ME-1668

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on staging.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
