### PR TITLE
fix(ME-1716): start refresh token job before starting tunnel

### DIFF
--- a/cmd/tunnel.go
+++ b/cmd/tunnel.go
@@ -128,7 +128,12 @@ var tunnelConnectCmd = &cobra.Command{
 			log.Fatalf("error: invalid socket_id")
 		}
 
-		socket, err := border0.NewSocket(context.Background(), api.NewAPI(api.WithVersion(version)), socketID)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		border0API := api.NewAPI(api.WithVersion(version))
+
+		socket, err := border0.NewSocket(ctx, border0API, socketID)
 		if err != nil {
 			log.Fatalf("error: %v", err)
 		}
@@ -148,6 +153,8 @@ var tunnelConnectCmd = &cobra.Command{
 		if socket.SocketType != "ssh" && localssh {
 			localssh = false
 		}
+
+		border0API.StartRefreshAccessTokenJob(ctx)
 
 		l, err := socket.Listen()
 		if err != nil {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -64,10 +64,9 @@ func WithVersion(version string) APIOption {
 }
 
 type Border0API struct {
-	Credentials       *models.Credentials
-	Version           string
-	mutex             *sync.Mutex
-	refreshJobStarted bool
+	Credentials *models.Credentials
+	Version     string
+	mutex       *sync.Mutex
 }
 
 type ErrorMessage struct {
@@ -430,15 +429,14 @@ func (a *Border0API) RefreshAccessToken() (*models.Credentials, error) {
 }
 
 func (a *Border0API) StartRefreshAccessTokenJob(ctx context.Context) {
-	if a.refreshJobStarted {
-		return
-	}
-
-	a.refreshJobStarted = true
-
 	if a.Credentials == nil {
-		fmt.Println("no credentials found, no need to refresh token")
-		return
+		token, err := getToken()
+		if err != nil {
+			fmt.Println("no credentials found:", err)
+			return
+		}
+
+		a.Credentials = token
 	}
 
 	if !a.Credentials.ShouldRefresh() {

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -169,44 +169,6 @@ func (c *Client) Request(method string, url string, target interface{}, data int
 	return nil
 }
 
-func RefreshLogin() (string, error) {
-
-	client, err := NewClient()
-	if err != nil {
-		return "", err
-	}
-	loginRefresh := models.LoginRefresh{}
-	res := models.TokenForm{}
-
-	err = client.Request(http.MethodPost, "login/refresh", &res, loginRefresh)
-	if err != nil {
-		return "", err
-	}
-
-	// create dir if not exists
-	configPath := filepath.Dir(tokenfile())
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		if err := os.Mkdir(configPath, 0700); err != nil {
-			return "", fmt.Errorf("failed to create directory %s : %s", configPath, err)
-		}
-	}
-
-	f, err := os.Create(tokenfile())
-	if err != nil {
-		return "", err
-	}
-	if err := os.Chmod(tokenfile(), 0600); err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	_, err = f.WriteString(fmt.Sprintf("%s\n", res.Token))
-	if err != nil {
-		return "", err
-	}
-	return res.Token, nil
-}
-
 func MFAChallenge(code string) error {
 	c, err := NewClient()
 	if err != nil {


### PR DESCRIPTION
# Description

When we moved to border0 Listen functions we removed the old refresh job.
But the new refresh job was not added.

This PR will start the new refresh job.
Fixes # ME-1716

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally with socket connect, run and connector mode.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
