### PR TITLE
[ME-1842] Fix username mismatch problem in built-in-ssh

### DIFF
--- a/internal/ssh/server.go
+++ b/internal/ssh/server.go
@@ -80,7 +80,7 @@ func NewServer(logger *zap.Logger, ca string, opts ...Option) (*ssh.Server, erro
 
 		cmd.Dir = user.HomeDir
 
-		execCmd(s, cmd, uid, gid)
+		execCmd(s, cmd, uid, gid, username)
 	})
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/internal/ssh/server_unix.go
+++ b/internal/ssh/server_unix.go
@@ -21,7 +21,7 @@ import (
 	"github.com/opencontainers/selinux/go-selinux"
 )
 
-func execCmd(s ssh.Session, cmd exec.Cmd, uid, gid uint64) {
+func execCmd(s ssh.Session, cmd exec.Cmd, uid, gid uint64, username string) {
 
 	euid := os.Geteuid()
 	var loginCmd string
@@ -48,9 +48,9 @@ func execCmd(s ssh.Session, cmd exec.Cmd, uid, gid uint64) {
 		if euid == 0 && loginCmd != "" {
 			cmd.Path = loginCmd
 			if isAlpine() {
-				cmd.Args = append([]string{loginCmd, "-p", "-h", "Border0", "-f", s.User()})
+				cmd.Args = append([]string{loginCmd, "-p", "-h", "Border0", "-f", username})
 			} else {
-				cmd.Args = append([]string{loginCmd, "-p", "-h", "Border0", "-f", s.User()}, cmd.Args...)
+				cmd.Args = append([]string{loginCmd, "-p", "-h", "Border0", "-f", username}, cmd.Args...)
 			}
 		} else {
 			sysProcAttr.Credential = &syscall.Credential{

--- a/internal/ssh/server_windows.go
+++ b/internal/ssh/server_windows.go
@@ -4,18 +4,19 @@
 package ssh
 
 import (
-	"github.com/ActiveState/termtest/conpty"
-	"github.com/gliderlabs/ssh"
-	"golang.org/x/sys/windows"
 	"io"
 	"log"
 	"os"
 	"os/exec"
 	"sync"
 	"syscall"
+
+	"github.com/ActiveState/termtest/conpty"
+	"github.com/gliderlabs/ssh"
+	"golang.org/x/sys/windows"
 )
 
-func execCmd(s ssh.Session, cmd exec.Cmd, uid, gid uint64) {
+func execCmd(s ssh.Session, cmd exec.Cmd, uid, gid uint64, username string) {
 	ptyReq, winCh, isPty := s.Pty()
 
 	vsn := windows.RtlGetVersion()


### PR DESCRIPTION
## [ME-1842] Fix username mismatch problem in built-in-ssh

Basically, the shell still tries to force the login to be the name provided in the ssh session even if there is an override, this changes that.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1842

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested against real built-in-ssh sockets in staging

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1842]: https://mysocket.atlassian.net/browse/ME-1842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ