### PR TITLE
fix(ME-1859): socket show displays address for upstream hostname

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/borderzero/border0-cli/cmd/logger"
 	"github.com/borderzero/border0-cli/internal/api/models"
+	"github.com/borderzero/border0-go/lib/types/pointer"
 	"github.com/jedib0t/go-pretty/table"
 
 	cc "github.com/ivanpirog/coloredcobra"
@@ -177,7 +178,7 @@ func print_socket(s models.Socket, policies []models.Policy) string {
 	if s.SocketType == "http" || s.SocketType == "https" {
 		th := table.NewWriter()
 		th.AppendHeader(table.Row{"Upstream Type", "Upstream Hostname"})
-		th.AppendRow(table.Row{s.UpstreamType, *s.UpstreamHttpHostname})
+		th.AppendRow(table.Row{s.UpstreamType, pointer.ValueOrZero(s.UpstreamHttpHostname)})
 		th.SetStyle(table.StyleLight)
 		if s.UpstreamType != "" || s.UpstreamHttpHostname != nil && *s.UpstreamHttpHostname != "" {
 			socket_output = socket_output + fmt.Sprintf("\nHTTP Options:\n%s\n", th.Render())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -177,7 +177,7 @@ func print_socket(s models.Socket, policies []models.Policy) string {
 	if s.SocketType == "http" || s.SocketType == "https" {
 		th := table.NewWriter()
 		th.AppendHeader(table.Row{"Upstream Type", "Upstream Hostname"})
-		th.AppendRow(table.Row{s.UpstreamType, s.UpstreamHttpHostname})
+		th.AppendRow(table.Row{s.UpstreamType, *s.UpstreamHttpHostname})
 		th.SetStyle(table.StyleLight)
 		if s.UpstreamType != "" || s.UpstreamHttpHostname != nil && *s.UpstreamHttpHostname != "" {
 			socket_output = socket_output + fmt.Sprintf("\nHTTP Options:\n%s\n", th.Render())


### PR DESCRIPTION
# Description

socket show displays address for upstream hostname:
HTTP Options:
```
┌───────────────┬───────────────────┐
│ UPSTREAM TYPE │ UPSTREAM HOSTNAME │
├───────────────┼───────────────────┤
│ http          │ 0x140005148c0     │
└───────────────┴───────────────────┘
```

Fixes # ((ME-1859)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
