### PR TITLE
[ME-1752] send connector logs to portal

### DIFF
--- a/internal/connector_v2/upstreamdata/builder.go
+++ b/internal/connector_v2/upstreamdata/builder.go
@@ -56,6 +56,8 @@ func (u *UpstreamDataBuilder) setupSSHUpstreamValues(s *models.Socket, configMap
 func (u *UpstreamDataBuilder) setupSSH(s *models.Socket, configMap types.ConnectorServiceUpstreamConfig) error {
 	s.ConnectorData.TargetHostname = configMap.Hostname
 	s.ConnectorData.Port = configMap.Port
+	s.TargetHostname = configMap.Hostname
+	s.TargetPort = configMap.Port
 	s.UpstreamType = UpstreamTypeSSH
 
 	if configMap.SSHConfiguration.UpstreamAuthenticationType == types.UpstreamAuthenticationTypeUsernamePassword {

--- a/internal/ssh/proxy.go
+++ b/internal/ssh/proxy.go
@@ -259,7 +259,7 @@ func handleSsmClient(conn net.Conn, config ProxyConfig) {
 
 	sshConn, chans, reqs, err := ssh.NewServerConn(conn, config.sshServerConfig)
 	if err != nil {
-		fmt.Printf("sshauthproxy: failed to accept ssh connection: %s", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: failed to accept ssh connection: %s", err)
 		return
 	}
 
@@ -269,7 +269,7 @@ func handleSsmClient(conn net.Conn, config ProxyConfig) {
 
 	for newChannel := range chans {
 		if newChannel == nil {
-			fmt.Printf("sshauthproxy: proxy channel closed")
+			config.Logger.Sugar().Errorf("sshauthproxy: proxy channel closed")
 			return
 		}
 
@@ -280,7 +280,7 @@ func handleSsmClient(conn net.Conn, config ProxyConfig) {
 
 		channel, requests, err := newChannel.Accept()
 		if err != nil {
-			fmt.Printf("sshauthproxy: failed to accept channel: %s", err)
+			config.Logger.Sugar().Errorf("sshauthproxy: failed to accept channel: %s", err)
 			return
 		}
 
@@ -566,7 +566,7 @@ func handleSSMShell(channel ssh.Channel, config *ProxyConfig) {
 		Target: &config.AwsSSMTarget,
 	})
 	if err != nil {
-		fmt.Printf("sshauthproxy: failed to start ssm session: %s\n", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: failed to start ssm session: %s\n", err)
 		return
 	}
 
@@ -583,7 +583,7 @@ func handleSSMShell(channel ssh.Channel, config *ProxyConfig) {
 	sessionLogger := ssmLog.Logger(false, "border0")
 
 	if err = s.OpenDataChannel(sessionLogger); err != nil {
-		fmt.Printf("sshauthproxy: failed to execute ssm session: %s\n", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: failed to execute ssm session: %s\n", err)
 		return
 	}
 
@@ -594,7 +594,7 @@ func handleSSMShell(channel ssh.Channel, config *ProxyConfig) {
 
 	s.Initialize(sessionLogger, &s)
 	if s.SetSessionHandlers(sessionLogger); err != nil {
-		fmt.Printf("sshauthproxy: failed to execute ssm session: %s\n", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: failed to execute ssm session: %s\n", err)
 	}
 }
 
@@ -603,13 +603,13 @@ func handleSshClient(conn net.Conn, config ProxyConfig) {
 
 	sshConn, chans, reqs, err := ssh.NewServerConn(conn, config.sshServerConfig)
 	if err != nil {
-		fmt.Printf("sshauthproxy: failed to accept ssh connection: %s\n", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: failed to accept ssh connection: %s\n", err)
 		return
 	}
 
 	go ssh.DiscardRequests(reqs)
 	if err := handleChannels(sshConn, chans, config); err != nil {
-		fmt.Printf("sshauthproxy: failed to handle channels: %s\n", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: failed to handle channels: %s", err)
 		return
 	}
 }
@@ -619,14 +619,14 @@ func handleEc2InstanceConnectClient(conn net.Conn, config ProxyConfig) {
 
 	sshConn, chans, reqs, err := ssh.NewServerConn(conn, config.sshServerConfig)
 	if err != nil {
-		fmt.Printf("sshauthproxy: failed to accept ssh connection: %s\n", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: failed to accept ssh connection: %s\n", err)
 		return
 	}
 
 	user := sshConn.User()
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		fmt.Printf("sshauthproxy: failed to generate key: %s\n", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: failed to generate key: %s\n", err)
 		return
 	}
 
@@ -638,7 +638,7 @@ func handleEc2InstanceConnectClient(conn net.Conn, config ProxyConfig) {
 
 	signer, err := ssh.ParsePrivateKey(privateKeyPEM)
 	if err != nil {
-		fmt.Printf("sshauthproxy: unable to parse private key: %s\n", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: unable to parse private key: %s\n", err)
 		return
 	}
 
@@ -650,7 +650,7 @@ func handleEc2InstanceConnectClient(conn net.Conn, config ProxyConfig) {
 
 	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
 	if err != nil {
-		fmt.Printf("sshauthproxy: unable to generate public key: %s\n", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: unable to generate public key: %s\n", err)
 		return
 	}
 
@@ -665,13 +665,13 @@ func handleEc2InstanceConnectClient(conn net.Conn, config ProxyConfig) {
 	})
 
 	if err != nil {
-		fmt.Printf("sshauthproxy: failed to send ssh public key: %s\n", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: failed to send ssh public key: %s\n", err)
 		return
 	}
 
 	go ssh.DiscardRequests(reqs)
 	if err := handleChannels(sshConn, chans, config); err != nil {
-		fmt.Printf("sshauthproxy: failed to handle channels: %s\n", err)
+		config.Logger.Sugar().Errorf("sshauthproxy: failed to handle channels: %s\n", err)
 		return
 	}
 }

--- a/internal/ssh/proxy.go
+++ b/internal/ssh/proxy.go
@@ -259,7 +259,7 @@ func handleSsmClient(conn net.Conn, config ProxyConfig) {
 
 	sshConn, chans, reqs, err := ssh.NewServerConn(conn, config.sshServerConfig)
 	if err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: failed to accept ssh connection: %s", err)
+		config.Logger.Sugar().Errorf("failed to accept ssh connection: %s", err)
 		return
 	}
 
@@ -269,7 +269,7 @@ func handleSsmClient(conn net.Conn, config ProxyConfig) {
 
 	for newChannel := range chans {
 		if newChannel == nil {
-			config.Logger.Sugar().Errorf("sshauthproxy: proxy channel closed")
+			config.Logger.Sugar().Errorf("proxy channel closed")
 			return
 		}
 
@@ -280,7 +280,7 @@ func handleSsmClient(conn net.Conn, config ProxyConfig) {
 
 		channel, requests, err := newChannel.Accept()
 		if err != nil {
-			config.Logger.Sugar().Errorf("sshauthproxy: failed to accept channel: %s", err)
+			config.Logger.Sugar().Errorf("failed to accept channel: %s", err)
 			return
 		}
 
@@ -302,7 +302,7 @@ func handleSsmClient(conn net.Conn, config ProxyConfig) {
 				case req.Type == "shell":
 					if config.ECSSSMProxy != nil {
 						if err := pickAwsEcsTargetForAwsSsm(channel, &config); err != nil {
-							config.Logger.Sugar().Errorf("sshauthproxy: failed to pick ECS target: %s", err)
+							config.Logger.Sugar().Errorf("failed to pick ECS target: %s", err)
 							req.Reply(false, nil)
 							sshConn.Close()
 							return
@@ -566,7 +566,7 @@ func handleSSMShell(channel ssh.Channel, config *ProxyConfig) {
 		Target: &config.AwsSSMTarget,
 	})
 	if err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: failed to start ssm session: %s\n", err)
+		config.Logger.Sugar().Errorf("failed to start ssm session: %s\n", err)
 		return
 	}
 
@@ -583,7 +583,7 @@ func handleSSMShell(channel ssh.Channel, config *ProxyConfig) {
 	sessionLogger := ssmLog.Logger(false, "border0")
 
 	if err = s.OpenDataChannel(sessionLogger); err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: failed to execute ssm session: %s\n", err)
+		config.Logger.Sugar().Errorf("failed to execute ssm session: %s\n", err)
 		return
 	}
 
@@ -594,7 +594,7 @@ func handleSSMShell(channel ssh.Channel, config *ProxyConfig) {
 
 	s.Initialize(sessionLogger, &s)
 	if s.SetSessionHandlers(sessionLogger); err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: failed to execute ssm session: %s\n", err)
+		config.Logger.Sugar().Errorf("failed to execute ssm session: %s\n", err)
 	}
 }
 
@@ -603,13 +603,13 @@ func handleSshClient(conn net.Conn, config ProxyConfig) {
 
 	sshConn, chans, reqs, err := ssh.NewServerConn(conn, config.sshServerConfig)
 	if err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: failed to accept ssh connection: %s\n", err)
+		config.Logger.Sugar().Errorf("failed to accept ssh connection: %s\n", err)
 		return
 	}
 
 	go ssh.DiscardRequests(reqs)
 	if err := handleChannels(sshConn, chans, config); err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: failed to handle channels: %s", err)
+		config.Logger.Sugar().Errorf("failed to handle channels: %s", err)
 		return
 	}
 }
@@ -619,14 +619,14 @@ func handleEc2InstanceConnectClient(conn net.Conn, config ProxyConfig) {
 
 	sshConn, chans, reqs, err := ssh.NewServerConn(conn, config.sshServerConfig)
 	if err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: failed to accept ssh connection: %s\n", err)
+		config.Logger.Sugar().Errorf("failed to accept ssh connection: %s\n", err)
 		return
 	}
 
 	user := sshConn.User()
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: failed to generate key: %s\n", err)
+		config.Logger.Sugar().Errorf("failed to generate key: %s\n", err)
 		return
 	}
 
@@ -638,7 +638,7 @@ func handleEc2InstanceConnectClient(conn net.Conn, config ProxyConfig) {
 
 	signer, err := ssh.ParsePrivateKey(privateKeyPEM)
 	if err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: unable to parse private key: %s\n", err)
+		config.Logger.Sugar().Errorf("unable to parse private key: %s\n", err)
 		return
 	}
 
@@ -650,7 +650,7 @@ func handleEc2InstanceConnectClient(conn net.Conn, config ProxyConfig) {
 
 	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
 	if err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: unable to generate public key: %s\n", err)
+		config.Logger.Sugar().Errorf("unable to generate public key: %s\n", err)
 		return
 	}
 
@@ -665,13 +665,13 @@ func handleEc2InstanceConnectClient(conn net.Conn, config ProxyConfig) {
 	})
 
 	if err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: failed to send ssh public key: %s\n", err)
+		config.Logger.Sugar().Errorf("failed to send ssh public key: %s\n", err)
 		return
 	}
 
 	go ssh.DiscardRequests(reqs)
 	if err := handleChannels(sshConn, chans, config); err != nil {
-		config.Logger.Sugar().Errorf("sshauthproxy: failed to handle channels: %s\n", err)
+		config.Logger.Sugar().Errorf("failed to handle channels: %s\n", err)
 		return
 	}
 }


### PR DESCRIPTION
# Description

- send the client error logs to connector portal
- setup the target hostname and port when the auth method is border0 certificate
Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
