### PR TITLE
[ME-1801] Allow Overriding SSH Username In Built-In SSH Server

### DIFF
--- a/internal/connector_v2/service.go
+++ b/internal/connector_v2/service.go
@@ -571,7 +571,13 @@ func (c *ConnectorService) Listen(socket *border0.Socket) {
 
 	switch {
 	case socket.Socket.SSHServer && socket.SocketType == "ssh":
-		sshServer, err := ssh.NewServer(logger, c.organization.Certificates["ssh_public_key"])
+		opts := []ssh.Option{}
+		if socket.Socket != nil &&
+			socket.Socket.ConnectorLocalData != nil &&
+			socket.Socket.ConnectorLocalData.UpstreamUsername != "" {
+			opts = append(opts, ssh.WithUsername(socket.Socket.ConnectorLocalData.UpstreamUsername))
+		}
+		sshServer, err := ssh.NewServer(logger, c.organization.Certificates["ssh_public_key"], opts...)
 		if err != nil {
 			logger.Error("failed to create ssh server", zap.String("socket", socket.SocketID), zap.Error(err))
 			return

--- a/internal/connector_v2/upstreamdata/builder.go
+++ b/internal/connector_v2/upstreamdata/builder.go
@@ -115,7 +115,7 @@ func (u *UpstreamDataBuilder) setupBuiltInSshServer(s *models.Socket, builtInSer
 		if err != nil {
 			return fmt.Errorf("failed to get the current user: %v", err)
 		}
-		s.ConnectorLocalData.UpstreamUsername = currentUser.Name
+		s.ConnectorLocalData.UpstreamUsername = currentUser.Username
 	case types.UsernameProviderDefined:
 		s.ConnectorLocalData.UpstreamUsername = u.fetchVariableFromSource(builtInServerDetails.Username)
 		return nil


### PR DESCRIPTION
## [[ME-1801](https://mysocket.atlassian.net/browse/ME-1801)] Allow Overriding SSH Username

Adds options to the built in ssh server constructor to override the username.

Fixes # (issue)
- part of https://mysocket.atlassian.net/browse/ME-1801

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1801]: https://mysocket.atlassian.net/browse/ME-1801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ