### PR TITLE
[ME-1821] Simplify Connector Cloud Install By Assuming Name

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -346,8 +346,8 @@ func (a *Border0API) DetachPolicies(ctx context.Context, socketID string, policy
 }
 
 // CreateConnector creates a new border0 connector (v2)
-func (a *Border0API) CreateConnector(ctx context.Context, name string, description string, enableBuiltInSshServer bool) (*models.Connector, error) {
-	payload := &models.Connector{Name: name, Description: description, BuiltInSshServerEnabled: enableBuiltInSshServer}
+func (a *Border0API) CreateConnector(ctx context.Context, name string, description string, enableBuiltInSshService bool) (*models.Connector, error) {
+	payload := &models.Connector{Name: name, Description: description, BuiltInSshServiceEnabled: enableBuiltInSshService}
 
 	var connector models.Connector
 	err := a.Request(http.MethodPost, "connector", &connector, payload, true)

--- a/internal/api/models/connector.go
+++ b/internal/api/models/connector.go
@@ -11,15 +11,15 @@ type ConnectorList struct {
 
 // Connector represents a cloud-managed Border0 Connector.
 type Connector struct {
-	Name                    string                 `json:"name"`
-	ConnectorID             string                 `json:"connector_id"`
-	BuiltInSshServerEnabled bool                   `json:"built_in_ssh_server_enabled"`
-	Description             string                 `json:"description"`
-	ActiveTokens            int                    `json:"active_tokens"`
-	Metadata                map[string]interface{} `json:"metadata"`
-	CreatedAt               *time.Time             `json:"created_at"`
-	UpdatedAt               *time.Time             `json:"updated_at"`
-	LastSeenAt              *time.Time             `json:"last_seen_at"`
+	Name                     string                 `json:"name"`
+	ConnectorID              string                 `json:"connector_id"`
+	BuiltInSshServiceEnabled bool                   `json:"built_in_ssh_service_enabled"`
+	Description              string                 `json:"description"`
+	ActiveTokens             int                    `json:"active_tokens"`
+	Metadata                 map[string]interface{} `json:"metadata"`
+	CreatedAt                *time.Time             `json:"created_at"`
+	UpdatedAt                *time.Time             `json:"updated_at"`
+	LastSeenAt               *time.Time             `json:"last_seen_at"`
 }
 
 // ConnectorTokenRequest represents a request to create a token for a Border0 Connector.

--- a/internal/connector_v2/install/aws.go
+++ b/internal/connector_v2/install/aws.go
@@ -76,9 +76,9 @@ func RunCloudInstallWizardForAWS(ctx context.Context, cliVersion string) error {
 		return fmt.Errorf("failed to prompt for AWS VPC Subnet ID: %v", err)
 	}
 
-	border0ConnectorName, err := promptForBorder0ConnectorName(ctx, cliVersion, "my-connector")
+	border0ConnectorName, err := getUniqueConnectorName(ctx, cliVersion, "aws-cloud-install-connector")
 	if err != nil {
-		return fmt.Errorf("failed to prompt for Border0 connector name: %v", err)
+		return fmt.Errorf("failed to determine unique name for connector: %v", err)
 	}
 
 	border0TokenSsmParameter, err := promptForBorder0TokenSsmParameterPath(ctx, cfg, border0ConnectorName)

--- a/internal/connector_v2/install/common.go
+++ b/internal/connector_v2/install/common.go
@@ -3,63 +3,12 @@ package install
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/AlecAivazis/survey/v2"
 	border0 "github.com/borderzero/border0-cli/internal/api"
 	"github.com/borderzero/border0-cli/internal/api/models"
 	"github.com/borderzero/border0-go/lib/types/set"
 	"github.com/borderzero/border0-go/lib/types/slice"
 )
-
-func promptForBorder0ConnectorName(ctx context.Context, cliVersion, suggestion string) (string, error) {
-	if suggestion == "" {
-		suggestion = fmt.Sprintf("my-connector-%d", time.Now().Unix())
-	}
-
-	var connectorNameTarget string
-	err := survey.AskOne(
-		&survey.Input{
-			Message: "What name would you like for your new connector?",
-			Default: suggestion,
-		},
-		&connectorNameTarget,
-		survey.WithValidator(survey.Required),
-		survey.WithValidator(getBorder0ConnectorNameValidator(ctx, cliVersion)),
-		// TODO: validator for connector name regex
-	)
-	if err != nil {
-		return "", fmt.Errorf("failed to ask survey question: %v", err)
-	}
-	return connectorNameTarget, nil
-}
-
-// returns a survey.Validator that checks that a given connector name does not already exist.
-func getBorder0ConnectorNameValidator(ctx context.Context, version string) survey.Validator {
-	border0Client := border0.NewAPI(border0.WithVersion(version))
-
-	return func(userInput interface{}) error {
-		// cast to string
-		connectorName, ok := userInput.(string)
-		if !ok {
-			return fmt.Errorf("user input not a string")
-		}
-
-		connectors, err := border0Client.ListConnectors(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to list connectors via the Border0 API: %v", err)
-		}
-
-		for _, connector := range connectors {
-			if connector.Name == connectorName {
-				return fmt.Errorf("A connector with the name %s already existst in the organization", connectorName)
-			}
-		}
-
-		// success!
-		return nil
-	}
-}
 
 func getUniqueConnectorName(ctx context.Context, version, prefix string) (string, error) {
 	border0Client := border0.NewAPI(border0.WithVersion(version))


### PR DESCRIPTION
## [[ME-1821](https://mysocket.atlassian.net/browse/ME-1821)] Simplify Connector Cloud Install By Assuming Name

Simplify the cloud installer by no longer prompting for name (we'll just get an available one, which the customer can change later on anyways).

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1821

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested the installer.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1821]: https://mysocket.atlassian.net/browse/ME-1821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ