### PR TITLE
[ME-1821] Enable Built In SSH Server During Connector Install

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -346,8 +346,8 @@ func (a *Border0API) DetachPolicies(ctx context.Context, socketID string, policy
 }
 
 // CreateConnector creates a new border0 connector (v2)
-func (a *Border0API) CreateConnector(ctx context.Context, name string, description string) (*models.Connector, error) {
-	payload := &models.Connector{Name: name, Description: description}
+func (a *Border0API) CreateConnector(ctx context.Context, name string, description string, enableBuiltInSshServer bool) (*models.Connector, error) {
+	payload := &models.Connector{Name: name, Description: description, BuiltInSshServerEnabled: enableBuiltInSshServer}
 
 	var connector models.Connector
 	err := a.Request(http.MethodPost, "connector", &connector, payload, true)

--- a/internal/api/models/connector.go
+++ b/internal/api/models/connector.go
@@ -11,14 +11,15 @@ type ConnectorList struct {
 
 // Connector represents a cloud-managed Border0 Connector.
 type Connector struct {
-	Name         string                 `json:"name"`
-	ConnectorID  string                 `json:"connector_id"`
-	Description  string                 `json:"description"`
-	ActiveTokens int                    `json:"active_tokens"`
-	Metadata     map[string]interface{} `json:"metadata"`
-	CreatedAt    *time.Time             `json:"created_at"`
-	UpdatedAt    *time.Time             `json:"updated_at"`
-	LastSeenAt   *time.Time             `json:"last_seen_at"`
+	Name                    string                 `json:"name"`
+	ConnectorID             string                 `json:"connector_id"`
+	BuiltInSshServerEnabled bool                   `json:"built_in_ssh_server_enabled"`
+	Description             string                 `json:"description"`
+	ActiveTokens            int                    `json:"active_tokens"`
+	Metadata                map[string]interface{} `json:"metadata"`
+	CreatedAt               *time.Time             `json:"created_at"`
+	UpdatedAt               *time.Time             `json:"updated_at"`
+	LastSeenAt              *time.Time             `json:"last_seen_at"`
 }
 
 // ConnectorTokenRequest represents a request to create a token for a Border0 Connector.

--- a/internal/connector_v2/install/common.go
+++ b/internal/connector_v2/install/common.go
@@ -92,7 +92,7 @@ func createNewBorder0Connector(
 ) (*models.Connector, error) {
 	border0Client := border0.NewAPI(border0.WithVersion(cliVersion))
 
-	connector, err := border0Client.CreateConnector(ctx, connectorName, connectorDescription)
+	connector, err := border0Client.CreateConnector(ctx, connectorName, connectorDescription, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a new Border0 connector via the Border0 API: %v", err)
 	}


### PR DESCRIPTION
## [ME-1821] Enable Built In SSH Server During Connector Install

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context

Fixes # (issue)
- part of https://mysocket.atlassian.net/browse/ME-1821

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested the installer locally against the production API

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1821]: https://mysocket.atlassian.net/browse/ME-1821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ