### PR TITLE
[HOTFIX] Dont break connector v2 when HOME not defined

### DIFF
--- a/internal/connector_v2/config/config.go
+++ b/internal/connector_v2/config/config.go
@@ -76,31 +76,30 @@ func GetConfiguration(ctx context.Context, configFilePath string) (*Configuratio
 				err,
 			)
 		}
-	} else { // otherwise use the default configuration file path for config
-		hd, err := util.GetUserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get the user's home directory: %v", err)
-		}
-		path = fmt.Sprintf("%s/%s", hd, defaultCredentialsFilePath)
-		if _, err = os.Stat(path); err != nil {
-			// when the default config file path is used, we only error out when
-			// the failure is not due to a missing config file. This is because
-			// the token and config might still be present in the environment.
-			if !errors.Is(err, os.ErrNotExist) {
-				return nil, fmt.Errorf(
-					"failed to read default configuration file (%s): %v",
-					defaultCredentialsFilePath,
-					err,
-				)
-			}
-			// pass
-		} else {
-			if err = unmarshalConfiguration(path, config); err != nil {
-				return nil, fmt.Errorf(
-					"failed to read the default configuration file (%s): %v",
-					path,
-					err,
-				)
+	} else {
+		// otherwise try the default configuration file path for config
+		if hd, err := util.GetUserHomeDir(); err == nil {
+			path = fmt.Sprintf("%s/%s", hd, defaultCredentialsFilePath)
+			if _, err = os.Stat(path); err != nil {
+				// when the default config file path is used, we only error out when
+				// the failure is not due to a missing config file. This is because
+				// the token and config might still be present in the environment.
+				if !errors.Is(err, os.ErrNotExist) {
+					return nil, fmt.Errorf(
+						"failed to read default configuration file (%s): %v",
+						defaultCredentialsFilePath,
+						err,
+					)
+				}
+				// pass
+			} else {
+				if err = unmarshalConfiguration(path, config); err != nil {
+					return nil, fmt.Errorf(
+						"failed to read the default configuration file (%s): %v",
+						path,
+						err,
+					)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## [HOTFIX] Dont break connector v2 when HOME not defined

Ignore error when HOME directory is not defined.

In EC2:

```
[   15.123908] cloud-init[1553]: + sudo chmod +x /usr/local/bin/border0
[   15.209225] cloud-init[1553]: + export AWS_REGION=us-east-1
[   15.211599] cloud-init[1553]: + AWS_REGION=us-east-1
[   15.212308] cloud-init[1553]: + export BORDER0_TOKEN=from:aws:ssm:connector-my-connector-token
[   15.213429] cloud-init[1553]: + BORDER0_TOKEN=from:aws:ssm:connector-my-connector-token
[   15.214438] cloud-init[1553]: + export BORDER0_TUNNEL=tunnel.border0.com
[   15.215269] cloud-init[1553]: + BORDER0_TUNNEL=tunnel.border0.com
[   15.216040] cloud-init[1553]: + export BORDER0_CONNECTOR_SERVER=capi.border0.com:443
[   15.216991] cloud-init[1553]: + BORDER0_CONNECTOR_SERVER=capi.border0.com:443
[   15.217886] cloud-init[1553]: + export BORDER0_LOG_LEVEL=info
[   15.218621] cloud-init[1553]: + BORDER0_LOG_LEVEL=info
[   15.219297] cloud-init[1553]: + border0 connector start --v2

Amazon Linux 2023
Kernel 6.1.41-63.114.amzn2023.aarch64 on an aarch64 (-)

ip-172-31-7-9 login: [   17.302435] cloud-init[1553]: {"level":"fatal","ts":"2023-08-10T18:27:37Z","msg":"failed to get connector (v2) configuration","error":"failed to get the user's home directory: couldn't get user home dir: $HOME is not defined"}
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Deployed to EC2.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
