### PR TITLE
[ME-1739] Connector Metadata Service First Stab

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.6
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
 	github.com/bluele/factory-go v0.0.1
-	github.com/borderzero/border0-go v0.1.17
+	github.com/borderzero/border0-go v0.1.18
 	github.com/borderzero/border0-proto v1.0.2
 	github.com/borderzero/discovery v0.1.18
 	github.com/brianvoe/gofakeit v3.18.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v0.1.17 h1:4Tdw2rQCJF8GJwb1E42iGwXPc5yR222Kmv4mRySIRgA=
-github.com/borderzero/border0-go v0.1.17/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
+github.com/borderzero/border0-go v0.1.18 h1:Xf62f93P3Q5FGdOWL3OFSI3NOFvWbcV3RelLGJoP0B4=
+github.com/borderzero/border0-go v0.1.18/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
 github.com/borderzero/border0-proto v1.0.2 h1:BDMLFvcXjX5rA0YPc4r+rTa2yBGV9g0nBE1wxTGOPck=
 github.com/borderzero/border0-proto v1.0.2/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
 github.com/borderzero/discovery v0.1.18 h1:YRC1yVoOaiUgSMQ+mSToNNk9EOv19+mOwuBNmpZXu9E=

--- a/internal/connector_v2/cmds/builder.go
+++ b/internal/connector_v2/cmds/builder.go
@@ -1,0 +1,45 @@
+package cmds
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/borderzero/border0-go/service/connector/types"
+)
+
+// MetadataFromContext gathers all metadata
+// regarding where/how the connector is running.
+func MetadataFromContext(ctx context.Context) *types.ConnectorMetadata {
+	metadata := &types.ConnectorMetadata{}
+
+	trySetAwsEc2IdentityMetadata(ctx, metadata)
+
+	return metadata
+}
+
+func trySetAwsEc2IdentityMetadata(ctx context.Context, cmd *types.ConnectorMetadata) {
+	awsConfig, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		// ignored error
+		return
+	}
+	identityDoc, err := imds.NewFromConfig(awsConfig).GetInstanceIdentityDocument(ctx, &imds.GetInstanceIdentityDocumentInput{})
+	if err != nil {
+		// ignored error
+		return
+	}
+	cmd.AwsEc2IdentityMetadata = &types.AwsEc2IdentityMetadata{
+		AwsAccountId:        identityDoc.AccountID,
+		AwsRegion:           identityDoc.Region,
+		AwsAvailabilityZone: identityDoc.AvailabilityZone,
+		Ec2InstanceId:       identityDoc.InstanceID,
+		Ec2InstanceType:     identityDoc.InstanceType,
+		Ec2ImageId:          identityDoc.ImageID,
+		KernelId:            identityDoc.KernelID,
+		RamdiskId:           identityDoc.RamdiskID,
+		Architecture:        identityDoc.Architecture,
+		PrivateIpAddress:    identityDoc.PrivateIP,
+	}
+	return
+}

--- a/internal/connector_v2/service.go
+++ b/internal/connector_v2/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/borderzero/border0-cli/internal/api/models"
 	"github.com/borderzero/border0-cli/internal/border0"
+	"github.com/borderzero/border0-cli/internal/connector_v2/cmds"
 	"github.com/borderzero/border0-cli/internal/connector_v2/config"
 	"github.com/borderzero/border0-cli/internal/connector_v2/errors"
 	"github.com/borderzero/border0-cli/internal/connector_v2/logger"
@@ -80,6 +81,7 @@ func (c *ConnectorService) Start() {
 
 	go c.StartControlStream(newCtx, cancel)
 	go c.handleDiscoveryResult(newCtx)
+	go c.uploadConnectorMetadata(newCtx)
 
 	<-newCtx.Done()
 }
@@ -652,6 +654,14 @@ func (c *ConnectorService) handleDiscoveryResult(ctx context.Context) {
 			}
 		}
 	}
+}
+
+func (c *ConnectorService) uploadConnectorMetadata(ctx context.Context) {
+	metadata := cmds.MetadataFromContext(ctx)
+
+	c.logger.Info("got metadata", zap.Any("metadata", metadata))
+
+	// TODO: send metadata over GRPC stream
 }
 
 func (c *ConnectorService) sendControlStreamRequest(request *pb.ControlStreamRequest) error {


### PR DESCRIPTION
## [[ME-1739](https://mysocket.atlassian.net/browse/ME-1739)] Connector Metadata Service First Stab

- Updates border0 go types lib to latest version
- First stab at implementing a connector metadata service

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1739

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested in EC2

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1739]: https://mysocket.atlassian.net/browse/ME-1739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ