### PR TITLE
[ME-1845] Fix Human Auth With Connector V2

### DIFF
--- a/internal/connector_v2/service.go
+++ b/internal/connector_v2/service.go
@@ -496,17 +496,20 @@ func (c *ConnectorService) GetUserID() (string, error) {
 		return "", fmt.Errorf("failed to parse token")
 	}
 
-	connectorID, ok := claims["connector_id"]
-	if !ok {
-		return "", fmt.Errorf("failed to parse token")
+	connectorId, connectorIdPresent := claims["connector_id"]
+	if connectorIdPresent {
+		connectorIdStr, ok := connectorId.(string)
+		if !ok {
+			return "", fmt.Errorf("failed to parse token")
+		}
+		return strings.ReplaceAll(connectorIdStr, "-", ""), nil
 	}
 
-	connectorIDStr, ok := connectorID.(string)
-	if !ok {
-		return "", fmt.Errorf("failed to parse token")
+	if c.config.ConnectorId != "" {
+		return strings.ReplaceAll(c.config.ConnectorId, "-", ""), nil
 	}
 
-	return strings.ReplaceAll(connectorIDStr, "-", ""), nil
+	return "", fmt.Errorf("failed to get user id")
 }
 
 func (c *ConnectorService) SignSSHKey(ctx context.Context, socketID string, publicKey []byte) (string, string, error) {


### PR DESCRIPTION
## [[ME-1845](https://mysocket.atlassian.net/browse/ME-1845)] Fix Human Auth With Connector V2

Trying to use human credentials does not work (client side)...

```
✔ ~/go/src/github.com/mysocketio/api [ME-1821|✔]
09:45 $ BORDER0_TOKEN=$(cat ~/.border0/token) border0 connector start --v2 --connector-id 33a117bf-7faa-412d-be97-fa5e1d63f811
{"level":"info","ts":"2023-08-15T09:45:25-07:00","msg":"starting the connector service"}
{"level":"info","ts":"2023-08-15T09:45:25-07:00","msg":"connecting to connector server","server":"capi.border0.com:443"}
{"level":"debug","ts":"2023-08-15T09:45:25-07:00","msg":"collected connector metadata","metadata":{}}
{"level":"info","ts":"2023-08-15T09:45:26-07:00","msg":"new socket","socket":"3d99a685-3ab8-44be-837d-e9d21a7b5e85"}
2023/08/15 09:45:26 border0 listener: failed to get userid from token: failed to parse token
2023/08/15 09:45:26 border0 listener: permanent error, exiting
{"level":"error","ts":"2023-08-15T09:45:26-07:00","msg":"failed to start listener","socket_id":"3d99a685-3ab8-44be-837d-e9d21a7b5e85","socket":"3d99a685-3ab8-44be-837d-e9d21a7b5e85","error":"context canceled"}
{"level":"debug","ts":"2023-08-15T09:45:32-07:00","msg":"control stream closed","next retry":0.546995032}
```

After this change

```
✔ ~/go/src/github.com/mysocketio/api [ME-1821|✔]
10:31 $ BORDER0_TOKEN=$(cat ~/.border0/token) border0 connector start --v2 --connector-id 33a117bf-7faa-412d-be97-fa5e1d63f811
{"level":"info","ts":"2023-08-15T10:36:17-07:00","msg":"starting the connector service"}
{"level":"info","ts":"2023-08-15T10:36:17-07:00","msg":"connecting to connector server","server":"capi.border0.com:443"}
{"level":"debug","ts":"2023-08-15T10:36:17-07:00","msg":"collected connector metadata","metadata":{}}
{"level":"info","ts":"2023-08-15T10:36:17-07:00","msg":"new socket","socket":"3d99a685-3ab8-44be-837d-e9d21a7b5e85"}
Welcome to Border0.com
self-ssh - https://client.border0.com/#/ssh/self-ssh-docs0.border0.io

=======================================================
Logs
=======================================================
```

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1845

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See above. Tested locally against production api/proxy.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
