### PR TITLE
[ME-1787] VarSource Path Change

### DIFF
--- a/lib/varsource/README.md
+++ b/lib/varsource/README.md
@@ -13,10 +13,10 @@ Currently supported upstreams include:
 
 ```
 vs := varsource.NewDefaultVariableSource()
-	
+
 vars, err := vs.GetVariables(ctx, map[string]string{
-	"DB_USERNAME": "${env:DB_USERNAME}",
-	"DB_PASSWORD": "${aws:secretsmanager:my-password}",
+	"DB_USERNAME": "from:env:DB_USERNAME",
+	"DB_PASSWORD": "from:aws:secretsmanager:my-password",
 }
 if err != nil {
 	log.Fatalf("failed to fetch variables: %v", err)

--- a/lib/varsource/variable_source.go
+++ b/lib/varsource/variable_source.go
@@ -11,8 +11,8 @@ type VariableSource interface {
 	//
 	// For example:
 	// {
-	//   "DB_USERNAME": "${env:DB_USERNAME}",
-	//   "DB_PASSWORD": "${file:~/.creds/password.txt}",
+	//   "DB_USERNAME": "from:env:DB_USERNAME",
+	//   "DB_PASSWORD": "from:file:~/.creds/password.txt",
 	// }
 	// would be translated to:
 	// {
@@ -26,6 +26,7 @@ type VariableSource interface {
 // NewDefaultVariableSource returns the default VariableSource implementation.
 func NewDefaultVariableSource() VariableSource {
 	return NewMultipleUpstreamVariableSource(
+		WithTopLevelPrefix("from:"),
 		WithEnvVariableUpstream(),
 		WithFileVariableUpstream(),
 		WithAWSSSMVariableUpstream(),

--- a/lib/varsource/variable_upstream_file.go
+++ b/lib/varsource/variable_upstream_file.go
@@ -16,6 +16,10 @@ var _ variableUpstream = (*fileVariableUpstream)(nil)
 // GetVariable gets a variable from a file
 func (vg *fileVariableUpstream) GetVariable(ctx context.Context, varDefn string) (string, error) {
 	filePath := varDefn
+	if strings.HasPrefix(filePath, `~/`) {
+		filePath = strings.TrimPrefix(filePath, `~/`)
+		filePath = fmt.Sprintf("%s/%s", os.Getenv("HOME"), filePath)
+	}
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read file at path \"%s\"", filePath)


### PR DESCRIPTION
## [ME-1787] VarSource Path Change

Better handling of upstream variables. No longer use dollar bracket syntax (e.g. `${...}`) in favour of using `from:PREFIX...` (which can be escaped with `\from`.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1787

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

With the following example program:

```
package main

import (
	"context"
	"fmt"
	"log"

	"github.com/borderzero/border0-cli/lib/varsource"
)

func main() {
	vs := varsource.NewDefaultVariableSource()

	vars, err := vs.GetVariables(context.Background(), map[string]string{
		"DB_USERNAME": "from:env:DB_USERNAME",
		"DB_PASSWORD": "from:file:~/.creds/password.txt",
	})
	if err != nil {
		log.Fatalf("failed to get variables: %v", err)
	}

	for key, value := range vars {
		fmt.Println(fmt.Sprintf("%s : %s", key, value))
	}
}
```

Ran:

```
✔ ~/go/src/github.com/borderzero/border0-cli [MISC_varsource_paths|…1]
11:46 $ DB_USERNAME=srdfghj go run __example/main.go
DB_USERNAME : srdfghj
DB_PASSWORD : esadrtfjgkhj
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1787]: https://mysocket.atlassian.net/browse/ME-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ