### PR TITLE
[ME-1721] Fix Cross-Region EC2 Instance Connect

### DIFF
--- a/internal/connector_v2/upstreamdata/builder.go
+++ b/internal/connector_v2/upstreamdata/builder.go
@@ -85,7 +85,7 @@ func (u *UpstreamDataBuilder) setupAWSSSM(s *models.Socket, ssmDetails types.Aws
 func (u *UpstreamDataBuilder) setupEc2Connect(s *models.Socket, ec2Details types.AwsEC2ConnectDetails) error {
 	s.UpstreamType = UpstreamTypeAwsEC2Conn
 	s.ConnectorLocalData.AwsEC2InstanceId = u.fetchVariableFromSource(ec2Details.InstanceID)
-	s.ConnectorLocalData.AWSRegion = u.fetchVariableFromSource(ec2Details.Region)
+	s.AWSRegion = u.fetchVariableFromSource(ec2Details.Region)
 	s.ConnectorLocalData.AWSEC2InstanceConnectEnabled = true
 
 	return nil


### PR DESCRIPTION
## [[ME-1721](https://mysocket.atlassian.net/browse/ME-1721)] Fix Cross-Region EC2 Instance Connect

Populate the right region field in the Socket object such that the region gets set in the AWS config for the EC2 Instance Connect `SendSshPublicKey` api call and cross-region sockets (e.g. when connector/cli is in a different region than the target instance) is possible.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1721

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally against a socket in staging cross-region.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
