### PR TITLE
ME-1791 Fix VPN header read

### DIFF
--- a/internal/vpnlib/vpnlib.go
+++ b/internal/vpnlib/vpnlib.go
@@ -556,8 +556,9 @@ func ConnToTunCopy(conn net.Conn, iface *water.Interface) error {
 
 	for {
 		// read first ${headerByteSize} bytes from the connection
-		// to know how big the next incoming packet is
-		headerN, err := conn.Read(headerBuffer)
+		// to know how big the next incoming packet is.
+		// Make sure we read all the way to the end of the header using io.ReadFull()
+		headerN, err := io.ReadFull(conn, headerBuffer)
 		if err != nil {
 			if errors.Is(err, io.EOF) ||
 				errors.Is(err, io.ErrUnexpectedEOF) {


### PR DESCRIPTION
# Description

Fix to make sure we read the complete first 2 bytes io.ReadFull() Previously, we were using conn.Read(headerBuffer), and even though the buffer size was 2 bytes, sometimes we ended up with 1 byte, which caused us to determine the wrong size of the subsequent payload data.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
