### PR TITLE
add https socket type to k8s to set upstream type as https

### DIFF
--- a/internal/connector/discover/k8.go
+++ b/internal/connector/discover/k8.go
@@ -79,6 +79,12 @@ func (s *K8Discover) buildSocket(connectorName string, group config.K8Plugin, se
 	switch service.Annotations["border0.com/socketType"] {
 	case "http":
 		socket.SocketType = "http"
+		if upstreamType, exists := service.Annotations["border0.com/upstreamType"]; exists {
+			socket.UpstreamType = upstreamType
+		}
+		if upstreamHttpHostname, exists := service.Annotations["border0.com/upstreamHttpHostname"]; exists {
+			socket.UpstreamHttpHostname = upstreamHttpHostname
+		}
 	case "ssh":
 		socket.SocketType = "ssh"
 	case "database":


### PR DESCRIPTION
# Description

Add `https` to k8s `border0.com/socketType` annotation, and set socket upstream type as `https` accordingly.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
