### PR TITLE
ME-1786 Forward http proxy

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/borderzero/border0-cli/cmd/logger"
 
 	"github.com/borderzero/border0-cli/cmd/client/hosts"
+	"github.com/borderzero/border0-cli/cmd/client/httpproxy"
 	"github.com/borderzero/border0-cli/cmd/client/ssh"
 	"github.com/borderzero/border0-cli/cmd/client/vpn"
 	"github.com/borderzero/border0-cli/internal/client"
@@ -146,4 +147,5 @@ func init() {
 	ssh.AddCommandsTo(clientCmd)
 	clientTls.AddCommandsTo(clientCmd)
 	vpn.AddCommandsTo(clientCmd)
+	httpproxy.AddCommandsTo(clientCmd)
 }

--- a/cmd/client/httpproxy/httpproxy.go
+++ b/cmd/client/httpproxy/httpproxy.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"log"
 	"net"
+	"strings"
+	"time"
 
 	b0tls "github.com/borderzero/border0-cli/cmd/client/tls"
 	"github.com/borderzero/border0-cli/cmd/logger"
@@ -13,12 +15,17 @@ import (
 	"github.com/borderzero/border0-cli/internal/enum"
 	"github.com/hashicorp/yamux"
 	"github.com/spf13/cobra"
+
+	"github.com/rivo/tview"
 )
 
 var (
-	hostname      string
-	httpProxyPort int
-	numStreams    int
+	hostname             string
+	httpProxyPort        int
+	numStreams           int
+	connectionsPerSecond int
+	connectionsPerMinute int
+	tuiView              bool
 )
 
 type SessionManager struct {
@@ -51,6 +58,30 @@ var clientProxyCmd = &cobra.Command{
 			hostname = pickedHost.Hostname()
 		}
 
+		var updateTextView func(line string)
+
+		if tuiView {
+			textView, app := startTUI()
+			logLines := make([]string, 0, 10)
+			updateTextView = func(line string) {
+				app.QueueUpdateDraw(func() {
+					if len(logLines) >= 10 {
+						logLines = logLines[len(logLines)-9:]
+					}
+					timestamp := time.Now().Format("2006-01-02 15:04:05")
+					logLine := fmt.Sprintf("%s: %s", timestamp, line)
+					logLines = append([]string{logLine}, logLines...) // Insert at the beginning
+
+					textView.SetText(strings.Join(logLines, "\n"))
+				})
+			}
+		} else {
+			updateTextView = func(line string) {
+				timestamp := time.Now().Format("2006-01-02 15:04:05")
+				fmt.Printf("%s: %s\n", timestamp, line)
+			}
+		}
+
 		info, err := client.GetResourceInfo(logger.Logger, hostname)
 		if err != nil {
 			return fmt.Errorf("failed to get certificate: %v", err)
@@ -76,14 +107,18 @@ var clientProxyCmd = &cobra.Command{
 				log.Fatalf("Failed to connect to proxy: %v", err)
 			}
 
-			fmt.Printf("%d = Connected to %s:%d\n", i, hostname, info.Port)
+			//fmt.Printf("%d = Connected to %s:%d\n", i, hostname, info.Port)
+			updateTextView(fmt.Sprintf("%d = Connected to %s:%d\n", i, hostname, info.Port))
+
 			session, err := yamux.Client(conn, nil)
 			if err != nil {
 				log.Fatalf("Failed to create yamux session: %v", err)
 			}
-			fmt.Println("Created session number ", i)
+			//fmt.Println("Created session number ", i)
+			updateTextView(fmt.Sprintf("created session number %d ", i))
 			//sessions[i] = session
 			sessionManager.addSession(session)
+
 		}
 
 		// Now start the local listener on which we accept the traffic
@@ -92,9 +127,26 @@ var clientProxyCmd = &cobra.Command{
 			log.Fatalf("error: Unable to start tcp listener on port %d, %s\n", httpProxyPort, err)
 		}
 		defer l.Close()
-		log.Printf("service started, listening for connections on port %d\n", httpProxyPort)
+		//log.Printf("service started, listening for connections on port %d\n", httpProxyPort)
+		updateTextView(fmt.Sprintf("service started, listening for connections on port %d\n", httpProxyPort))
 
 		sessionIndex := 0
+
+		// Reset the connections per second counter every second
+		go func() {
+			for {
+				time.Sleep(time.Second)
+				connectionsPerSecond = 0
+			}
+		}()
+
+		// Reset the connections per minute counter every minute
+		go func() {
+			for {
+				time.Sleep(time.Minute)
+				connectionsPerMinute = 0
+			}
+		}()
 
 		for {
 			clientConn, err := l.Accept()
@@ -102,6 +154,11 @@ var clientProxyCmd = &cobra.Command{
 				log.Printf("Failed to accept connection: %v", err)
 				continue
 			}
+
+			// Increment the counters
+			connectionsPerSecond++
+			connectionsPerMinute++
+
 			// Choose a session from the slice by using the index
 			//selectedSession := sessions[sessionIndex]
 			selectedSession := sessionManager.selectSession(sessionIndex)
@@ -109,7 +166,7 @@ var clientProxyCmd = &cobra.Command{
 			// Increment the index so that next time a different session is used
 			sessionIndex++
 
-			go handleClientConnection(clientConn, selectedSession)
+			go handleClientConnection(clientConn, selectedSession, updateTextView)
 		}
 
 		return nil
@@ -148,9 +205,14 @@ func (sm *SessionManager) selectSession(index int) *yamux.Session {
 }
 
 // handleClientConnection is a function that handles the client connection
-func handleClientConnection(clientConn net.Conn, session *yamux.Session) {
+// func handleClientConnection(clientConn net.Conn, session *yamux.Session) {
+func handleClientConnection(clientConn net.Conn, session *yamux.Session, updateTextView func(string)) {
+
 	defer clientConn.Close()
-	fmt.Println("New connection accepted from ", clientConn.RemoteAddr())
+	//fmt.Println("New connection accepted from ", clientConn.RemoteAddr())
+
+	logLine := fmt.Sprintf("New connection accepted from %s", clientConn.RemoteAddr())
+	updateTextView(logLine)
 
 	stream, err := session.OpenStream()
 	if err != nil {
@@ -163,9 +225,58 @@ func handleClientConnection(clientConn net.Conn, session *yamux.Session) {
 	io.Copy(stream, clientConn)
 }
 
+func startTUI() (*tview.TextView, *tview.Application) {
+	if !tuiView {
+		return nil, nil // If TUI view is not enabled, return nil
+	}
+
+	app := tview.NewApplication()
+
+	// Stats view
+	statsView := tview.NewTextView().
+		SetDynamicColors(true).
+		SetWrap(false)
+	statsView.SetBorder(true).SetTitle("Statistics")
+
+	// Log view
+	textView := tview.NewTextView().
+		SetDynamicColors(true).
+		SetWrap(false)
+	textView.SetBorder(true).SetTitle("Log")
+
+	// Grid layout
+	grid := tview.NewGrid().
+		SetRows(5, 0). // 3 rows for stats, rest for logs
+		SetColumns(0).
+		AddItem(statsView, 0, 0, 1, 1, 0, 0, false).
+		AddItem(textView, 1, 0, 1, 1, 0, 0, false)
+
+	// Update stats every second
+
+	go func() {
+		for {
+			stats := fmt.Sprintf(
+				"Time: %s\nAverage Connections Per Second: %d\nAverage Connections Per Minute: %d",
+				time.Now().Format(time.RFC1123), connectionsPerSecond, connectionsPerMinute)
+			statsView.SetText(stats)
+			time.Sleep(1 * time.Second)
+		}
+	}()
+
+	go func() {
+		if err := app.SetRoot(grid, true).Run(); err != nil {
+			panic(err)
+		}
+	}()
+
+	return textView, app
+}
+
 func AddCommandsTo(client *cobra.Command) {
 	client.AddCommand(clientProxyCmd)
+	clientProxyCmd.Flags().BoolVarP(&tuiView, "tui", "t", false, "Tui output")
 	clientProxyCmd.Flags().IntVarP(&httpProxyPort, "port", "p", 8080, "port number to listen on")
+
 	clientProxyCmd.Flags().IntVarP(&numStreams, "connections", "c", 1, "number of parallel connections to open to the Border0 service")
 	clientProxyCmd.Flags().StringVarP(&hostname, "service", "", "", "The Border0 service identifier")
 }

--- a/cmd/client/httpproxy/httpproxy.go
+++ b/cmd/client/httpproxy/httpproxy.go
@@ -1,0 +1,171 @@
+package httpproxy
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log"
+	"net"
+
+	b0tls "github.com/borderzero/border0-cli/cmd/client/tls"
+	"github.com/borderzero/border0-cli/cmd/logger"
+	"github.com/borderzero/border0-cli/internal/client"
+	"github.com/borderzero/border0-cli/internal/enum"
+	"github.com/hashicorp/yamux"
+	"github.com/spf13/cobra"
+)
+
+var (
+	hostname      string
+	httpProxyPort int
+	numStreams    int
+)
+
+type SessionManager struct {
+	sessions []*yamux.Session
+}
+
+// clientProxyCmd represents the client tls command
+var clientProxyCmd = &cobra.Command{
+	Use:               "proxy",
+	Short:             "Connect a Border0 HTTP proxy",
+	ValidArgsFunction: client.AutocompleteHost,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			hostname = args[0]
+		}
+
+		if numStreams < 1 {
+			return fmt.Errorf("number of streams must be greater than 0")
+		}
+
+		if httpProxyPort == 0 {
+			return fmt.Errorf("port number is required")
+		}
+
+		if hostname == "" {
+			pickedHost, err := client.PickHost(hostname, enum.TLSSocket)
+			if err != nil {
+				return fmt.Errorf("failed to pick host: %v", err)
+			}
+			hostname = pickedHost.Hostname()
+		}
+
+		info, err := client.GetResourceInfo(logger.Logger, hostname)
+		if err != nil {
+			return fmt.Errorf("failed to get certificate: %v", err)
+		}
+
+		certificate := tls.Certificate{
+			Certificate: [][]byte{info.Certficate.Raw},
+			PrivateKey:  info.PrivateKey,
+		}
+
+		tlsConfig := tls.Config{
+			Certificates:       []tls.Certificate{certificate},
+			InsecureSkipVerify: true,
+		}
+
+		// Create a multiplexed session over multiple TCP connections
+		//sessions := make([]*yamux.Session, numStreams)
+		sessionManager := &SessionManager{}
+
+		for i := 0; i < numStreams; i++ {
+			conn, err := b0tls.EstablishConnection(info.ConnectorAuthenticationEnabled, fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
+			if err != nil {
+				log.Fatalf("Failed to connect to proxy: %v", err)
+			}
+
+			fmt.Printf("%d = Connected to %s:%d\n", i, hostname, info.Port)
+			session, err := yamux.Client(conn, nil)
+			if err != nil {
+				log.Fatalf("Failed to create yamux session: %v", err)
+			}
+			fmt.Println("Created session number ", i)
+			//sessions[i] = session
+			sessionManager.addSession(session)
+		}
+
+		// Now start the local listener on which we accept the traffic
+		l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", httpProxyPort))
+		if err != nil {
+			log.Fatalf("error: Unable to start tcp listener on port %d, %s\n", httpProxyPort, err)
+		}
+		defer l.Close()
+		log.Printf("service started, listening for connections on port %d\n", httpProxyPort)
+
+		sessionIndex := 0
+
+		for {
+			clientConn, err := l.Accept()
+			if err != nil {
+				log.Printf("Failed to accept connection: %v", err)
+				continue
+			}
+			// Choose a session from the slice by using the index
+			//selectedSession := sessions[sessionIndex]
+			selectedSession := sessionManager.selectSession(sessionIndex)
+
+			// Increment the index so that next time a different session is used
+			sessionIndex++
+
+			go handleClientConnection(clientConn, selectedSession)
+		}
+
+		return nil
+	},
+}
+
+// SessionManager is a simple struct that holds a slice of yamux sessions
+// here we can add and remove sessions as they are created and closed
+func (sm *SessionManager) addSession(session *yamux.Session) {
+	sm.sessions = append(sm.sessions, session)
+	go func() {
+		<-session.CloseChan() // Wait for the session to close
+		sm.removeSession(session)
+	}()
+}
+
+// removeSession is a simple function that removes a session from the slice
+func (sm *SessionManager) removeSession(session *yamux.Session) {
+	for i, s := range sm.sessions {
+		if s == session {
+			log.Printf("one of the upstream connections went down and has been removed. Pool size is now %d\n", len(sm.sessions))
+			sm.sessions = append(sm.sessions[:i], sm.sessions[i+1:]...)
+
+			// Todo, we could try to reconnect here and add one back to the pool
+			break
+		}
+	}
+	if len(sm.sessions) == 0 {
+		log.Fatalf("All upstream sessions have been closed, no more upstream options available. Exiting.")
+	}
+}
+
+// selectSession is a simple function that selects a session from the slice
+func (sm *SessionManager) selectSession(index int) *yamux.Session {
+	return sm.sessions[index%len(sm.sessions)]
+}
+
+// handleClientConnection is a function that handles the client connection
+func handleClientConnection(clientConn net.Conn, session *yamux.Session) {
+	defer clientConn.Close()
+	fmt.Println("New connection accepted from ", clientConn.RemoteAddr())
+
+	stream, err := session.OpenStream()
+	if err != nil {
+		log.Printf("Failed to open yamux stream: %v", err)
+		return
+	}
+	defer stream.Close()
+
+	go io.Copy(clientConn, stream)
+	io.Copy(stream, clientConn)
+}
+
+func AddCommandsTo(client *cobra.Command) {
+	client.AddCommand(clientProxyCmd)
+	clientProxyCmd.Flags().IntVarP(&httpProxyPort, "port", "p", 8080, "port number to listen on")
+	clientProxyCmd.Flags().IntVarP(&numStreams, "connections", "c", 1, "number of parallel connections to open to the Border0 service")
+	clientProxyCmd.Flags().StringVarP(&hostname, "service", "", "", "The Border0 service identifier")
+}

--- a/cmd/client/tls/tls.go
+++ b/cmd/client/tls/tls.go
@@ -79,7 +79,7 @@ var clientTlsCmd = &cobra.Command{
 				}
 
 				go func() {
-					conn, err := establishConnection(info.ConnectorAuthenticationEnabled, fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
+					conn, err := EstablishConnection(info.ConnectorAuthenticationEnabled, fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
 					if err != nil {
 						log.Printf("failed to connect: %v", err.Error())
 						return
@@ -90,7 +90,7 @@ var clientTlsCmd = &cobra.Command{
 				}()
 			}
 		} else {
-			conn, err := establishConnection(info.ConnectorAuthenticationEnabled, fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
+			conn, err := EstablishConnection(info.ConnectorAuthenticationEnabled, fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
 			if err != nil {
 				log.Fatalf("failed to connect: %v", err.Error())
 			}
@@ -102,7 +102,7 @@ var clientTlsCmd = &cobra.Command{
 	},
 }
 
-func establishConnection(connectorAuthenticationEnabled bool, addr string, tlsConfig *tls.Config) (conn net.Conn, err error) {
+func EstablishConnection(connectorAuthenticationEnabled bool, addr string, tlsConfig *tls.Config) (conn net.Conn, err error) {
 	if connectorAuthenticationEnabled {
 		conn, err = client.ConnectorAuthConnect(addr, tlsConfig)
 	} else {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,11 +88,10 @@ var (
 	disableBrowser          bool
 	awsEc2InstanceId        string
 	awsEc2InstanceConnect   bool
-	vpnSubnet               string
-	routes                  []string
-	allowedProxyHosts       []string
-	numStreams              int
-	tuiView                 bool
+	vpnSubnet               string   // used in the socket connect vpn command
+	routes                  []string // used in the socket connect vpn command
+	allowedProxyHosts       []string // used in the socket connect proxy command
+
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,6 +91,7 @@ var (
 	vpnSubnet               string
 	routes                  []string
 	allowedProxyHosts       []string
+	numStreams              int
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,6 +90,7 @@ var (
 	awsEc2InstanceConnect   bool
 	vpnSubnet               string
 	routes                  []string
+	allowedProxyHosts       []string
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,6 +92,7 @@ var (
 	routes                  []string
 	allowedProxyHosts       []string
 	numStreams              int
+	tuiView                 bool
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/socket.go
+++ b/cmd/socket.go
@@ -35,6 +35,7 @@ import (
 	"github.com/borderzero/border0-cli/internal/border0"
 	"github.com/borderzero/border0-cli/internal/cloudsql"
 	"github.com/borderzero/border0-cli/internal/http"
+	"github.com/borderzero/border0-cli/internal/httpproxylib"
 	"github.com/borderzero/border0-cli/internal/sqlauthproxy"
 	"github.com/borderzero/border0-cli/internal/ssh"
 	"github.com/borderzero/border0-cli/internal/util"
@@ -325,7 +326,7 @@ var socketConnectProxyCmd = &cobra.Command{
 			}
 		}()
 
-		err = http.StartHttpProxy(l)
+		err = httpproxylib.StartHttpProxy(l)
 		fmt.Println("Proxy stopped: ", err)
 		return nil
 

--- a/cmd/socket.go
+++ b/cmd/socket.go
@@ -325,8 +325,8 @@ var socketConnectProxyCmd = &cobra.Command{
 				os.Exit(0)
 			}
 		}()
-
-		err = httpproxylib.StartHttpProxy(l)
+	
+		err = httpproxylib.StartHttpProxy(l, allowedProxyHosts)
 		fmt.Println("Proxy stopped: ", err)
 		return nil
 
@@ -731,6 +731,8 @@ func AutocompleteSocket(cmd *cobra.Command, args []string, toComplete string) ([
 }
 
 func init() {
+
+	socketConnectProxyCmd.Flags().StringSliceVarP(&allowedProxyHosts, "allowed-host", "", []string{}, "Allowed host to proxy to, if ommited all proxy requests are allowed")
 	socketConnectCmd.AddCommand(socketConnectProxyCmd)
 
 	socketConnectVpnCmd.Flags().StringVarP(&vpnSubnet, "vpn-subnet", "", "10.42.0.0/22", "Ip range used to allocate to vpn clients")

--- a/cmd/socket.go
+++ b/cmd/socket.go
@@ -325,9 +325,13 @@ var socketConnectProxyCmd = &cobra.Command{
 				os.Exit(0)
 			}
 		}()
-	
+
 		err = httpproxylib.StartHttpProxy(l, allowedProxyHosts)
-		fmt.Println("Proxy stopped: ", err)
+		if err != nil {
+			log.Fatalf("Proxy stopped with error: %v", err)
+		} else {
+			fmt.Println("Proxy stopped")
+		}
 		return nil
 
 	},

--- a/go.mod
+++ b/go.mod
@@ -80,6 +80,9 @@ require (
 	github.com/aws/smithy-go v1.14.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
+	github.com/gdamore/encoding v1.0.0 // indirect
+	github.com/gdamore/tcell v1.4.0 // indirect
+	github.com/gdamore/tcell/v2 v2.6.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
@@ -94,10 +97,12 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
+	github.com/rivo/tview v0.0.0-20230621164836-6cc0565babaf // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 // indirect

--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.9.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,12 @@ github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
+github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
+github.com/gdamore/tcell v1.4.0 h1:vUnHwJRvcPQa3tzi+0QI4U9JINXYJlOz9yiaiPQ2wMU=
+github.com/gdamore/tcell v1.4.0/go.mod h1:vxEiSDZdW3L+Uhjii9c3375IlDmR05bzxY404ZVSMo0=
+github.com/gdamore/tcell/v2 v2.6.0 h1:OKbluoP9VYmJwZwq/iLb4BxwKcwGthaa1YNBJIyCySg=
+github.com/gdamore/tcell/v2 v2.6.0/go.mod h1:be9omFATkdr0D9qewWW3d+MEvl5dha+Etb5y65J2H8Y=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
@@ -442,6 +448,9 @@ github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgx
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
+github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a h1:N9zuLhTvBSRt0gWSiJswwQ2HqDmtX/ZCDJURnKUt1Ik=
 github.com/lufia/plan9stats v0.0.0-20230326075908-cb1d2100619a/go.mod h1:JKx41uQRwqlTZabZc+kILPrO/3jlKnQ2Z8b7YiVw5cE=
@@ -464,6 +473,7 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
@@ -524,7 +534,10 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rivo/tview v0.0.0-20230621164836-6cc0565babaf h1:IchpMMtnfvzg7T3je672bP1nKWz1M4tW3kMZT6CbgoM=
+github.com/rivo/tview v0.0.0-20230621164836-6cc0565babaf/go.mod h1:nVwGv4MP47T0jvlk7KuTTjjuSmrGO4JF0iaiNt4bufE=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
@@ -791,6 +804,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,7 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.4 h1:1kZ/sQM3srePvKs3tXAvQzo66XfcReoqFpIpIccE7Oc=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
@@ -345,6 +346,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
+github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
@@ -640,6 +643,7 @@ go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -2,15 +2,12 @@ package http
 
 import (
 	"fmt"
-	"io"
-	"log"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	jwt "github.com/golang-jwt/jwt"
 )
@@ -341,88 +338,4 @@ func getAdminData() (jwt.MapClaims, error) {
 
 	claims, _ := token.Claims.(jwt.MapClaims)
 	return claims, nil
-}
-
-func handleTunneling(w http.ResponseWriter, r *http.Request) {
-	// Modify the host if necessary.
-	//r.Host = mapHost(r.Host)
-	if r.Host == "" {
-		http.Error(w, "Not found", http.StatusNotFound)
-		return
-	}
-
-	destConn, err := net.DialTimeout("tcp", r.Host, 10*time.Second)
-	if err != nil {
-		log.Printf("Failed to connect to host %s: %v", r.Host, err)
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
-		return
-	}
-	log.Printf("Tunneling from %s to %s", r.RemoteAddr, r.Host)
-	w.WriteHeader(http.StatusOK)
-	hijacker, ok := w.(http.Hijacker)
-	if !ok {
-		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
-		return
-	}
-	clientConn, _, err := hijacker.Hijack()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
-	}
-	go connect(destConn, clientConn)
-}
-
-func handleHTTP(w http.ResponseWriter, req *http.Request) {
-	//req.Host = mapHost(req.Host)
-	if req.Host == "" {
-		http.Error(w, "Not found", http.StatusNotFound)
-		return
-	}
-	req.URL.Host = req.Host
-	req.URL.Scheme = "http" // You can also dynamically set the scheme based on the original request
-
-	resp, err := http.DefaultTransport.RoundTrip(req)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
-		return
-	}
-	defer resp.Body.Close()
-	copyHeader(w.Header(), resp.Header)
-	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
-}
-
-func copyHeader(dst, src http.Header) {
-	for k, vv := range src {
-		for _, v := range vv {
-			dst.Add(k, v)
-		}
-	}
-}
-
-func connect(destConn, clientConn net.Conn) {
-	defer destConn.Close()
-	defer clientConn.Close()
-	go copy(destConn, clientConn)
-	copy(clientConn, destConn)
-}
-
-func copy(dst io.Writer, src io.Reader) {
-	_, _ = io.Copy(dst, src)
-}
-
-func StartHttpProxy(listener net.Listener) error {
-	server := &http.Server{
-		//Addr: ":8080",
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			log.Printf("Received request %s %s %s\n", r.Method, r.Host, r.RemoteAddr)
-			if r.Method == http.MethodConnect {
-				handleTunneling(w, r)
-			} else {
-				handleHTTP(w, r)
-			}
-		}),
-	}
-
-	//log.Fatal(server.ListenAndServe())
-	return server.Serve(listener)
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -2,12 +2,15 @@ package http
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	jwt "github.com/golang-jwt/jwt"
 )
@@ -338,4 +341,88 @@ func getAdminData() (jwt.MapClaims, error) {
 
 	claims, _ := token.Claims.(jwt.MapClaims)
 	return claims, nil
+}
+
+func handleTunneling(w http.ResponseWriter, r *http.Request) {
+	// Modify the host if necessary.
+	//r.Host = mapHost(r.Host)
+	if r.Host == "" {
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
+
+	destConn, err := net.DialTimeout("tcp", r.Host, 10*time.Second)
+	if err != nil {
+		log.Printf("Failed to connect to host %s: %v", r.Host, err)
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	log.Printf("Tunneling from %s to %s", r.RemoteAddr, r.Host)
+	w.WriteHeader(http.StatusOK)
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+	}
+	go connect(destConn, clientConn)
+}
+
+func handleHTTP(w http.ResponseWriter, req *http.Request) {
+	//req.Host = mapHost(req.Host)
+	if req.Host == "" {
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
+	req.URL.Host = req.Host
+	req.URL.Scheme = "http" // You can also dynamically set the scheme based on the original request
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	defer resp.Body.Close()
+	copyHeader(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+func connect(destConn, clientConn net.Conn) {
+	defer destConn.Close()
+	defer clientConn.Close()
+	go copy(destConn, clientConn)
+	copy(clientConn, destConn)
+}
+
+func copy(dst io.Writer, src io.Reader) {
+	_, _ = io.Copy(dst, src)
+}
+
+func StartHttpProxy(listener net.Listener) error {
+	server := &http.Server{
+		//Addr: ":8080",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			log.Printf("Received request %s %s %s\n", r.Method, r.Host, r.RemoteAddr)
+			if r.Method == http.MethodConnect {
+				handleTunneling(w, r)
+			} else {
+				handleHTTP(w, r)
+			}
+		}),
+	}
+
+	//log.Fatal(server.ListenAndServe())
+	return server.Serve(listener)
 }

--- a/internal/httpproxylib/proxylib.go
+++ b/internal/httpproxylib/proxylib.go
@@ -1,10 +1,12 @@
 package httpproxylib
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/borderzero/border0-cli/internal/border0"
@@ -22,7 +24,7 @@ func handleTunneling(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
-	log.Printf("Tunneling from %s to %s", r.RemoteAddr, r.Host)
+	//log.Printf("Tunneling from %s to %s", r.RemoteAddr, r.Host)
 	w.WriteHeader(http.StatusOK)
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
@@ -35,7 +37,27 @@ func handleTunneling(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	buf := make([]byte, 1024)
+	// for rw.Reader.Buffered() > 0 {
+	// 	b := make([]byte, rw.Reader.Buffered())
+	// 	n, err := rw.Read(b)
+	// 	if err != nil {
+	// 		fmt.Printf("Error reading from buffered reader: %v\n", err)
+	// 		return
+	// 	}
+
+	// 	m, err := clientConn.Write(b[:n])
+	// 	// check error
+	// 	if err != nil {
+	// 		fmt.Printf("Error writing to client: %v\n", err)
+	// 		return
+	// 	}
+	// 	if m != n {
+	// 		fmt.Printf("Byte mismatch: %d != %d\n", m, n)
+	// 		return
+	// 	}
+	// }
+
+	buf := make([]byte, 4096)
 	n, err := rw.Read(buf)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
@@ -82,10 +104,38 @@ func copyHeader(dst, src http.Header) {
 	}
 }
 
-func StartHttpProxy(listener net.Listener) error {
+func checkIfAllowed(host string, allowedHosts []string) bool {
+	// host may contain a colon and port number, so we should remove it
+	// before checking if it is in the allowedHosts list
+	if index := strings.LastIndex(host, ":"); index != -1 {
+		host = host[:index]
+	}
+
+	for _, h := range allowedHosts {
+		if h == host {
+			return true
+		}
+	}
+	return false
+}
+
+func StartHttpProxy(listener net.Listener, allowedProxyHosts []string) error {
+	// print all enttries in allowedHosts
+	for _, h := range allowedProxyHosts {
+		fmt.Println("Allowed host: ", h)
+	}
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			log.Printf("Received request %s %s %s\n", r.Method, r.Host, r.RemoteAddr)
+			log.Printf("Received request %s %s\n", r.Method, r.Host)
+
+			// check if host is in allowedHosts
+			// if not return not allowed
+
+			if !checkIfAllowed(r.Host, allowedProxyHosts) {
+				http.Error(w, "Not found", http.StatusMethodNotAllowed)
+				return
+			}
+
 			if r.Method == http.MethodConnect {
 				handleTunneling(w, r)
 			} else {

--- a/internal/httpproxylib/proxylib.go
+++ b/internal/httpproxylib/proxylib.go
@@ -1,0 +1,97 @@
+package httpproxylib
+
+import (
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/borderzero/border0-cli/internal/border0"
+)
+
+func handleTunneling(w http.ResponseWriter, r *http.Request) {
+	if r.Host == "" {
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
+
+	destConn, err := net.DialTimeout("tcp", r.Host, 10*time.Second)
+	if err != nil {
+		log.Printf("Failed to connect to host %s: %v", r.Host, err)
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	log.Printf("Tunneling from %s to %s", r.RemoteAddr, r.Host)
+	w.WriteHeader(http.StatusOK)
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+	clientConn, rw, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	buf := make([]byte, 1024)
+	n, err := rw.Read(buf)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	m, err := destConn.Write(buf[:n])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	if m != n {
+		http.Error(w, "byte mismatch", http.StatusServiceUnavailable)
+		return
+	}
+
+	border0.ProxyConnection(clientConn, destConn)
+}
+
+func handleHTTP(w http.ResponseWriter, req *http.Request) {
+	//req.Host = mapHost(req.Host)
+	if req.Host == "" {
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
+	req.URL.Host = req.Host
+	req.URL.Scheme = "http" // You can also dynamically set the scheme based on the original request
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	defer resp.Body.Close()
+	copyHeader(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}
+
+func copyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+func StartHttpProxy(listener net.Listener) error {
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			log.Printf("Received request %s %s %s\n", r.Method, r.Host, r.RemoteAddr)
+			if r.Method == http.MethodConnect {
+				handleTunneling(w, r)
+			} else {
+				handleHTTP(w, r)
+			}
+		}),
+	}
+	return server.Serve(listener)
+}


### PR DESCRIPTION
# Description

Support for HTTP proxy over TLS socket
on the server:
`border0 socket connect proxy proxysocket`  start proxy
optionally add one or more `--allowed-host` to limit what is allowed to be proxied. If ommited, all urls are allowed to proxied

on the client `./border0 client proxy  -c 2` This will start two upstream client connections, over which HTTP requests to the proxy will be load balanced.  default is one stream. More streams allow for better throughput if there are multiple parallel requests.

optionally use `./border0 client proxy  -t` for a terminal UI (TUI), experiment.

Ater that you can use localhost as proxy, for example test with curl:
```
$ curl   -x http://127.0.0.1:8080 https://ifconfig.io
207.102.57.34
```

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
