### PR TITLE
ME-1788 Fix for local route lookups

### DIFF
--- a/cmd/client/vpn/vpn.go
+++ b/cmd/client/vpn/vpn.go
@@ -138,7 +138,7 @@ var clientVpnCmd = &cobra.Command{
 					// Check if this is a local IP, or routed via default gateway
 					// If so, we don't want to add it to the static routes
 
-					networkInterfaces, err := vpnlib.IsLocalIp(dnsServer)
+					networkInterfaces, err := vpnlib.GetLocalInterfacesForIp(dnsServer)
 					if err != nil {
 						log.Println("failed to check if IP is local", err)
 						continue
@@ -147,7 +147,7 @@ var clientVpnCmd = &cobra.Command{
 					// if the map is not empty, then the IP is local
 					if len(networkInterfaces) > 0 {
 						// This is the case if the IP is on the same subnet as the local gateway, for example on the router
-						// However we shoidl make sure it's not on the newly added tun VPN interface
+						// However we should make sure it's not on the newly added tun VPN interface
 
 						// we should make sure the list of interfaces is not empty, and doesn't contain iface.Name()
 						// if it does, we should continue

--- a/cmd/client/vpn/vpn.go
+++ b/cmd/client/vpn/vpn.go
@@ -138,15 +138,30 @@ var clientVpnCmd = &cobra.Command{
 					// Check if this is a local IP, or routed via default gateway
 					// If so, we don't want to add it to the static routes
 
-					isLocal, err := vpnlib.IsLocalIp(dnsServer)
+					isLocal, networkInterfaces, err := vpnlib.IsLocalIp(dnsServer)
 					if err != nil {
 						log.Println("failed to check if IP is local", err)
 						continue
 					}
+
 					if isLocal {
-						// if it's on the local network
 						// This is the case if the IP is on the same subnet as the local gateway, for example on the router
-						continue
+						// However we shoidl make sure it's not on the newly added tun VPN interface
+
+						// we should make sure the list of interfaces is not empty, and doesn't contain iface.Name()
+						// if it does, we should continue
+						if len(networkInterfaces) > 0 {
+							// check the list to and if the interface found is not the same as  iface.Name()
+							// Which is the VPN tunnel, then it's a local network, and we should continue
+							// ie. no by pass route is needed, since the IP address is locally connected.
+							vpnIfaceName := iface.Name()
+							for _, name := range networkInterfaces {
+								if name != vpnIfaceName {
+									// network found, not adding bypass route
+									continue
+								}
+							}
+						}
 					}
 
 					// For now we old support IPv4

--- a/cmd/client/vpn/vpn.go
+++ b/cmd/client/vpn/vpn.go
@@ -138,29 +138,29 @@ var clientVpnCmd = &cobra.Command{
 					// Check if this is a local IP, or routed via default gateway
 					// If so, we don't want to add it to the static routes
 
-					isLocal, networkInterfaces, err := vpnlib.IsLocalIp(dnsServer)
+					networkInterfaces, err := vpnlib.IsLocalIp(dnsServer)
 					if err != nil {
 						log.Println("failed to check if IP is local", err)
 						continue
 					}
 
-					if isLocal {
+					// if the map is not empty, then the IP is local
+					if len(networkInterfaces) > 0 {
 						// This is the case if the IP is on the same subnet as the local gateway, for example on the router
 						// However we shoidl make sure it's not on the newly added tun VPN interface
 
 						// we should make sure the list of interfaces is not empty, and doesn't contain iface.Name()
 						// if it does, we should continue
-						if len(networkInterfaces) > 0 {
-							// check the list to and if the interface found is not the same as  iface.Name()
-							// Which is the VPN tunnel, then it's a local network, and we should continue
-							// ie. no by pass route is needed, since the IP address is locally connected.
-							vpnIfaceName := iface.Name()
-							for _, name := range networkInterfaces {
-								if name != vpnIfaceName {
-									// network found, not adding bypass route
-									continue
-								}
+						// check the list to and if the interface found is not the same as  iface.Name()
+						// Which is the VPN tunnel, then it's a local network, and we should continue
+						// ie. no by pass route is needed, since the IP address is locally connected.
+						vpnIfaceName := iface.Name()
+						for _, name := range networkInterfaces {
+							if name != vpnIfaceName {
+								// network found, not adding bypass route
+								continue
 							}
+
 						}
 					}
 

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v0.1.21 h1:QfCNDMmqqrBvUNpCzWfVkKhxMPUmbLb5nT3NzUyKXP4=
-github.com/borderzero/border0-go v0.1.21/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
 github.com/borderzero/border0-go v0.1.22 h1:+/x2Xwoo9il9oSpl1KNIKhjRQRef6gYEB0KoAVKCxoU=
 github.com/borderzero/border0-go v0.1.22/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
 github.com/borderzero/border0-proto v1.0.3 h1:I7xj7qsNlVvWD0+h7oin2fZbwNDrK0tiHgnmz2ODPr4=
@@ -325,7 +323,6 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
-github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.4 h1:1kZ/sQM3srePvKs3tXAvQzo66XfcReoqFpIpIccE7Oc=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
@@ -645,7 +642,6 @@ go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
-go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/internal/vpnlib/iputil.go
+++ b/internal/vpnlib/iputil.go
@@ -62,19 +62,18 @@ func validateIPv4(packet []byte) error {
 // Ie if it is routed via the default gateway or not.
 // returns True if the IP can reached via a local network interface.
 // ALso returns a list of interfaces on which this IP network was found
-func IsLocalIp(ipAddress string) (bool, []string, error) {
-	isLocal := false
-	// also create a list of network interfaces, so we can return those if a match is found
+func IsLocalIp(ipAddress string) ([]string, error) {
+	//create a list of network interfaces, so we can return those if a match is found
 	networkInterfaces := []string{}
 
 	targetIP := net.ParseIP(ipAddress)
 	if targetIP == nil {
-		return false, networkInterfaces, fmt.Errorf("invalid IP address")
+		return networkInterfaces, fmt.Errorf("invalid IP address")
 	}
 
 	interfaces, err := net.Interfaces()
 	if err != nil {
-		return false, networkInterfaces, fmt.Errorf("failed to get local network interfaces: %v", err)
+		return networkInterfaces, fmt.Errorf("failed to get local network interfaces: %v", err)
 	}
 
 	for _, iface := range interfaces {
@@ -85,7 +84,7 @@ func IsLocalIp(ipAddress string) (bool, []string, error) {
 
 		addresses, err := iface.Addrs()
 		if err != nil {
-			return false, networkInterfaces, fmt.Errorf("failed to get addresses for interface %v: %v", iface.Name, err)
+			return networkInterfaces, fmt.Errorf("failed to get addresses for interface %v: %v", iface.Name, err)
 		}
 
 		for _, address := range addresses {
@@ -94,12 +93,11 @@ func IsLocalIp(ipAddress string) (bool, []string, error) {
 				continue
 			}
 			if ipNet.Contains(targetIP) {
-				isLocal = true
 				// append iface.Name to list of interfaces
 				networkInterfaces = append(networkInterfaces, iface.Name)
 			}
 		}
 	}
-	return isLocal, networkInterfaces, nil
+	return networkInterfaces, nil
 
 }

--- a/internal/vpnlib/iputil.go
+++ b/internal/vpnlib/iputil.go
@@ -58,11 +58,8 @@ func validateIPv4(packet []byte) error {
 	return nil
 }
 
-// Check if an IP address is local or not.
-// Ie if it is routed via the default gateway or not.
-// returns True if the IP can reached via a local network interface.
-// ALso returns a list of interfaces on which this IP network was found
-func IsLocalIp(ipAddress string) ([]string, error) {
+// Returns a list of interfaces on which this IP network was found
+func GetLocalInterfacesForIp(ipAddress string) ([]string, error) {
 	//create a list of network interfaces, so we can return those if a match is found
 	networkInterfaces := []string{}
 

--- a/internal/vpnlib/iputil.go
+++ b/internal/vpnlib/iputil.go
@@ -61,34 +61,45 @@ func validateIPv4(packet []byte) error {
 // Check if an IP address is local or not.
 // Ie if it is routed via the default gateway or not.
 // returns True if the IP can reached via a local network interface.
-func IsLocalIp(ipAddress string) (bool, error) {
+// ALso returns a list of interfaces on which this IP network was found
+func IsLocalIp(ipAddress string) (bool, []string, error) {
+	isLocal := false
+	// also create a list of network interfaces, so we can return those if a match is found
+	networkInterfaces := []string{}
+
 	targetIP := net.ParseIP(ipAddress)
 	if targetIP == nil {
-		return false, fmt.Errorf("invalid IP address")
-
+		return false, networkInterfaces, fmt.Errorf("invalid IP address")
 	}
 
-	localIPs, err := net.InterfaceAddrs()
+	interfaces, err := net.Interfaces()
 	if err != nil {
-		return false, fmt.Errorf("failed to get local IP addresses: %v", err)
+		return false, networkInterfaces, fmt.Errorf("failed to get local network interfaces: %v", err)
 	}
 
-	isLocal := false
-	for _, address := range localIPs {
-		_, ipNet, err := net.ParseCIDR(address.String())
-		if err != nil {
+	for _, iface := range interfaces {
+		// Only consider interfaces that are up
+		if iface.Flags&net.FlagUp == 0 {
 			continue
 		}
 
-		if ipNet.Contains(targetIP) {
-			isLocal = true
-			break
+		addresses, err := iface.Addrs()
+		if err != nil {
+			return false, networkInterfaces, fmt.Errorf("failed to get addresses for interface %v: %v", iface.Name, err)
+		}
+
+		for _, address := range addresses {
+			_, ipNet, err := net.ParseCIDR(address.String())
+			if err != nil {
+				continue
+			}
+			if ipNet.Contains(targetIP) {
+				isLocal = true
+				// append iface.Name to list of interfaces
+				networkInterfaces = append(networkInterfaces, iface.Name)
+			}
 		}
 	}
+	return isLocal, networkInterfaces, nil
 
-	if isLocal {
-		return true, nil
-	} else {
-		return false, nil
-	}
 }


### PR DESCRIPTION
# Description

A fix to make sure we only take into account network interfaces that are up. And we need to make sure it doesn't match the newly created VPN interfaces.

This broke my blenz coffee shop test! Now i can vpn again from coffeeshop.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
