### PR TITLE
[MISC] Border0 VPN Implementation Over TLS

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/borderzero/border0-cli/cmd/client/hosts"
 	"github.com/borderzero/border0-cli/cmd/client/ssh"
+	"github.com/borderzero/border0-cli/cmd/client/vpn"
 	"github.com/borderzero/border0-cli/internal/client"
 	"github.com/spf13/cobra"
 )
@@ -144,4 +145,5 @@ func init() {
 	hosts.AddCommandsTo(clientCmd)
 	ssh.AddCommandsTo(clientCmd)
 	clientTls.AddCommandsTo(clientCmd)
+	vpn.AddCommandsTo(clientCmd)
 }

--- a/cmd/client/vpn/vpn.go
+++ b/cmd/client/vpn/vpn.go
@@ -1,0 +1,101 @@
+package vpn
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/borderzero/border0-cli/cmd/logger"
+	"github.com/borderzero/border0-cli/internal/client"
+	"github.com/borderzero/border0-cli/internal/enum"
+	"github.com/borderzero/border0-cli/internal/vpnlib"
+	"github.com/songgao/water"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var (
+	hostname string
+)
+
+// clientVpnCmd represents the client tls command
+var clientVpnCmd = &cobra.Command{
+	Use:               "vpn",
+	Short:             "Start a Border0 VPN",
+	ValidArgsFunction: client.AutocompleteHost,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			hostname = args[0]
+		}
+
+		if hostname == "" {
+			pickedHost, err := client.PickHost(hostname, enum.TLSSocket)
+			if err != nil {
+				return fmt.Errorf("failed to pick host: %v", err)
+			}
+			hostname = pickedHost.Hostname()
+		}
+
+		info, err := client.GetResourceInfo(logger.Logger, hostname)
+		if err != nil {
+			return fmt.Errorf("failed to get certificate: %v", err)
+		}
+
+		certificate := tls.Certificate{
+			Certificate: [][]byte{info.Certficate.Raw},
+			PrivateKey:  info.PrivateKey,
+		}
+
+		tlsConfig := tls.Config{
+			Certificates:       []tls.Certificate{certificate},
+			InsecureSkipVerify: true,
+		}
+
+		conn, err := establishConnection(info.ConnectorAuthenticationEnabled, fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
+		if err != nil {
+			return fmt.Errorf("failed to connect: %v", err)
+		}
+
+		iface, err := water.New(water.Config{DeviceType: water.TUN})
+		if err != nil {
+			return fmt.Errorf("failed to create TUN iface: %v", err)
+		}
+		logger.Logger.Info("Created TUN interface", zap.String("interface_name", iface.Name()))
+
+		ctrl, err := vpnlib.GetControlMessage(conn, time.Second*5)
+		if err != nil {
+			return fmt.Errorf("failed to get control message from connection: %v", err)
+		}
+		logger.Logger.Info("Received control message", zap.Any("control_message", ctrl))
+
+		if err = vpnlib.AddIpToIface(iface.Name(), ctrl.ClientIp, ctrl.ServerIp); err != nil {
+			return fmt.Errorf("failed to add static IPs to interface: %v", err)
+		}
+
+		if err = vpnlib.AddRoutesToIface(iface.Name(), ctrl.Routes); err != nil {
+			return fmt.Errorf("failed to add routes to interface: %v", err)
+		}
+
+		// note: this blocks
+		if err = vpnlib.PacketCopy(conn, iface); err != nil {
+			return fmt.Errorf("failed to forward between tls conn and TUN iface: %v", err)
+		}
+		return nil
+	},
+}
+
+func establishConnection(connectorAuthenticationEnabled bool, addr string, tlsConfig *tls.Config) (conn net.Conn, err error) {
+	if connectorAuthenticationEnabled {
+		conn, err = client.ConnectorAuthConnect(addr, tlsConfig)
+	} else {
+		conn, err = tls.Dial("tcp", addr, tlsConfig)
+	}
+	return
+}
+
+func AddCommandsTo(client *cobra.Command) {
+	client.AddCommand(clientVpnCmd)
+
+	clientVpnCmd.Flags().StringVarP(&hostname, "service", "", "", "The Border0 service identifier")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,9 @@ var (
 	disableBrowser          bool
 	awsEc2InstanceId        string
 	awsEc2InstanceConnect   bool
+	clientIp                string
+	serverIp                string
+	routes                  []string
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/satori/go.uuid v1.2.0
 	github.com/shirou/gopsutil/v3 v3.23.4
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
+	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -546,6 +546,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
+github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8 h1:TG/diQgUe0pntT/2D9tmUCz4VNwm9MfrtPr0SU2qSX8=
+github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8/go.mod h1:P5HUIBuIWKbyjl083/loAegFkfbFNx5i2qEP4CNbm7E=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=

--- a/internal/ssh/proxy.go
+++ b/internal/ssh/proxy.go
@@ -53,7 +53,7 @@ type ProxyConfig struct {
 	ECSSSMProxy        *ECSSSMProxy
 	awsConfig          aws.Config
 	AwsUpstreamType    string
-	Logger              *zap.Logger
+	Logger             *zap.Logger
 }
 
 type ECSSSMProxy struct {
@@ -96,7 +96,7 @@ func BuildProxyConfig(logger *zap.Logger, socket models.Socket, AWSRegion, AWSPr
 	}
 
 	proxyConfig := &ProxyConfig{
-		Logger:              logger,
+		Logger:             logger,
 		Hostname:           socket.ConnectorData.TargetHostname,
 		Port:               socket.ConnectorData.Port,
 		Username:           socket.ConnectorLocalData.UpstreamUsername,

--- a/internal/vpnlib/vpnlib.go
+++ b/internal/vpnlib/vpnlib.go
@@ -1,0 +1,243 @@
+package vpnlib
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/songgao/water"
+)
+
+const (
+	controlMessageHeaderByteSize = 2
+)
+
+// ControlMessage represents a message used to tell clients
+// the tunnel IPs and what routes to install on the interface.
+type ControlMessage struct {
+	ClientIp     string   `json:"client_ip"`
+	ServerIp     string   `json:"server_ip"`
+	SubnetLength uint8    `json:"subnet_length"`
+	Routes       []string `json:"routes"` // CIDRs
+}
+
+// Build encodes a control message to ready-to-send bytes.
+func (m *ControlMessage) Build() ([]byte, error) {
+	controlMessageBytes, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode control message to json: %v", err)
+	}
+	controlMessageHeader := make([]byte, controlMessageHeaderByteSize)
+	binary.BigEndian.PutUint16(controlMessageHeader, uint16(len(controlMessageBytes)))
+	return append(controlMessageHeader, controlMessageBytes...), nil
+}
+
+// GetControlMessage reads a control message from a net conn.
+func GetControlMessage(conn net.Conn, timeout time.Duration) (*ControlMessage, error) {
+	conn.SetReadDeadline(time.Now().Add(timeout)) // note: ignored error
+	defer conn.SetDeadline(time.Time{})           // note: ignored error
+
+	controlMessageHeaderBuffer := make([]byte, controlMessageHeaderByteSize)
+
+	// read first ${headerByteSize} bytes from the connection
+	// to know how big the next incoming packet is
+	headerN, err := io.ReadFull(conn, controlMessageHeaderBuffer)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read header: %v", err)
+	}
+	if headerN < controlMessageHeaderByteSize {
+		return nil, fmt.Errorf("Read less than controlMessageHeaderByteSize bytes (%d): %d", controlMessageHeaderByteSize, headerN)
+	}
+
+	// convert binary header to the size uint16
+	inboundControlMessageSize := binary.BigEndian.Uint16(controlMessageHeaderBuffer)
+
+	// new empty buffer of the size of the control message we're about to read
+	controlMessageBuffer := make([]byte, inboundControlMessageSize)
+
+	// read the control message
+	controlMessageN, err := io.ReadFull(conn, controlMessageBuffer)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read control message from net conn: %v", err)
+	}
+	if controlMessageN < int(inboundControlMessageSize) {
+		return nil, fmt.Errorf("Read less than the advertised control message size (expected %d, got %d)", inboundControlMessageSize, controlMessageN)
+	}
+
+	// decode control message JSON
+	var ctrlMessage *ControlMessage
+	if err = json.Unmarshal(controlMessageBuffer, &ctrlMessage); err != nil {
+		return nil, fmt.Errorf("Failed to decode control message JSON: %v", err)
+	}
+
+	return ctrlMessage, nil
+}
+
+// AddRoutesToIface adds routes to a network interface.
+func AddRoutesToIface(iface string, routes []string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return addRoutesToIfaceDarwin(iface, routes)
+	case "linux":
+		return addRoutesToIfaceLinux(iface, routes)
+	case "windows":
+		return addRoutesToIfaceWindows(iface, routes)
+	default:
+		return fmt.Errorf("Runtime %s not supported", runtime.GOOS)
+	}
+}
+
+func addRoutesToIfaceDarwin(iface string, routes []string) error {
+	for _, route := range routes {
+		if err := exec.Command("route", "-n", "add", "-net", route, "-interface", iface).Run(); err != nil {
+			return fmt.Errorf("error adding route %s to interface %s: %v", route, iface, err)
+		}
+	}
+	return nil
+}
+
+func addRoutesToIfaceLinux(iface string, routes []string) error {
+	for _, route := range routes {
+		if err := exec.Command("ip", "route", "add", route, "dev", iface).Run(); err != nil {
+			return fmt.Errorf("error adding route %s to interface %s: %v", route, iface, err)
+		}
+	}
+	return nil
+}
+
+func addRoutesToIfaceWindows(iface string, routes []string) error {
+	for _, route := range routes {
+		// Convert route in CIDR notation to network and mask.
+		_, ipNet, err := net.ParseCIDR(route)
+		if err != nil {
+			return fmt.Errorf("invalid CIDR notation %s: %v", route, err)
+		}
+		network := ipNet.IP.String()
+		mask := net.IP(ipNet.Mask).String()
+
+		if err := exec.Command("route", "add", network, "mask", mask, iface).Run(); err != nil {
+			return fmt.Errorf("error adding route %s to interface %s: %v", route, iface, err)
+		}
+	}
+	return nil
+}
+
+// AddIpToIface adds an ip address to a network interface.
+func AddIpToIface(iface, localIp, remoteIp string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return addIpToIfaceDarwin(iface, localIp, remoteIp)
+	case "linux":
+		return addIpToIfaceLinux(iface, localIp)
+	case "windows":
+		return addIpToIfaceWindows(iface, localIp)
+	default:
+		return fmt.Errorf("Runtime %s not supported", runtime.GOOS)
+	}
+}
+
+func addIpToIfaceDarwin(iface, localIp, remoteIp string) error {
+	if err := exec.Command("ifconfig", iface, "mtu", "1200").Run(); err != nil {
+		return fmt.Errorf("error setting MTU for interface %s: %v", iface, err)
+	}
+
+	if err := exec.Command("ifconfig", iface, localIp, remoteIp, "up").Run(); err != nil {
+		return fmt.Errorf("error adding tunnel [ %s <--> %s ] to interface %s: %v", localIp, remoteIp, iface, err)
+	}
+	return nil
+}
+
+func addIpToIfaceLinux(iface, localIp string) error {
+	if err := exec.Command("ip", "addr", "add", fmt.Sprintf("%s/30", localIp), "dev", iface).Run(); err != nil {
+		return fmt.Errorf("error adding ip %s to interface %s: %v", localIp, iface, err)
+	}
+	if err := exec.Command("ip", "link", "set", "dev", iface, "up", "mtu", "1200").Run(); err != nil {
+		return fmt.Errorf("error setting link for interface %s: %v", iface, err)
+	}
+	return nil
+}
+
+func addIpToIfaceWindows(iface, localIp string) error {
+	if err := exec.Command("netsh", "interface", "ip", "set", "address", iface, "static", localIp).Run(); err != nil {
+		return fmt.Errorf("error adding ip %s to interface %s: %v", localIp, iface, err)
+	}
+	return nil
+}
+
+// PacketCopy copies packets between a net.Conn and a TUN interface.
+func PacketCopy(conn net.Conn, iface *water.Interface) error {
+	headerByteSize := 2
+	headerBuffer := make([]byte, headerByteSize)
+
+	packetBufferSize := 9000
+	packetbuffer := make([]byte, packetBufferSize)
+
+	go func() {
+		for {
+			// read first ${headerByteSize} bytes from the connection
+			// to know how big the next incoming packet is
+			headerN, err := conn.Read(headerBuffer)
+			if err != nil {
+				if errors.Is(err, io.EOF) ||
+					errors.Is(err, io.ErrUnexpectedEOF) {
+					return
+				}
+				fmt.Printf("Failed to read header: %v\n", err)
+				continue
+			}
+			if headerN < headerByteSize {
+				fmt.Printf("Read less than headerByteSize bytes (%d): %d\n", headerByteSize, headerN)
+				continue
+			}
+
+			// convert binary header to the size uint16
+			inboundPacketSize := binary.BigEndian.Uint16(headerBuffer)
+
+			// new empty buffer of the size of the packet we're about to read
+			packetBuffer := make([]byte, inboundPacketSize)
+
+			// read the one individual packet
+			packetN, err := io.ReadFull(conn, packetBuffer)
+			if err != nil {
+				fmt.Printf("Failed to read packet from net conn: %v\n", err)
+				continue
+			}
+			if packetN < int(inboundPacketSize) {
+				fmt.Printf("Read less than the advertised packet size (expected %d, got %d)\n", inboundPacketSize, packetN)
+				continue
+			}
+
+			// write the packate to the TUN iface
+			if _, err = iface.Write(packetBuffer); err != nil {
+				fmt.Printf("Failed to write packet to the TUN iface: %v\n", err)
+				continue
+			}
+		}
+	}()
+
+	for {
+		// read one packet from the TUN iface
+		n, err := iface.Read(packetbuffer)
+		if err != nil {
+			fmt.Printf("Failed to read packet from the TUN iface: %v\n", err)
+			continue
+		}
+
+		// compute the header to prepend to the packet before writing to net conn
+		sizeBuf := make([]byte, headerByteSize)
+		binary.BigEndian.PutUint16(sizeBuf, uint16(n))
+
+		// write the encapsulated packet to the net conn
+		_, err = conn.Write(append(sizeBuf, packetbuffer[:n]...))
+		if err != nil {
+			fmt.Printf("Failed to write encapsulated packet to the net conn: %v\n", err)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
## [MISC] Border0 VPN Implementation Over TLS Socket

Example:

```
17:15 $ sudo border0 socket connect vpn vpn-socket --client-ip 10.42.0.2 --server-ip 10.42.0.1 --route 100.0.0.1/32
Welcome to Border0.com
vpn-socket - tls://vpn-socket-adriano.border0.io

=======================================================
Logs
=======================================================
{"level":"info","ts":"2023-07-28T17:15:53-07:00","msg":"Created TUN interface","interface_name":"utun3"}
```

```
17:05 $ sudo border0 client vpn
? choose a host: vpn-socket-adriano.border0.io []
{"level":"info","ts":"2023-07-28T17:06:10-07:00","msg":"Created TUN interface","interface_name":"utun4"}
{"level":"info","ts":"2023-07-28T17:06:10-07:00","msg":"Received control message","control_message":{"client_ip":"10.42.0.2","server_ip":"10.42.0.1","subnet_length":30,"routes":["100.0.0.1/32"]}}
```

Fixes # (issue):

Fixes nothing, but its fucking cool. It's extremely cool. Never forget the rule of cool; you know... anything is acceptable to do, so long as it is cool.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
