### PR TITLE
ME-1717: fix brew error when running commands on macos

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
 
+	"github.com/borderzero/border0-cli/internal/command"
 	"github.com/spf13/cobra"
 )
 
@@ -35,14 +35,13 @@ var completionCmd = &cobra.Command{
 }
 
 func completionUsage() string {
-	brewPrefix := "/usr/local"
-	if runtime.GOOS == "darwin" {
+	macOSPrefix := "/usr/local"
+	if runtime.GOOS == "darwin" && command.Exists("brew") {
 		out, err := exec.Command("brew", "--prefix").CombinedOutput()
-		trimmed := strings.TrimSpace(string(out))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: cannot execute `brew --prefix` %s, %s\n\n", trimmed, err)
+			// do nothing, just use default prefix
 		} else {
-			brewPrefix = trimmed
+			macOSPrefix = strings.TrimSpace(string(out))
 		}
 	}
 	return `To load completions:
@@ -55,7 +54,7 @@ Bash:
   # Linux:
   $ border0 completion bash > /etc/bash_completion.d/border0
   # macOS:
-  $ border0 completion bash > ` + brewPrefix + `/etc/bash_completion.d/border0
+  $ border0 completion bash > ` + macOSPrefix + `/etc/bash_completion.d/border0
 
 Zsh:
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -1,0 +1,10 @@
+package command
+
+import "os/exec"
+
+func Exists(name string) bool {
+	if _, err := exec.LookPath(name); err != nil {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
# Description

Commands on macOS should not show brew error when it's not installed.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested on macOS with and without brew installed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
