### PR TITLE
ME-1804: strip go debugging info from binary with linker flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
 # BORDER0_VERSION is supplied by the build script
 BORDER0_VERSION ?= $(git describe --long --dirty --tags)
 VERSION=$(BORDER0_VERSION)
-FLAGS := -ldflags "-X github.com/borderzero/border0-cli/cmd.version=$(VERSION) -X github.com/borderzero/border0-cli/cmd.date=$(DATE)"
+# strip debugging information with -s and -w linker flags
+# -s: disable symbol table
+# -w: disable DWARF generation
+FLAGS := -ldflags "-s -w -X github.com/borderzero/border0-cli/cmd.version=$(VERSION) -X github.com/borderzero/border0-cli/cmd.date=$(DATE)"
 
 all: lint moddownload test build
 


### PR DESCRIPTION
# Description

Add `-s` and `-w` linker flags to strip debugging info and reduce binary size.

Before:
![Screen Shot 2023-08-08 at 4 20 04 PM](https://github.com/borderzero/border0-cli/assets/965430/c1fae994-88c9-41ed-8018-97169b609a51)

After:
![Screen Shot 2023-08-08 at 4 21 23 PM](https://github.com/borderzero/border0-cli/assets/965430/e92342ab-807e-45ce-99cd-fe33b596dc79)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested with `make build-all`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
