### PR TITLE
[ME-1816] Allow Empty Hostname

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -66,7 +66,7 @@ var connectCmd = &cobra.Command{
 			SocketType:                     socketType,
 			UpstreamUsername:               &upstream_username,
 			UpstreamPassword:               &upstream_password,
-			UpstreamHttpHostname:           upstream_http_hostname,
+			UpstreamHttpHostname:           &upstream_http_hostname,
 			UpstreamType:                   upstreamType,
 			CloudAuthEnabled:               true,
 			ConnectorAuthenticationEnabled: connectorAuthEnabled,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -179,7 +179,7 @@ func print_socket(s models.Socket, policies []models.Policy) string {
 		th.AppendHeader(table.Row{"Upstream Type", "Upstream Hostname"})
 		th.AppendRow(table.Row{s.UpstreamType, s.UpstreamHttpHostname})
 		th.SetStyle(table.StyleLight)
-		if s.UpstreamType != "" || s.UpstreamHttpHostname != "" {
+		if s.UpstreamType != "" || s.UpstreamHttpHostname != nil && *s.UpstreamHttpHostname != "" {
 			socket_output = socket_output + fmt.Sprintf("\nHTTP Options:\n%s\n", th.Render())
 		}
 	}

--- a/cmd/socket.go
+++ b/cmd/socket.go
@@ -190,7 +190,7 @@ var socketCreateCmd = &cobra.Command{
 			AllowedEmailDomains:            allowedEmailDomains,
 			UpstreamUsername:               &upstream_username,
 			UpstreamPassword:               &upstream_password,
-			UpstreamHttpHostname:           upstream_http_hostname,
+			UpstreamHttpHostname:           &upstream_http_hostname,
 			UpstreamType:                   upstreamType,
 			CloudAuthEnabled:               true,
 			ConnectorAuthenticationEnabled: connectorAuthEnabled,

--- a/internal/api/models/socket.go
+++ b/internal/api/models/socket.go
@@ -107,7 +107,7 @@ type Socket struct {
 	UpstreamCert                   *string           `json:"upstream_cert,omitempty"`
 	UpstreamKey                    *string           `json:"upstream_key,omitempty"`
 	UpstreamCa                     *string           `json:"upstream_ca,omitempty"`
-	UpstreamHttpHostname           string            `json:"upstream_http_hostname,omitempty"`
+	UpstreamHttpHostname           *string           `json:"upstream_http_hostname,omitempty"`
 	UpstreamType                   string            `json:"upstream_type,omitempty"`
 	CloudAuthEnabled               bool              `json:"cloud_authentication_enabled,omitempty"`
 	ConnectorAuthenticationEnabled bool              `json:"connector_authentication_enabled,omitempty"`

--- a/internal/connector/discover/k8.go
+++ b/internal/connector/discover/k8.go
@@ -83,7 +83,7 @@ func (s *K8Discover) buildSocket(connectorName string, group config.K8Plugin, se
 			socket.UpstreamType = upstreamType
 		}
 		if upstreamHttpHostname, exists := service.Annotations["border0.com/upstreamHttpHostname"]; exists {
-			socket.UpstreamHttpHostname = upstreamHttpHostname
+			socket.UpstreamHttpHostname = &upstreamHttpHostname
 		}
 	case "ssh":
 		socket.SocketType = "ssh"

--- a/internal/connector/discover/static_sockets.go
+++ b/internal/connector/discover/static_sockets.go
@@ -34,7 +34,7 @@ func (s *StaticSocketFinder) Find(ctx context.Context, cfg config.Config, state 
 			socket.TargetHostname = v.Host
 			socket.TargetPort = v.Port
 			socket.ConnectorAuthenticationEnabled = v.ConnectorAuthenticationEnabled
-			socket.UpstreamHttpHostname = v.UpstreamHttpHostname
+			socket.UpstreamHttpHostname = &v.UpstreamHttpHostname
 			socket.CloudAuthEnabled = true
 			socket.PolicyNames = v.Policies
 			socket.UpstreamType = v.UpstreamType


### PR DESCRIPTION
# [[ME-1816](https://mysocket.atlassian.net/browse/ME-1816)] Allow Empty HTTP Hostname

Legacy connectors can get in an update loop because if you set the SNI header in the portal and the local config file doesn't have the same upstream http hostname, it will try to set empty string as the hostname when it sees the mismatch. The CLI does not include hostname in the socket request if it is empty string; after this change it will.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1816

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally against latest API

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1816]: https://mysocket.atlassian.net/browse/ME-1816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ