### PR TITLE
[ME-1761] Proper GRPC Authentication

### DIFF
--- a/internal/connector_v2/config/config.go
+++ b/internal/connector_v2/config/config.go
@@ -32,6 +32,7 @@ const (
 // Configuration represents (static) connector configuration
 type Configuration struct {
 	Token                      string            `yaml:"token"`
+	ConnectorId                string            `yaml:"connector_id"`
 	ConnectorServer            string            `yaml:"connector_server"`
 	ConnectorInsecureTransport bool              `yaml:"connector_insecure"`
 	TunnelServer               string            `yaml:"tunnel_server"`


### PR DESCRIPTION
## [[ME-1761](https://mysocket.atlassian.net/browse/ME-1761)] Proper GRPC Authentication

After the recent changes to the grpc server side we can use border0 admin access tokens (and user tokens) to connect connectors (if the role policy is right). In cases where the credentials used are not a connector (v2) token -- the connector id needs to be provided explicitly

This adds a hidden flag to do that, as well as cleans up the existing GRPC authentication code.

Fixes # (issue):
- https://github.com/mysocketio/api/pull/971

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested extensively. The details of such testing are in the corresponding api change PR: 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1761]: https://mysocket.atlassian.net/browse/ME-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ