### PR TITLE
[ME-1718] Proper AWS-nomenclature for ec2 instance connect

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,7 +86,8 @@ var (
 	awsECSTasks             []string
 	awsECSContainers        []string
 	disableBrowser          bool
-	awsEC2Connect           bool
+	awsEc2InstanceId        string
+	awsEc2InstanceConnect   bool
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/socket.go
+++ b/cmd/socket.go
@@ -363,7 +363,7 @@ var socketConnectCmd = &cobra.Command{
 
 		var sshAuthProxy bool
 		var sshProxyConfig ssh.ProxyConfig
-		if socket.SocketType == "ssh" && (upstream_username != "" || upstream_password != "" || upstream_identify_file != "" || awsEC2Target != "" || socket.UpstreamType == "aws-ssm" || socket.UpstreamType == "aws-ec2connect" || awsEC2Connect) {
+		if socket.SocketType == "ssh" && (upstream_username != "" || upstream_password != "" || upstream_identify_file != "" || awsEC2Target != "" || awsEc2InstanceId != "" || socket.UpstreamType == "aws-ssm" || socket.UpstreamType == "aws-ec2connect" || awsEc2InstanceConnect) {
 			switch {
 			case socket.UpstreamType == "aws-ssm":
 				if awsECSCluster == "" && awsEC2Target == "" {
@@ -385,19 +385,19 @@ var socketConnectCmd = &cobra.Command{
 						Containers: awsECSContainers,
 					}
 				}
-			case socket.UpstreamType == "aws-ec2connect" || awsEC2Connect:
-				if awsEC2Target == "" {
-					return fmt.Errorf("aws_ec2_target is required for aws-ec2connect upstream services")
+			case socket.UpstreamType == "aws-ec2connect" || awsEc2InstanceConnect:
+				if awsEc2InstanceId == "" {
+					return fmt.Errorf("aws ec2 instance id is required for EC2 Instance Connect based upstream services")
 				}
 
 				sshProxyConfig = ssh.ProxyConfig{
-					AwsEC2Target:    awsEC2Target,
-					AWSRegion:       awsRegion,
-					AWSProfile:      awsProfile,
-					Hostname:        hostname,
-					Port:            port,
-					Username:        upstream_username,
-					AwsUpstreamType: "aws-ec2connect",
+					AwsEC2InstanceId: awsEc2InstanceId,
+					AWSRegion:        awsRegion,
+					AWSProfile:       awsProfile,
+					Hostname:         hostname,
+					Port:             port,
+					Username:         upstream_username,
+					AwsUpstreamType:  "aws-ec2connect",
 				}
 
 			default:
@@ -631,7 +631,8 @@ func init() {
 	socketConnectCmd.Flags().BoolVarP(&upstream_tls, "upstream_tls", "", true, "Use TLS for upstream connection")
 	socketConnectCmd.Flags().StringVarP(&upstream_identify_file, "upstream_identity_file", "", "", "Upstream identity file")
 	socketConnectCmd.Flags().StringVarP(&awsEC2Target, "aws_ec2_target", "", "", "Aws EC2 target identifier")
-	socketConnectCmd.Flags().BoolVarP(&awsEC2Connect, "aws_ec2_connect", "", false, "Use AWS EC2 connect to connect to the target")
+	socketConnectCmd.Flags().StringVarP(&awsEc2InstanceId, "aws-ec2-instance-id", "", "", "Instance id of the target AWS EC2 Instance")
+	socketConnectCmd.Flags().BoolVarP(&awsEc2InstanceConnect, "aws-ec2-instance-connect", "", false, "Use AWS EC2 Instance Connect to connect to the target")
 	socketConnectCmd.Flags().StringVarP(&awsRegion, "region", "", "", "AWS region to use")
 	socketConnectCmd.Flags().StringVarP(&awsProfile, "profile", "", "", "AWS profile to use")
 	socketConnectCmd.Flags().StringVarP(&awsECSCluster, "aws_ecs_cluster", "", "", "The aws cluster to connect to, Required if upstream type is asw-ssm")

--- a/internal/api/models/socket.go
+++ b/internal/api/models/socket.go
@@ -47,6 +47,7 @@ type ConnectorLocalData struct {
 	RdsIAMAuth                 bool
 	AWSRegion                  string
 	AWSEC2Target               string
+	AwsEC2InstanceId           string
 	CloudSQLConnector          bool
 	CloudSQLIAMAuth            bool
 	CloudSQLInstance           string

--- a/internal/ssh/proxy.go
+++ b/internal/ssh/proxy.go
@@ -43,6 +43,7 @@ type ProxyConfig struct {
 	sshClientConfig    *ssh.ClientConfig
 	sshServerConfig    *ssh.ServerConfig
 	AwsEC2Target       string
+	AwsEC2InstanceId   string
 	ssmClient          *ssm.Client
 	windowWidth        int
 	windowHeight       int
@@ -88,8 +89,8 @@ func BuildProxyConfig(socket models.Socket, AWSRegion, AWSProfile string) (*Prox
 	}
 
 	if socket.UpstreamType == "aws-ec2connect" || socket.ConnectorLocalData.AWSEC2ConnectEnabled {
-		if socket.ConnectorLocalData.AWSEC2Target == "" {
-			return nil, fmt.Errorf("aws_ec2_target is required for aws-ec2connect upstream type")
+		if socket.ConnectorLocalData.AwsEC2InstanceId == "" {
+			return nil, fmt.Errorf("aws ec2 instance id is required for aws-ec2connect upstream type")
 		}
 	}
 
@@ -101,6 +102,7 @@ func BuildProxyConfig(socket models.Socket, AWSRegion, AWSProfile string) (*Prox
 		IdentityFile:       socket.ConnectorLocalData.UpstreamIdentifyFile,
 		IdentityPrivateKey: socket.ConnectorLocalData.UpstreamIdentityPrivateKey,
 		AwsEC2Target:       socket.ConnectorLocalData.AWSEC2Target,
+		AwsEC2InstanceId:   socket.ConnectorLocalData.AwsEC2InstanceId,
 		AWSRegion:          AWSRegion,
 		AWSProfile:         AWSProfile,
 	}
@@ -653,7 +655,7 @@ func handleEC2ConnectClient(conn net.Conn, config ProxyConfig) {
 
 	ec2ConnectClient := ec2instanceconnect.NewFromConfig(config.awsConfig)
 	_, err = ec2ConnectClient.SendSSHPublicKey(context.TODO(), &ec2instanceconnect.SendSSHPublicKeyInput{
-		InstanceId:     &config.AwsEC2Target,
+		InstanceId:     &config.AwsEC2InstanceId,
 		InstanceOSUser: &user,
 		SSHPublicKey:   &publicKeyString,
 	})


### PR DESCRIPTION
## [[ME-1718](https://mysocket.atlassian.net/browse/ME-1718)] Proper AWS-nomenclature for ec2 instance connect

Uses naming of AWS things in accordance to how AWS calls things.
- aws ec2 target --> aws ec2 instance id, `--aws_ec2_target` becomes `--aws-ec2-instance-id`
- aws ec2 connect --> aws ec2 instance connect (the technology is called "ec2 instance connect", not "ec2 connect", we can't be calling it different than aws calls it) `--aws-ec2-connect` becomes `--aws-ec2-instance-connect`

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1718

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally:

```
Adrianos-MacBook-Pro:~ adriano$ AWS_PROFILE=default AWS_REGION=us-east-1 border0 socket connect demo-ec2-ic-socket --aws-ec2-instance-connect --aws-ec2-instance-id i-07ef34b7a4d50bb47 --host 44.203.135.224 --port 22

Welcome to Border0.com
demo-ec2-ic-socket - ssh://demo-ec2-ic-socket-docs0.border0.io

=======================================================
Logs
=======================================================
89.187.177.73:60608 [Wed, 19 Jul 2023 02:26:32 UTC] TCP 200 bytes_sent:3729 bytes_received:4468 session_time: 21.27
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1718]: https://mysocket.atlassian.net/browse/ME-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ