### PR TITLE
[ME-1718] Re-establish compatibility with connector v2

### DIFF
--- a/internal/ssh/proxy.go
+++ b/internal/ssh/proxy.go
@@ -102,6 +102,7 @@ func BuildProxyConfig(socket models.Socket, AWSRegion, AWSProfile string) (*Prox
 		IdentityFile:       socket.ConnectorLocalData.UpstreamIdentifyFile,
 		IdentityPrivateKey: socket.ConnectorLocalData.UpstreamIdentityPrivateKey,
 		AwsEC2InstanceId:   socket.ConnectorLocalData.AwsEC2InstanceId,
+		AwsSSMTarget:       socket.ConnectorLocalData.AwsEC2InstanceId, // when instance id empty and ecs cluster is given, target will be constructed during connection
 		AWSRegion:          AWSRegion,
 		AWSProfile:         AWSProfile,
 	}
@@ -114,6 +115,8 @@ func BuildProxyConfig(socket models.Socket, AWSRegion, AWSProfile string) (*Prox
 	}
 
 	if socket.UpstreamType == "aws-ssm" && socket.ConnectorLocalData.AWSECSCluster != "" {
+		// TODO: when ECSSSMProxy is not nil, proxyConfig.AwsSSMTarget will be constructed
+		// from ecs cluster during connection... this kind of sucks... improve
 		proxyConfig.ECSSSMProxy = &ECSSSMProxy{
 			Cluster:    socket.ConnectorLocalData.AWSECSCluster,
 			Services:   socket.ConnectorLocalData.AWSECSServices,


### PR DESCRIPTION
# [[ME-1718](https://mysocket.atlassian.net/browse/ME-1718)] Re-establish compatibility with connector v2 #122

Re-establish compatibility of ec2 SSM targets with connector v2

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1718

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
Adrianos-MacBook-Pro:~ adriano$ AWS_PROFILE=default border0 connector start --v2
{"level":"info","ts":"2023-07-18T21:44:24-06:00","msg":"starting the connector service"}
{"level":"info","ts":"2023-07-18T21:44:24-06:00","msg":"connecting to connector server","server":"capi.staging.border0.com:443"}
{"level":"info","ts":"2023-07-18T21:44:24-06:00","msg":"new plugin","plugin":"875bfcfc-fe4f-4a5d-ba6b-a37516c39200"}
{"level":"info","ts":"2023-07-18T21:44:24-06:00","msg":"new socket","socket":"5c0bab4a-9fe0-4b4c-9d50-3826657bc2dc"}
{"level":"debug","ts":"2023-07-18T21:44:28-06:00","msg":"discovery result","plugin_id":"875bfcfc-fe4f-4a5d-ba6b-a37516c39200","discoverer_id":"aws ec2 ( region = eu-west-1 )","resources":1}
Welcome to Border0.com
my-demo-instan-ssmce - ssh://my-demo-instan-ssmce-adrianosela.staging.border0.io

=======================================================
Logs
=======================================================
89.187.177.73:38608 [Wed, 19 Jul 2023 03:44:43 UTC] TCP 200 bytes_sent:4129 bytes_received:5268 session_time: 11.21
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1718]: https://mysocket.atlassian.net/browse/ME-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ