### PR TITLE
ME-1788 Fix Sudo behaviour with border0 cli

### DIFF
--- a/cmd/client/httpproxy/httpproxy.go
+++ b/cmd/client/httpproxy/httpproxy.go
@@ -207,6 +207,12 @@ func (sm *SessionManager) removeSession(session *yamux.Session, logStream *yamux
 
 // selectSession is a simple function that selects a session from the slice
 func (sm *SessionManager) selectSession(index int) *yamux.Session {
+	if len(sm.sessions) == 0 {
+		// Handle the error appropriately here.
+		// You could log an error, return a special value, etc.
+		log.Fatalf("All upstream sessions have been closed, no more upstream options available. Exiting.")
+		return nil // Returning nil as an example.
+	}
 	return sm.sessions[index%len(sm.sessions)]
 }
 

--- a/cmd/client/vpn/vpn.go
+++ b/cmd/client/vpn/vpn.go
@@ -3,6 +3,7 @@ package vpn
 import (
 	"crypto/tls"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"time"
@@ -77,11 +78,11 @@ var clientVpnCmd = &cobra.Command{
 		logger.Logger.Info("Received control message", zap.Any("control_message", ctrl))
 
 		if err = vpnlib.AddIpToIface(iface.Name(), ctrl.ClientIp, ctrl.ServerIp, ctrl.SubnetSize); err != nil {
-			return fmt.Errorf("failed to add static IPs to interface: %v", err)
+			log.Println("failed to add IPs to interface", err)
 		}
 
 		if err = vpnlib.AddRoutesToIface(iface.Name(), ctrl.Routes); err != nil {
-			return fmt.Errorf("failed to add routes to interface: %v", err)
+			log.Println("failed to add routes to interface", err)
 		}
 
 		// create the connection map

--- a/internal/client/resources.go
+++ b/internal/client/resources.go
@@ -106,7 +106,7 @@ func Login(org string) (token string, claims jwt.MapClaims, err error) {
 	if runtime.GOOS == "darwin" && sudoUsername != "" {
 		err = exec.Command("sudo", "-u", sudoUsername, "open", url).Run()
 		if err == nil {
-			// If for some reason this failed, we'll try again to old way
+			// This means, it's successull. So set sudo attemtp to True.
 			sudoAttempt = true
 		}
 	}

--- a/internal/vpnlib/vpnlib.go
+++ b/internal/vpnlib/vpnlib.go
@@ -265,7 +265,7 @@ func TunToConnCopy(iface *water.Interface, cm *ConnectionMap, returnOnErr bool, 
 			var exists bool
 
 			if recipientConn, exists = cm.Get(dstIp.String()); !exists {
-				fmt.Printf("No connection exists for IP: %s\n", dstIp)
+				//fmt.Printf("No connection exists for IP: %s\n", dstIp)
 				continue
 			}
 		} else {


### PR DESCRIPTION
# Description

This change implements some of the user feedback regarding the VPN log messages and  HTTP proxy crash.
Also making sure the user can use sudo without losing his or her preferences, ie we use the original users preference, admin and client token locations.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
