### PR TITLE
[ME-1739] Send Connector (v2) Metadata Upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.6
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
 	github.com/bluele/factory-go v0.0.1
-	github.com/borderzero/border0-go v0.1.18
-	github.com/borderzero/border0-proto v1.0.2
+	github.com/borderzero/border0-go v0.1.19
+	github.com/borderzero/border0-proto v1.0.3
 	github.com/borderzero/discovery v0.1.18
 	github.com/brianvoe/gofakeit v3.18.0+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1

--- a/go.sum
+++ b/go.sum
@@ -119,10 +119,10 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v0.1.18 h1:Xf62f93P3Q5FGdOWL3OFSI3NOFvWbcV3RelLGJoP0B4=
-github.com/borderzero/border0-go v0.1.18/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
-github.com/borderzero/border0-proto v1.0.2 h1:BDMLFvcXjX5rA0YPc4r+rTa2yBGV9g0nBE1wxTGOPck=
-github.com/borderzero/border0-proto v1.0.2/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
+github.com/borderzero/border0-go v0.1.19 h1:gBwqhacSrMmvYQQQbd7swN9KSZBMW3gQVIa6QCKtbcY=
+github.com/borderzero/border0-go v0.1.19/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
+github.com/borderzero/border0-proto v1.0.3 h1:I7xj7qsNlVvWD0+h7oin2fZbwNDrK0tiHgnmz2ODPr4=
+github.com/borderzero/border0-proto v1.0.3/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
 github.com/borderzero/discovery v0.1.18 h1:YRC1yVoOaiUgSMQ+mSToNNk9EOv19+mOwuBNmpZXu9E=
 github.com/borderzero/discovery v0.1.18/go.mod h1:XcuKldfCIyQd/GT7pv7amTbLZOZE6o8CgXwRb6UI6aI=
 github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=

--- a/internal/connector_v2/util/util.go
+++ b/internal/connector_v2/util/util.go
@@ -7,14 +7,26 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// AsStruct unmarshals a structbp onto a given target object.
-func AsStruct(structpb *structpb.Struct, target any) error {
+// AsStruct converts a protobuf struct to a go struct
+func AsStruct(structpb *structpb.Struct, gostruct any) error {
 	jsonBytes, err := structpb.MarshalJSON()
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal structpb: %w", err)
+		return fmt.Errorf("failed to marshal pb struct to json: %v", err)
 	}
-	if err = json.Unmarshal(jsonBytes, target); err != nil {
-		return fmt.Errorf("failed to unmarshal json: %v", err)
+	if err = json.Unmarshal(jsonBytes, gostruct); err != nil {
+		return fmt.Errorf("failed to unmarshal json onto go struct: %v", err)
+	}
+	return nil
+}
+
+// AsPbStruct converts a go struct to a protobuf struct
+func AsPbStruct(gostruct any, structpb *structpb.Struct) error {
+	jsonBytes, err := json.Marshal(gostruct)
+	if err != nil {
+		return fmt.Errorf("failed to marshal go struct to json: %v", err)
+	}
+	if err = json.Unmarshal(jsonBytes, &structpb); err != nil {
+		return fmt.Errorf("failed to unmarshal json onto pb struct: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## [[ME-1739](https://mysocket.atlassian.net/browse/ME-1739)] Send Connector (v2) Metadata Upstream

Sends collected connector metadata upstream to the api for updating

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1739

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested against a local border0 api and checked the results in the db looked as expected.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1739]: https://mysocket.atlassian.net/browse/ME-1739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ