### PR TITLE
[ME-1718] Remove Need for Useless Availability Zone Arg

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,6 @@ var (
 	awsECSServices          []string
 	awsECSTasks             []string
 	awsECSContainers        []string
-	awsAvailabilityZone     string
 	disableBrowser          bool
 	awsEC2Connect           bool
 )

--- a/cmd/socket.go
+++ b/cmd/socket.go
@@ -386,19 +386,18 @@ var socketConnectCmd = &cobra.Command{
 					}
 				}
 			case socket.UpstreamType == "aws-ec2connect" || awsEC2Connect:
-				if awsEC2Target == "" || awsAvailabilityZone == "" {
-					return fmt.Errorf("aws_ec2_target and aws_availability_zone is required for aws-ec2connect upstream services")
+				if awsEC2Target == "" {
+					return fmt.Errorf("aws_ec2_target is required for aws-ec2connect upstream services")
 				}
 
 				sshProxyConfig = ssh.ProxyConfig{
-					AwsEC2Target:        awsEC2Target,
-					AwsAvailabilityZone: awsAvailabilityZone,
-					AWSRegion:           awsRegion,
-					AWSProfile:          awsProfile,
-					Hostname:            hostname,
-					Port:                port,
-					Username:            upstream_username,
-					AwsUpstreamType:     "aws-ec2connect",
+					AwsEC2Target:    awsEC2Target,
+					AWSRegion:       awsRegion,
+					AWSProfile:      awsProfile,
+					Hostname:        hostname,
+					Port:            port,
+					Username:        upstream_username,
+					AwsUpstreamType: "aws-ec2connect",
 				}
 
 			default:
@@ -632,7 +631,6 @@ func init() {
 	socketConnectCmd.Flags().BoolVarP(&upstream_tls, "upstream_tls", "", true, "Use TLS for upstream connection")
 	socketConnectCmd.Flags().StringVarP(&upstream_identify_file, "upstream_identity_file", "", "", "Upstream identity file")
 	socketConnectCmd.Flags().StringVarP(&awsEC2Target, "aws_ec2_target", "", "", "Aws EC2 target identifier")
-	socketConnectCmd.Flags().StringVarP(&awsAvailabilityZone, "aws_availability_zone", "", "", "Aws availability zone")
 	socketConnectCmd.Flags().BoolVarP(&awsEC2Connect, "aws_ec2_connect", "", false, "Use AWS EC2 connect to connect to the target")
 	socketConnectCmd.Flags().StringVarP(&awsRegion, "region", "", "", "AWS region to use")
 	socketConnectCmd.Flags().StringVarP(&awsProfile, "profile", "", "", "AWS profile to use")

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,6 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v0.1.15 h1:p1XVOmI2cSu8AqtrRKFmbbAeRw6ntievhRiZEYsH1k4=
-github.com/borderzero/border0-go v0.1.15/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/borderzero/border0-go v0.1.17 h1:4Tdw2rQCJF8GJwb1E42iGwXPc5yR222Kmv4mRySIRgA=
 github.com/borderzero/border0-go v0.1.17/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/borderzero/border0-proto v1.0.1 h1:55F9gy2RVH4dZdkBkiqgMqr1HBr38uGZ7HvEE3H3KBA=

--- a/internal/ssh/proxy.go
+++ b/internal/ssh/proxy.go
@@ -34,25 +34,24 @@ import (
 const ResizeSleepInterval = 500 * time.Millisecond
 
 type ProxyConfig struct {
-	Username            string
-	Password            string
-	IdentityFile        string
-	IdentityPrivateKey  []byte
-	Hostname            string
-	Port                int
-	sshClientConfig     *ssh.ClientConfig
-	sshServerConfig     *ssh.ServerConfig
-	AwsEC2Target        string
-	AwsAvailabilityZone string
-	ssmClient           *ssm.Client
-	windowWidth         int
-	windowHeight        int
-	session             *ShellSession
-	AWSRegion           string
-	AWSProfile          string
-	ECSSSMProxy         *ECSSSMProxy
-	awsConfig           aws.Config
-	AwsUpstreamType     string
+	Username           string
+	Password           string
+	IdentityFile       string
+	IdentityPrivateKey []byte
+	Hostname           string
+	Port               int
+	sshClientConfig    *ssh.ClientConfig
+	sshServerConfig    *ssh.ServerConfig
+	AwsEC2Target       string
+	ssmClient          *ssm.Client
+	windowWidth        int
+	windowHeight       int
+	session            *ShellSession
+	AWSRegion          string
+	AWSProfile         string
+	ECSSSMProxy        *ECSSSMProxy
+	awsConfig          aws.Config
+	AwsUpstreamType    string
 }
 
 type ECSSSMProxy struct {
@@ -92,22 +91,18 @@ func BuildProxyConfig(socket models.Socket, AWSRegion, AWSProfile string) (*Prox
 		if socket.ConnectorLocalData.AWSEC2Target == "" {
 			return nil, fmt.Errorf("aws_ec2_target is required for aws-ec2connect upstream type")
 		}
-		if socket.ConnectorLocalData.AWSAvailabilityZone == "" {
-			return nil, fmt.Errorf("aws_availability_zone is required for aws-ec2connect upstream type")
-		}
 	}
 
 	proxyConfig := &ProxyConfig{
-		Hostname:            socket.ConnectorData.TargetHostname,
-		Port:                socket.ConnectorData.Port,
-		Username:            socket.ConnectorLocalData.UpstreamUsername,
-		Password:            socket.ConnectorLocalData.UpstreamPassword,
-		IdentityFile:        socket.ConnectorLocalData.UpstreamIdentifyFile,
-		IdentityPrivateKey:  socket.ConnectorLocalData.UpstreamIdentityPrivateKey,
-		AwsEC2Target:        socket.ConnectorLocalData.AWSEC2Target,
-		AWSRegion:           AWSRegion,
-		AWSProfile:          AWSProfile,
-		AwsAvailabilityZone: socket.ConnectorLocalData.AWSAvailabilityZone,
+		Hostname:           socket.ConnectorData.TargetHostname,
+		Port:               socket.ConnectorData.Port,
+		Username:           socket.ConnectorLocalData.UpstreamUsername,
+		Password:           socket.ConnectorLocalData.UpstreamPassword,
+		IdentityFile:       socket.ConnectorLocalData.UpstreamIdentifyFile,
+		IdentityPrivateKey: socket.ConnectorLocalData.UpstreamIdentityPrivateKey,
+		AwsEC2Target:       socket.ConnectorLocalData.AWSEC2Target,
+		AWSRegion:          AWSRegion,
+		AWSProfile:         AWSProfile,
 	}
 
 	switch {
@@ -658,10 +653,9 @@ func handleEC2ConnectClient(conn net.Conn, config ProxyConfig) {
 
 	ec2ConnectClient := ec2instanceconnect.NewFromConfig(config.awsConfig)
 	_, err = ec2ConnectClient.SendSSHPublicKey(context.TODO(), &ec2instanceconnect.SendSSHPublicKeyInput{
-		AvailabilityZone: &config.AwsAvailabilityZone,
-		InstanceId:       &config.AwsEC2Target,
-		InstanceOSUser:   &user,
-		SSHPublicKey:     &publicKeyString,
+		InstanceId:     &config.AwsEC2Target,
+		InstanceOSUser: &user,
+		SSHPublicKey:   &publicKeyString,
 	})
 
 	if err != nil {


### PR DESCRIPTION
## [[ME-1718](https://mysocket.atlassian.net/browse/ME-1718)] Remove Need for Useless Availability Zone Arg

Removing availability zone because:
- The SDK does not require it
- It is optional under all circumstances in the send-public-key operation; seems to be left in the aws api/sdk/cli for backwards compatibility only
- Instance IDs are globally unique and are guaranteed not to change for a given instance
- One less option is a big win in terms of friction

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1718

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally

```
Adrianos-MacBook-Pro:~ adriano$ AWS_PROFILE=default AWS_REGION=us-east-1 border0 socket connect demo-ec2-ic-socket --aws_ec2_connect --aws_ec2_target i-07ef34b7a4d50bb47 --host 44.203.135.224 --port 22

Welcome to Border0.com
demo-ec2-ic-socket - ssh://demo-ec2-ic-socket-docs0.border0.io

=======================================================
Logs
=======================================================
89.187.177.73:36198 [Wed, 19 Jul 2023 02:01:16 UTC] TCP 200 bytes_sent:3729 bytes_received:4468 session_time: 18.99
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1718]: https://mysocket.atlassian.net/browse/ME-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ