### PR TITLE
[MISC] Support for Multiple VPN Clients

### DIFF
--- a/cmd/client/vpn/vpn.go
+++ b/cmd/client/vpn/vpn.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"time"
 
 	"github.com/borderzero/border0-cli/cmd/logger"
@@ -13,6 +14,8 @@ import (
 	"github.com/songgao/water"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
 )
 
 var (
@@ -57,19 +60,23 @@ var clientVpnCmd = &cobra.Command{
 			return fmt.Errorf("failed to connect: %v", err)
 		}
 
+		defer conn.Close()
+
 		iface, err := water.New(water.Config{DeviceType: water.TUN})
 		if err != nil {
 			return fmt.Errorf("failed to create TUN iface: %v", err)
 		}
 		logger.Logger.Info("Created TUN interface", zap.String("interface_name", iface.Name()))
 
-		ctrl, err := vpnlib.GetControlMessage(conn, time.Second*5)
+		defer iface.Close()
+
+		ctrl, err := vpnlib.GetControlMessage(conn)
 		if err != nil {
 			return fmt.Errorf("failed to get control message from connection: %v", err)
 		}
 		logger.Logger.Info("Received control message", zap.Any("control_message", ctrl))
 
-		if err = vpnlib.AddIpToIface(iface.Name(), ctrl.ClientIp, ctrl.ServerIp); err != nil {
+		if err = vpnlib.AddIpToIface(iface.Name(), ctrl.ClientIp, ctrl.ServerIp, ctrl.SubnetSize); err != nil {
 			return fmt.Errorf("failed to add static IPs to interface: %v", err)
 		}
 
@@ -77,10 +84,62 @@ var clientVpnCmd = &cobra.Command{
 			return fmt.Errorf("failed to add routes to interface: %v", err)
 		}
 
+		// create the connection map
+		cm := vpnlib.NewConnectionMap()
+		cm.Set(ctrl.ServerIp, conn)
+		defer cm.Delete(ctrl.ServerIp)
+
+		// Now start the Tun to Conn goroutine
+		// This will listen for packets on the TUN interface and forward them to the right connection
+		go vpnlib.TunToConnCopy(iface, cm, true, conn)
+
+		// Let's start a goroutine that send keep alive ping messges to the other side
+		go func() {
+			// Create ICMP Echo message
+			c, err := icmp.ListenPacket("ip4:icmp", "0.0.0.0")
+			if err != nil {
+				fmt.Println("Error opening ICMP socket:", err)
+				return
+			}
+			defer c.Close()
+			msg := icmp.Message{
+				Type: ipv4.ICMPTypeEcho, Code: 0,
+				Body: &icmp.Echo{
+					ID: os.Getpid() & 0xffff, Seq: 1,
+					Data: []byte("Border0-keepalive-ping"),
+				},
+			}
+			// Convert message to bytes
+			b, err := msg.Marshal(nil)
+			if err != nil {
+				fmt.Println("Error marshaling ICMP message:", err)
+				return
+			}
+
+			for {
+				// send an ICMP ping to ctrl.ServerIp
+				n, err := c.WriteTo(b, &net.IPAddr{IP: net.ParseIP(ctrl.ServerIp)})
+				if err != nil {
+					fmt.Println("Error writing ICMP keep alive message:", err)
+					return
+				} else if n != len(b) {
+					fmt.Println("Got short write from WriteTo")
+					return
+				}
+				time.Sleep(120 * time.Second)
+			}
+		}()
+
+		// Now start the Conn to Tun goroutine
+		// This will listen for packets on the connection and forward them to the TUN interface
 		// note: this blocks
-		if err = vpnlib.PacketCopy(conn, iface); err != nil {
+
+		if err = vpnlib.ConnToTunCopy(conn, iface); err != nil {
+			fmt.Println("Error forwarding packets:", err)
 			return fmt.Errorf("failed to forward between tls conn and TUN iface: %v", err)
 		}
+
+		fmt.Println("Done forwarding packets")
 		return nil
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,8 +88,7 @@ var (
 	disableBrowser          bool
 	awsEc2InstanceId        string
 	awsEc2InstanceConnect   bool
-	clientIp                string
-	serverIp                string
+	vpnSubnet               string
 	routes                  []string
 )
 

--- a/internal/vpnlib/connmap.go
+++ b/internal/vpnlib/connmap.go
@@ -1,0 +1,47 @@
+package vpnlib
+
+import (
+	"net"
+	"sync"
+)
+
+// ConnectionMap is a concurrent-safe map for managing connections.
+// The key is the client IP address, and the value is the net.Conn for that connection
+type ConnectionMap struct {
+	sync.RWMutex
+
+	Connections map[string]net.Conn
+}
+
+// NewConnectionMap creates a new ConnectionMap with an empty map.
+// This map will be used to keep track of connections to clients.
+func NewConnectionMap() *ConnectionMap {
+	return &ConnectionMap{
+		Connections: make(map[string]net.Conn),
+	}
+}
+
+// Get retrieves a connection (Net.Conn) by IP from the map.
+func (cm *ConnectionMap) Get(ip string) (net.Conn, bool) {
+	cm.RLock()
+	defer cm.RUnlock()
+
+	conn, exists := cm.Connections[ip]
+	return conn, exists
+}
+
+// Set adds a connection to the map.
+func (cm *ConnectionMap) Set(ip string, conn net.Conn) {
+	cm.Lock()
+	defer cm.Unlock()
+
+	cm.Connections[ip] = conn
+}
+
+// Delete removes a connection from the connection map
+func (cm *ConnectionMap) Delete(ip string) {
+	cm.Lock()
+	defer cm.Unlock()
+
+	delete(cm.Connections, ip)
+}

--- a/internal/vpnlib/ippool.go
+++ b/internal/vpnlib/ippool.go
@@ -1,0 +1,73 @@
+package vpnlib
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// This is a pool of IPs that can be allocated to clients.
+type IPPool struct {
+	sync.Mutex
+	ips map[string]bool
+
+	serverIp   string
+	subnetSize uint8
+}
+
+// NewIPPool creates a new IP pool based on the provided CIDR.
+// This pool will be used to allocate IPs to clients. (think DHCP)
+func NewIPPool(cidr string) (*IPPool, error) {
+	usableIps, subnetSize, err := cidrToUsableIPs(cidr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cidr: %v", err)
+	}
+
+	serverIp := usableIps[0]
+	ips := make(map[string]bool)
+	for _, ip := range usableIps[1:] {
+		ips[ip] = true
+	}
+
+	return &IPPool{
+		ips:        ips,
+		serverIp:   serverIp,
+		subnetSize: subnetSize,
+	}, nil
+}
+
+// GetServerIp returns the server ip
+func (p *IPPool) GetServerIp() string {
+	return p.serverIp
+}
+
+// GetSubnetSize returns the subnet size
+func (p *IPPool) GetSubnetSize() uint8 {
+	return p.subnetSize
+}
+
+// Allocate allocates an available IP address from the pool.
+// This will find a free IP address and mark it as used.
+func (p *IPPool) Allocate() (string, error) {
+	p.Lock()
+	defer p.Unlock()
+
+	for ip, available := range p.ips {
+		if available {
+			p.ips[ip] = false
+			return ip, nil
+		}
+	}
+	return "", errors.New("IP Pool exhausted")
+}
+
+// Release releases an IP address back to the pool.
+// This will mark the IP address as available.
+func (p *IPPool) Release(ip string) {
+	p.Lock()
+	defer p.Unlock()
+
+	if _, ok := p.ips[ip]; ok {
+		p.ips[ip] = true
+	}
+}

--- a/internal/vpnlib/iputil.go
+++ b/internal/vpnlib/iputil.go
@@ -1,0 +1,59 @@
+package vpnlib
+
+import (
+	"fmt"
+	"net"
+)
+
+const (
+	ipv4HeaderLengthBytes = 20
+	subnetMaxSize         = 30
+)
+
+func cidrToUsableIPs(cidr string) ([]string, uint8, error) {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, 0, fmt.Errorf("invalid cidr range: %v", err)
+	}
+
+	subnetSize, _ := ipnet.Mask.Size()
+	if subnetSize > subnetMaxSize {
+		return nil, 0, fmt.Errorf("invalid cidr range, must have at least 2 usable addresses (i.e. /30 or less), got %d", subnetSize)
+	}
+
+	var ips []string
+	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); incIp(ip) {
+		ips = append(ips, ip.String())
+	}
+
+	// remove network and broadcast addresses
+	if len(ips) > 2 {
+		ips = ips[1 : len(ips)-1]
+	}
+
+	return ips, uint8(subnetSize), nil
+}
+
+func incIp(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}
+
+func parseIpFromPacketHeader(packet []byte) (net.IP, net.IP) {
+	return net.IP(packet[12:16]), net.IP(packet[16:20])
+}
+
+func validateIPv4(packet []byte) error {
+	if len(packet) < ipv4HeaderLengthBytes {
+		return fmt.Errorf("packet too short")
+	}
+	ipVersion := (packet[0] & 0xF0) >> 4
+	if ipVersion != 4 {
+		return fmt.Errorf("packet header advertises non IPv4")
+	}
+	return nil
+}

--- a/internal/vpnlib/vpnlib.go
+++ b/internal/vpnlib/vpnlib.go
@@ -1,3 +1,6 @@
+// Package vpnlib provides utilities for managing VPN connections over TLS sockets,
+// Including IP address allocation, route management, and client to server communication
+// over the VPN tunnel.
 package vpnlib
 
 import (
@@ -9,22 +12,25 @@ import (
 	"net"
 	"os/exec"
 	"runtime"
-	"time"
+	"strings"
 
 	"github.com/songgao/water"
 )
 
 const (
+	// controlMessageHeaderByteSize is the number of bytes used for the header of the control message.
 	controlMessageHeaderByteSize = 2
+	// headerByteSize is the number of bytes used for the header.
+	headerByteSize = 2
 )
 
 // ControlMessage represents a message used to tell clients
 // the tunnel IPs and what routes to install on the interface.
 type ControlMessage struct {
-	ClientIp     string   `json:"client_ip"`
-	ServerIp     string   `json:"server_ip"`
-	SubnetLength uint8    `json:"subnet_length"`
-	Routes       []string `json:"routes"` // CIDRs
+	ClientIp   string   `json:"client_ip"`
+	ServerIp   string   `json:"server_ip"`
+	SubnetSize uint8    `json:"subnet_size"`
+	Routes     []string `json:"routes"` // CIDRs
 }
 
 // Build encodes a control message to ready-to-send bytes.
@@ -39,20 +45,17 @@ func (m *ControlMessage) Build() ([]byte, error) {
 }
 
 // GetControlMessage reads a control message from a net conn.
-func GetControlMessage(conn net.Conn, timeout time.Duration) (*ControlMessage, error) {
-	conn.SetReadDeadline(time.Now().Add(timeout)) // note: ignored error
-	defer conn.SetDeadline(time.Time{})           // note: ignored error
-
+func GetControlMessage(conn net.Conn) (*ControlMessage, error) {
 	controlMessageHeaderBuffer := make([]byte, controlMessageHeaderByteSize)
 
 	// read first ${headerByteSize} bytes from the connection
 	// to know how big the next incoming packet is
-	headerN, err := io.ReadFull(conn, controlMessageHeaderBuffer)
+	headerN, err := conn.Read(controlMessageHeaderBuffer)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read header: %v", err)
+		return nil, fmt.Errorf("failed to read header: %v", err)
 	}
 	if headerN < controlMessageHeaderByteSize {
-		return nil, fmt.Errorf("Read less than controlMessageHeaderByteSize bytes (%d): %d", controlMessageHeaderByteSize, headerN)
+		return nil, fmt.Errorf("read less than controlMessageHeaderByteSize bytes (%d): %d", controlMessageHeaderByteSize, headerN)
 	}
 
 	// convert binary header to the size uint16
@@ -64,16 +67,16 @@ func GetControlMessage(conn net.Conn, timeout time.Duration) (*ControlMessage, e
 	// read the control message
 	controlMessageN, err := io.ReadFull(conn, controlMessageBuffer)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read control message from net conn: %v", err)
+		return nil, fmt.Errorf("failed to read control message from net conn: %v", err)
 	}
 	if controlMessageN < int(inboundControlMessageSize) {
-		return nil, fmt.Errorf("Read less than the advertised control message size (expected %d, got %d)", inboundControlMessageSize, controlMessageN)
+		return nil, fmt.Errorf("read less than the advertised control message size (expected %d, got %d)", inboundControlMessageSize, controlMessageN)
 	}
 
 	// decode control message JSON
 	var ctrlMessage *ControlMessage
 	if err = json.Unmarshal(controlMessageBuffer, &ctrlMessage); err != nil {
-		return nil, fmt.Errorf("Failed to decode control message JSON: %v", err)
+		return nil, fmt.Errorf("failed to decode control message JSON: %v", err)
 	}
 
 	return ctrlMessage, nil
@@ -89,7 +92,7 @@ func AddRoutesToIface(iface string, routes []string) error {
 	case "windows":
 		return addRoutesToIfaceWindows(iface, routes)
 	default:
-		return fmt.Errorf("Runtime %s not supported", runtime.GOOS)
+		return fmt.Errorf("runtime %s not supported", runtime.GOOS)
 	}
 }
 
@@ -105,6 +108,7 @@ func addRoutesToIfaceDarwin(iface string, routes []string) error {
 func addRoutesToIfaceLinux(iface string, routes []string) error {
 	for _, route := range routes {
 		if err := exec.Command("ip", "route", "add", route, "dev", iface).Run(); err != nil {
+			fmt.Println("ip", "route", "add", route, "dev", iface)
 			return fmt.Errorf("error adding route %s to interface %s: %v", route, iface, err)
 		}
 	}
@@ -128,17 +132,58 @@ func addRoutesToIfaceWindows(iface string, routes []string) error {
 	return nil
 }
 
+func AddServerIp(iface, localIp string, subnetSize uint8) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return AddServerIpDarwin(iface, localIp, subnetSize)
+	case "linux":
+		return AddServerIpLinux(iface, localIp, subnetSize)
+	// case "windows":
+	// 	return AddServerIpWindows(iface, localIp)
+	default:
+		return fmt.Errorf("runtime %s not supported", runtime.GOOS)
+	}
+}
+
+func AddServerIpDarwin(iface, localIp string, subnetSize uint8) error {
+	if err := exec.Command("ifconfig", iface, "mtu", "1200").Run(); err != nil {
+		return fmt.Errorf("error setting MTU for interface %s: %v", iface, err)
+	}
+	// calculate p2p ip address from localIP take one digit lower
+	ip := net.ParseIP(localIp)
+	newIP := ip.To4()
+	newIP[3] = newIP[3] - 1
+
+	ipAddress := fmt.Sprintf("%s/%d", localIp, subnetSize)
+	if err := exec.Command("ifconfig", iface, ipAddress, newIP.String(), "up").Run(); err != nil {
+		fmt.Println("ifconfig ", iface, " ", ipAddress, " ", newIP.String(), " up")
+		return fmt.Errorf("error adding tunnel %s to interface %s: %v", ipAddress, iface, err)
+	}
+	return nil
+}
+
+func AddServerIpLinux(iface, localIp string, subnetSize uint8) error {
+	serverIp := fmt.Sprintf("%s/%d", localIp, subnetSize)
+	if err := exec.Command("ip", "addr", "add", serverIp, "dev", iface).Run(); err != nil {
+		return fmt.Errorf("error adding ip %s to interface %s: %v", localIp, iface, err)
+	}
+	if err := exec.Command("ip", "link", "set", "dev", iface, "up", "mtu", "1200").Run(); err != nil {
+		return fmt.Errorf("error setting link for interface %s: %v", iface, err)
+	}
+	return nil
+}
+
 // AddIpToIface adds an ip address to a network interface.
-func AddIpToIface(iface, localIp, remoteIp string) error {
+func AddIpToIface(iface, localIp, remoteIp string, subnetSize uint8) error {
 	switch runtime.GOOS {
 	case "darwin":
 		return addIpToIfaceDarwin(iface, localIp, remoteIp)
 	case "linux":
-		return addIpToIfaceLinux(iface, localIp)
+		return addIpToIfaceLinux(iface, localIp, subnetSize)
 	case "windows":
 		return addIpToIfaceWindows(iface, localIp)
 	default:
-		return fmt.Errorf("Runtime %s not supported", runtime.GOOS)
+		return fmt.Errorf("runtime %s not supported", runtime.GOOS)
 	}
 }
 
@@ -153,8 +198,8 @@ func addIpToIfaceDarwin(iface, localIp, remoteIp string) error {
 	return nil
 }
 
-func addIpToIfaceLinux(iface, localIp string) error {
-	if err := exec.Command("ip", "addr", "add", fmt.Sprintf("%s/30", localIp), "dev", iface).Run(); err != nil {
+func addIpToIfaceLinux(iface, localIp string, subnetSize uint8) error {
+	if err := exec.Command("ip", "addr", "add", fmt.Sprintf("%s/%d", localIp, subnetSize), "dev", iface).Run(); err != nil {
 		return fmt.Errorf("error adding ip %s to interface %s: %v", localIp, iface, err)
 	}
 	if err := exec.Command("ip", "link", "set", "dev", iface, "up", "mtu", "1200").Run(); err != nil {
@@ -170,73 +215,134 @@ func addIpToIfaceWindows(iface, localIp string) error {
 	return nil
 }
 
-// PacketCopy copies packets between a net.Conn and a TUN interface.
-func PacketCopy(conn net.Conn, iface *water.Interface) error {
-	headerByteSize := 2
-	headerBuffer := make([]byte, headerByteSize)
+// Start Tun to Conn thread
 
+func TunToConnCopy(iface *water.Interface, cm *ConnectionMap, returnOnErr bool, conn net.Conn) error {
 	packetBufferSize := 9000
 	packetbuffer := make([]byte, packetBufferSize)
-
-	go func() {
-		for {
-			// read first ${headerByteSize} bytes from the connection
-			// to know how big the next incoming packet is
-			headerN, err := conn.Read(headerBuffer)
-			if err != nil {
-				if errors.Is(err, io.EOF) ||
-					errors.Is(err, io.ErrUnexpectedEOF) {
-					return
-				}
-				fmt.Printf("Failed to read header: %v\n", err)
-				continue
-			}
-			if headerN < headerByteSize {
-				fmt.Printf("Read less than headerByteSize bytes (%d): %d\n", headerByteSize, headerN)
-				continue
-			}
-
-			// convert binary header to the size uint16
-			inboundPacketSize := binary.BigEndian.Uint16(headerBuffer)
-
-			// new empty buffer of the size of the packet we're about to read
-			packetBuffer := make([]byte, inboundPacketSize)
-
-			// read the one individual packet
-			packetN, err := io.ReadFull(conn, packetBuffer)
-			if err != nil {
-				fmt.Printf("Failed to read packet from net conn: %v\n", err)
-				continue
-			}
-			if packetN < int(inboundPacketSize) {
-				fmt.Printf("Read less than the advertised packet size (expected %d, got %d)\n", inboundPacketSize, packetN)
-				continue
-			}
-
-			// write the packate to the TUN iface
-			if _, err = iface.Write(packetBuffer); err != nil {
-				fmt.Printf("Failed to write packet to the TUN iface: %v\n", err)
-				continue
-			}
-		}
-	}()
+	sizeBuf := make([]byte, headerByteSize)
+	var recipientConn net.Conn
 
 	for {
 		// read one packet from the TUN iface
 		n, err := iface.Read(packetbuffer)
 		if err != nil {
-			fmt.Printf("Failed to read packet from the TUN iface: %v\n", err)
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				fmt.Printf("TUN iface closed, exiting\n")
+				return err
+			}
+			// If error contails "file already closed" then we can return
+			// because the connection was closed
+			if strings.Contains(err.Error(), "file already closed") {
+				if returnOnErr {
+					return err
+				} else {
+					continue
+				}
+			}
+			fmt.Printf("Failed to read packet from the TUN iface: %v %s\n", err, err)
 			continue
 		}
 
+		// Identify the recipient IP from the packetBuffer
+		// with that IP, find the net conn in the connection map
+
+		packet := packetbuffer[:n] // assuming packetbuffer contains an IP packet
+		if err := validateIPv4(packet); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			continue
+		}
+		_, dstIp := parseIpFromPacketHeader(packet)
+
+		// Check if conn is not nil
+		if conn == nil {
+			// we didnt get a net.Conn object, so we need to find it in the connection map
+			// This happens only on the server side
+			// Clients provide the conn object
+
+			// TODO: maybe we should use the net.IP object instead of string
+			// to avoid the string conversion, maybe it's not a big deal... not sure?
+			var exists bool
+
+			if recipientConn, exists = cm.Get(dstIp.String()); !exists {
+				fmt.Printf("No connection exists for IP: %s\n", dstIp)
+				continue
+			}
+		} else {
+			recipientConn = conn
+		}
+
 		// compute the header to prepend to the packet before writing to net conn
-		sizeBuf := make([]byte, headerByteSize)
+
 		binary.BigEndian.PutUint16(sizeBuf, uint16(n))
 
 		// write the encapsulated packet to the net conn
-		_, err = conn.Write(append(sizeBuf, packetbuffer[:n]...))
+
+		_, err = recipientConn.Write(append(sizeBuf, packetbuffer[:n]...))
 		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				recipientConn.Close()
+				cm.Delete(dstIp.String())
+
+				if returnOnErr {
+					return err
+				}
+			}
 			fmt.Printf("Failed to write encapsulated packet to the net conn: %v\n", err)
+			recipientConn.Close()
+			cm.Delete(dstIp.String())
+			if returnOnErr {
+				return err
+			} else {
+				continue
+			}
+		}
+	}
+}
+
+func ConnToTunCopy(conn net.Conn, iface *water.Interface) error {
+	headerBuffer := make([]byte, headerByteSize)
+
+	for {
+		// read first ${headerByteSize} bytes from the connection
+		// to know how big the next incoming packet is
+		headerN, err := conn.Read(headerBuffer)
+		if err != nil {
+			if errors.Is(err, io.EOF) ||
+				errors.Is(err, io.ErrUnexpectedEOF) {
+				fmt.Println("Connection closed by remote host")
+				return err
+			} else {
+				fmt.Printf("Failed to read header: %v\n", err)
+				continue
+			}
+
+		}
+		if headerN < headerByteSize {
+			fmt.Printf("Read less than headerByteSize bytes (%d): %d\n", headerByteSize, headerN)
+			continue
+		}
+
+		// convert binary header to the size uint16
+		inboundPacketSize := binary.BigEndian.Uint16(headerBuffer)
+
+		// new empty buffer of the size of the packet we're about to read
+		packetBuffer := make([]byte, inboundPacketSize)
+
+		// read the one individual packet
+		packetN, err := io.ReadFull(conn, packetBuffer)
+		if err != nil {
+			fmt.Printf("Failed to read packet from net conn: %v\n", err)
+			continue
+		}
+		if packetN < int(inboundPacketSize) {
+			fmt.Printf("Read less than the advertised packet size (expected %d, got %d)\n", inboundPacketSize, packetN)
+			continue
+		}
+
+		// write the packet to the TUN iface
+		if _, err = iface.Write(packetBuffer); err != nil {
+			fmt.Printf("Failed to write packet to the TUN iface: %v\n", err)
 			continue
 		}
 	}


### PR DESCRIPTION
## [MISC] Support for Multiple VPN Clients

VPN multiple-clients support. Create a TLS socket and then connect:

`sudo border0socket connect vpn  awsvpn --route 1.2.3.4/32 --vpn-subnet 10.42.0.0/22`
 
 as a client to connect
`sudo border0-cli client vpn`
 
Fixes # (issue):

N/A -  experimental

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested extensively manually

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code