### PR TITLE
[ME-1801] Connector V2 Built-In SSH Server Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.8
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
 	github.com/bluele/factory-go v0.0.1
-	github.com/borderzero/border0-go v0.1.21
+	github.com/borderzero/border0-go v0.1.22
 	github.com/borderzero/border0-proto v1.0.3
 	github.com/borderzero/discovery v0.1.21
 	github.com/brianvoe/gofakeit v3.18.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
 github.com/borderzero/border0-go v0.1.21 h1:QfCNDMmqqrBvUNpCzWfVkKhxMPUmbLb5nT3NzUyKXP4=
 github.com/borderzero/border0-go v0.1.21/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
+github.com/borderzero/border0-go v0.1.22 h1:+/x2Xwoo9il9oSpl1KNIKhjRQRef6gYEB0KoAVKCxoU=
+github.com/borderzero/border0-go v0.1.22/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
 github.com/borderzero/border0-proto v1.0.3 h1:I7xj7qsNlVvWD0+h7oin2fZbwNDrK0tiHgnmz2ODPr4=
 github.com/borderzero/border0-proto v1.0.3/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
 github.com/borderzero/discovery v0.1.21 h1:2ILAepf7I5/ot/019QrEA3/EnOrk0efdttQmeR2ozwc=
@@ -323,6 +325,7 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.4 h1:1kZ/sQM3srePvKs3tXAvQzo66XfcReoqFpIpIccE7Oc=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
@@ -642,6 +645,7 @@ go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/internal/connector_v2/upstreamdata/builder.go
+++ b/internal/connector_v2/upstreamdata/builder.go
@@ -46,6 +46,8 @@ func (u *UpstreamDataBuilder) setupSSHUpstreamValues(s *models.Socket, configMap
 		u.setupEc2Connect(s, *configMap.SSHConfiguration.AwsEC2ConnectDetails)
 	case types.UpstreamAuthenticationTypeBorder0Cert:
 		u.setupBorder0Certificate(s, configMap.SSHConfiguration.Border0CertificateDetails)
+	case types.UpstreamConnectionTypeBuiltInSshServer:
+		u.setupBuiltInSshServer(s)
 	default:
 		return fmt.Errorf("unknown upstream connection type: %s", configMap.UpstreamConnectionType)
 	}
@@ -103,12 +105,16 @@ func (u *UpstreamDataBuilder) setupEc2Connect(s *models.Socket, ec2Details types
 	return nil
 }
 
+func (u *UpstreamDataBuilder) setupBuiltInSshServer(s *models.Socket) error {
+	s.SSHServer = true
+	return nil
+}
+
 func (u *UpstreamDataBuilder) fetchVariableFromSource(field string) string {
 	val, err := u.vs.GetVariable(context.Background(), field)
 	if err != nil {
 		fmt.Printf("error evaluating variable %s: %v\n", field, err)
 		return field
 	}
-
 	return val
 }


### PR DESCRIPTION
## [ME-1801] Connector V2 Built-In SSH Server Support

- Support for the built in ssh server in connector v2 (based on the new upstream connection type defined in the border0 go sdk)
- A minor refactor that shortens the code quite a bit by using a `set` library instead of iterating over slice

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1801

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

In the staging border0 environment with a new connector. Manually inserted the socket upstream config into the db.

```
16:44 $ ./border0 connector start --v2
{"level":"info","ts":"2023-08-08T16:45:25-07:00","msg":"starting the connector service"}
{"level":"info","ts":"2023-08-08T16:45:25-07:00","msg":"connecting to connector server","server":"capi.staging.border0.com:443"}
{"level":"debug","ts":"2023-08-08T16:45:25-07:00","msg":"collected connector metadata","metadata":{}}
{"level":"info","ts":"2023-08-08T16:45:25-07:00","msg":"new socket","socket":"817fb338-1eb9-4ae5-8b9c-04fd4513b512"}
Welcome to Border0.com
target - https://client.border0.com/#/ssh/target-adrianosela.staging.border0.io

=======================================================
Logs
=======================================================
{"level":"info","ts":"2023-08-08T16:45:39-07:00","msg":"new ssh session for me@adrianosela.com (as user adriano)","socket_id":"817fb338-1eb9-4ae5-8b9c-04fd4513b512"}
206.214.246.196:55220 [Tue, 08 Aug 2023 23:45:35 UTC] TCP 200 bytes_sent:2901 bytes_received:4024 session_time: 8.85
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1801]: https://mysocket.atlassian.net/browse/ME-1801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ