### PR TITLE
[ME-1854] Initial Support for HTTP and TLS Sockets in Connector V2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.8
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
 	github.com/bluele/factory-go v0.0.1
-	github.com/borderzero/border0-go v1.3.2
+	github.com/borderzero/border0-go v1.3.3
 	github.com/borderzero/border0-proto v1.0.3
 	github.com/borderzero/discovery v0.1.21
 	github.com/brianvoe/gofakeit v3.18.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.8
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
 	github.com/bluele/factory-go v0.0.1
-	github.com/borderzero/border0-go v1.2.1
+	github.com/borderzero/border0-go v1.3.2
 	github.com/borderzero/border0-proto v1.0.3
 	github.com/borderzero/discovery v0.1.21
 	github.com/brianvoe/gofakeit v3.18.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.8
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
 	github.com/bluele/factory-go v0.0.1
-	github.com/borderzero/border0-go v1.3.3
+	github.com/borderzero/border0-go v1.3.4
 	github.com/borderzero/border0-proto v1.0.3
 	github.com/borderzero/discovery v0.1.21
 	github.com/brianvoe/gofakeit v3.18.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v1.3.2 h1:iCwiAJHZENm1ggKXjokjjAFXYbrTf5qnkwVKN9MSFDc=
-github.com/borderzero/border0-go v1.3.2/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
+github.com/borderzero/border0-go v1.3.3 h1:tMgqWOwHDdpQN7e8t2hQWYZYaX6nPct4A8bWuWd9fmo=
+github.com/borderzero/border0-go v1.3.3/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
 github.com/borderzero/border0-proto v1.0.3 h1:I7xj7qsNlVvWD0+h7oin2fZbwNDrK0tiHgnmz2ODPr4=
 github.com/borderzero/border0-proto v1.0.3/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
 github.com/borderzero/discovery v0.1.21 h1:2ILAepf7I5/ot/019QrEA3/EnOrk0efdttQmeR2ozwc=

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v1.2.1 h1:6PVvmsTdCkYHdECnOY+D7W/Lav5hByR5C7eVDz0BAlg=
-github.com/borderzero/border0-go v1.2.1/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
+github.com/borderzero/border0-go v1.3.2 h1:iCwiAJHZENm1ggKXjokjjAFXYbrTf5qnkwVKN9MSFDc=
+github.com/borderzero/border0-go v1.3.2/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
 github.com/borderzero/border0-proto v1.0.3 h1:I7xj7qsNlVvWD0+h7oin2fZbwNDrK0tiHgnmz2ODPr4=
 github.com/borderzero/border0-proto v1.0.3/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
 github.com/borderzero/discovery v0.1.21 h1:2ILAepf7I5/ot/019QrEA3/EnOrk0efdttQmeR2ozwc=

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v1.3.3 h1:tMgqWOwHDdpQN7e8t2hQWYZYaX6nPct4A8bWuWd9fmo=
-github.com/borderzero/border0-go v1.3.3/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
+github.com/borderzero/border0-go v1.3.4 h1:DrU3MqgIcev8bl251LJlmYBfja6Vxz/upnHZwbC1cu4=
+github.com/borderzero/border0-go v1.3.4/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
 github.com/borderzero/border0-proto v1.0.3 h1:I7xj7qsNlVvWD0+h7oin2fZbwNDrK0tiHgnmz2ODPr4=
 github.com/borderzero/border0-proto v1.0.3/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
 github.com/borderzero/discovery v0.1.21 h1:2ILAepf7I5/ot/019QrEA3/EnOrk0efdttQmeR2ozwc=

--- a/internal/connector_v2/upstreamdata/http.go
+++ b/internal/connector_v2/upstreamdata/http.go
@@ -15,15 +15,12 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForHttpService(s *models.Socket, 
 	if config.HttpServiceType == service.HttpServiceTypeStandard {
 		hostname := config.StandardHttpServiceConfiguration.Hostname
 		port := config.StandardHttpServiceConfiguration.Port
-		hostSniHeader := config.StandardHttpServiceConfiguration.HostSniHeader
 
 		hostname = u.fetchVariableFromSource(hostname)
 
-		s.ConnectorData.TargetHostname = hostname
-		s.ConnectorData.Port = int(port)
 		s.TargetHostname = hostname
 		s.TargetPort = int(port)
-		s.UpstreamHttpHostname = &hostSniHeader
+		s.UpstreamHttpHostname = &hostname
 	}
 
 	return nil

--- a/internal/connector_v2/upstreamdata/http.go
+++ b/internal/connector_v2/upstreamdata/http.go
@@ -1,7 +1,6 @@
 package upstreamdata
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/borderzero/border0-cli/internal/api/models"
@@ -12,6 +11,14 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForHttpService(s *models.Socket, 
 	if config == nil {
 		return fmt.Errorf("got http service with no http service configuration")
 	}
-	// FIXME: implement
-	return errors.New("Have not implemented handling upstream data for http services")
+
+	hostname, port := u.fetchVariableFromSource(config.Hostname), int(config.Port)
+
+	s.ConnectorData.TargetHostname = hostname
+	s.ConnectorData.Port = port
+	s.TargetHostname = hostname
+	s.TargetPort = port
+	s.UpstreamHttpHostname = &hostname
+
+	return nil
 }

--- a/internal/connector_v2/upstreamdata/http.go
+++ b/internal/connector_v2/upstreamdata/http.go
@@ -12,13 +12,19 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForHttpService(s *models.Socket, 
 		return fmt.Errorf("got http service with no http service configuration")
 	}
 
-	hostname, port := u.fetchVariableFromSource(config.Hostname), int(config.Port)
+	if config.HttpServiceType == service.HttpServiceTypeStandard {
+		hostname := config.StandardHttpServiceConfiguration.Hostname
+		port := config.StandardHttpServiceConfiguration.Port
+		hostSniHeader := config.StandardHttpServiceConfiguration.HostSniHeader
 
-	s.ConnectorData.TargetHostname = hostname
-	s.ConnectorData.Port = port
-	s.TargetHostname = hostname
-	s.TargetPort = port
-	s.UpstreamHttpHostname = &hostname
+		hostname = u.fetchVariableFromSource(hostname)
+
+		s.ConnectorData.TargetHostname = hostname
+		s.ConnectorData.Port = int(port)
+		s.TargetHostname = hostname
+		s.TargetPort = int(port)
+		s.UpstreamHttpHostname = &hostSniHeader
+	}
 
 	return nil
 }

--- a/internal/connector_v2/upstreamdata/tls.go
+++ b/internal/connector_v2/upstreamdata/tls.go
@@ -1,7 +1,6 @@
 package upstreamdata
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/borderzero/border0-cli/internal/api/models"
@@ -12,6 +11,13 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForTlsService(s *models.Socket, c
 	if config == nil {
 		return fmt.Errorf("got tls service with no tls service configuration")
 	}
-	// FIXME: implement
-	return errors.New("Have not implemented handling upstream data for tls services")
+
+	hostname, port := u.fetchVariableFromSource(config.Hostname), int(config.Port)
+
+	s.ConnectorData.TargetHostname = hostname
+	s.ConnectorData.Port = port
+	s.TargetHostname = hostname
+	s.TargetPort = port
+
+	return nil
 }

--- a/internal/connector_v2/upstreamdata/tls.go
+++ b/internal/connector_v2/upstreamdata/tls.go
@@ -12,12 +12,12 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForTlsService(s *models.Socket, c
 		return fmt.Errorf("got tls service with no tls service configuration")
 	}
 
-	hostname, port := u.fetchVariableFromSource(config.Hostname), int(config.Port)
+	// hostname, port := u.fetchVariableFromSource(config.Hostname), int(config.Port)
 
-	s.ConnectorData.TargetHostname = hostname
-	s.ConnectorData.Port = port
-	s.TargetHostname = hostname
-	s.TargetPort = port
+	// s.ConnectorData.TargetHostname = hostname
+	// s.ConnectorData.Port = port
+	// s.TargetHostname = hostname
+	// s.TargetPort = port
 
 	return nil
 }

--- a/vendor/github.com/borderzero/border0-go/lib/types/netaddr/ipv4.go
+++ b/vendor/github.com/borderzero/border0-go/lib/types/netaddr/ipv4.go
@@ -1,0 +1,13 @@
+package netaddr
+
+import "regexp"
+
+// IsCIDRv4 returns true if a given string is an IPv4 CIDR.
+func IsCIDRv4(target string) bool {
+	return regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$`).MatchString(target)
+}
+
+// IsIPv4 returns true if a given string is an IPv4 adddress.
+func IsIPv4(target string) bool {
+	return regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`).MatchString(target)
+}

--- a/vendor/github.com/borderzero/border0-go/lib/types/null/null.go
+++ b/vendor/github.com/borderzero/border0-go/lib/types/null/null.go
@@ -1,0 +1,11 @@
+package null
+
+// All returns true if all given values are nil.
+func All(values ...any) bool {
+	for _, v := range values {
+		if v != nil {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/borderzero/border0-go/lib/types/regex/regex.go
+++ b/vendor/github.com/borderzero/border0-go/lib/types/regex/regex.go
@@ -1,0 +1,16 @@
+package regex
+
+import (
+	"regexp"
+)
+
+// MatchAny matches a value against one or more regex patterns.
+func MatchAny(value string, patterns ...string) bool {
+	for _, pattern := range patterns {
+		match, _ := regexp.MatchString(pattern, value)
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/borderzero/border0-go/lib/types/slice/slice.go
+++ b/vendor/github.com/borderzero/border0-go/lib/types/slice/slice.go
@@ -45,3 +45,34 @@ func CountWhere[T any](slice []T, condition func(T) bool) int {
 	}
 	return count
 }
+
+// Diff finds the difference between two slices, `original` and `changed`. It returns two new slices for the changes.
+// The first slice contains new items that are in `changed` but not in `original`, and the second slice contains removed
+// items that are in `original` but not in `changed`.
+func Diff[T comparable](original, changed []T) (newItems, removedItems []T) {
+	originalMap := make(map[T]bool)
+	changedMap := make(map[T]bool)
+
+	for _, item := range original {
+		originalMap[item] = true
+	}
+	for _, item := range changed {
+		changedMap[item] = true
+	}
+
+	// find items that are in b but not in a (new items)
+	for _, item := range changed {
+		if _, exists := originalMap[item]; !exists {
+			newItems = append(newItems, item)
+		}
+	}
+
+	// find items that are in a but not in b (removed items)
+	for _, item := range original {
+		if _, exists := changedMap[item]; !exists {
+			removedItems = append(removedItems, item)
+		}
+	}
+
+	return newItems, removedItems
+}

--- a/vendor/github.com/borderzero/border0-go/types/common/aws.go
+++ b/vendor/github.com/borderzero/border0-go/types/common/aws.go
@@ -1,0 +1,122 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/borderzero/border0-go/lib/types/pointer"
+	"github.com/borderzero/border0-go/lib/types/regex"
+	"github.com/borderzero/border0-go/lib/types/set"
+)
+
+const (
+	externalVarPattern                   = `^\$\{(from:).+\}$`
+	awsAccessKeyIdPattern                = `^AKIA[0-9A-Z]{16}$`
+	awsSecretAccessKeyPattern            = `^[A-Za-z0-9]{40}$`
+	awsProfilePattern                    = `^[a-zA-Z0-9-_]+$`
+	awsSessionTokenConservativeMaxLength = 2048
+)
+
+// AwsCredentials represents aws credentials.
+type AwsCredentials struct {
+	AwsAccessKeyId     *string `json:"aws_access_key_id,omitempty"`
+	AwsSecretAccessKey *string `json:"aws_secret_access_key,omitempty"`
+	AwsSessionToken    *string `json:"aws_session_token,omitempty"`
+	AwsProfile         *string `json:"aws_profile,omitempty"`
+}
+
+// Validate validates the AwsCredentials.
+func (c *AwsCredentials) Validate() error {
+	awsAccessKeyId := pointer.ValueOrZero(c.AwsAccessKeyId)
+	awsSecretAccessKey := pointer.ValueOrZero(c.AwsSecretAccessKey)
+	awsSessionToken := pointer.ValueOrZero(c.AwsSessionToken)
+	awsProfile := pointer.ValueOrZero(c.AwsProfile)
+
+	hasAwsAccessKeyId := awsAccessKeyId != ""
+	hasAwsSecretAccessKey := awsSecretAccessKey != ""
+	hasAwsSessionToken := awsSessionToken != ""
+	hasAwsProfile := awsProfile != ""
+
+	if hasAwsAccessKeyId && !hasAwsSecretAccessKey {
+		return errors.New("aws_secret_access_key is required when aws_access_key_id is provided")
+	}
+	if !hasAwsAccessKeyId && hasAwsSecretAccessKey {
+		return errors.New("aws_access_key_id is required when aws_secret_access_key is provided")
+	}
+	if hasAwsAccessKeyId && hasAwsSecretAccessKey {
+		if !regex.MatchAny(awsAccessKeyId, []string{externalVarPattern, awsAccessKeyIdPattern}...) {
+			return errors.New("invalid aws_access_key_id")
+		}
+		if !regex.MatchAny(awsSecretAccessKey, []string{externalVarPattern, awsSecretAccessKey}...) {
+			return errors.New("invalid aws_secret_access_key")
+		}
+	}
+
+	if hasAwsSessionToken {
+		if !hasAwsAccessKeyId || !hasAwsSecretAccessKey {
+			return errors.New("both aws_access_key_id and aws_secret_access_key are required when aws_session_token is provided")
+		}
+		// note: aws session token has no documented pattern we can validate against... they are typically
+		// several hundred characters long and there isn't a defined maximum length documented anywhere.
+		// However, we can choose a conservative size to ensure we don't allow the field to be unbounded.
+		if len(awsSessionToken) > awsSessionTokenConservativeMaxLength {
+			return fmt.Errorf("aws_session_token too long (%d characters)", len(awsSessionToken))
+		}
+	}
+
+	if hasAwsProfile {
+		if !regex.MatchAny(awsProfile, []string{externalVarPattern, awsProfilePattern}...) {
+			return errors.New("invalid aws_profile")
+		}
+	}
+
+	return nil
+}
+
+// GetValidAwsRegions returns a set of valid aws regions.
+func GetValidAwsRegions() set.Set[string] {
+	return set.New(
+		"af-south-1",     // Africa (Cape Town).
+		"ap-east-1",      // Asia Pacific (Hong Kong).
+		"ap-northeast-1", // Asia Pacific (Tokyo).
+		"ap-northeast-2", // Asia Pacific (Seoul).
+		"ap-northeast-3", // Asia Pacific (Osaka).
+		"ap-south-1",     // Asia Pacific (Mumbai).
+		"ap-south-2",     // Asia Pacific (Hyderabad).
+		"ap-southeast-1", // Asia Pacific (Singapore).
+		"ap-southeast-2", // Asia Pacific (Sydney).
+		"ap-southeast-3", // Asia Pacific (Jakarta).
+		"ap-southeast-4", // Asia Pacific (Melbourne).
+		"ca-central-1",   // Canada (Central).
+		"eu-central-1",   // Europe (Frankfurt).
+		"eu-central-2",   // Europe (Zurich).
+		"eu-north-1",     // Europe (Stockholm).
+		"eu-south-1",     // Europe (Milan).
+		"eu-south-2",     // Europe (Spain).
+		"eu-west-1",      // Europe (Ireland).
+		"eu-west-2",      // Europe (London).
+		"eu-west-3",      // Europe (Paris).
+		"il-central-1",   // Israel (Tel Aviv).
+		"me-central-1",   // Middle East (UAE).
+		"me-south-1",     // Middle East (Bahrain).
+		"sa-east-1",      // South America (Sao Paulo).
+		"us-east-1",      // US East (N. Virginia).
+		"us-east-2",      // US East (Ohio).
+		"us-west-1",      // US West (N. California).
+		"us-west-2",      // US West (Oregon).
+	)
+}
+
+// ValidateAwsRegions validates that a list of strings is
+// valid aws regions in the default AWS partition.
+func ValidateAwsRegions(regions ...string) error {
+	validRegions := GetValidAwsRegions()
+
+	for _, region := range regions {
+		if !validRegions.Has(region) {
+			return fmt.Errorf("region \"%s\" is not a valid aws region", region)
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/borderzero/border0-go/types/connector/plugin.go
+++ b/vendor/github.com/borderzero/border0-go/types/connector/plugin.go
@@ -1,5 +1,7 @@
 package connector
 
+import "github.com/borderzero/border0-go/types/common"
+
 const (
 	// PluginTypeAwsEc2Discovery is the plugin type for aws ec2 instance discovery.
 	PluginTypeAwsEc2Discovery = "aws_ec2_discovery"
@@ -30,14 +32,6 @@ type PluginConfiguration struct {
 	NetworkDiscoveryPluginConfiguration    *NetworkDiscoveryPluginConfiguration    `json:"network_discovery_plugin_configuration,omitempty"`
 }
 
-// AwsCredentials represents credentials and configuration for authenticating against AWS APIs.
-type AwsCredentials struct {
-	AwsProfile         *string `json:"aws_profile,omitempty"`
-	AwsAccessKeyId     *string `json:"aws_access_key_id,omitempty"`
-	AwsSecretAccessKey *string `json:"aws_secret_access_key,omitempty"`
-	AwsSessionToken    *string `json:"aws_session_token,omitempty"`
-}
-
 // KubernetesCredentials represents credentials and configuration for authenticating against a Kubernetes API.
 type KubernetesCredentials struct {
 	MasterUrl      *string `json:"master_url,omitempty"`
@@ -46,8 +40,8 @@ type KubernetesCredentials struct {
 
 // BaseAwsPluginConfiguration represents configuration fields shared across all AWS related plugins.
 type BaseAwsPluginConfiguration struct {
-	AwsCredentials *AwsCredentials `json:"aws_credentials,omitempty"`
-	AwsRegions     []string        `json:"aws_regions,omitempty"`
+	AwsCredentials *common.AwsCredentials `json:"aws_credentials,omitempty"`
+	AwsRegions     []string               `json:"aws_regions,omitempty"`
 }
 
 // BaseDiscoveryPluginConfiguration represents configuration fields shared across all discovery related plugins.

--- a/vendor/github.com/borderzero/border0-go/types/service/common.go
+++ b/vendor/github.com/borderzero/border0-go/types/service/common.go
@@ -1,18 +1,15 @@
 package service
 
+import (
+	"fmt"
+
+	"github.com/borderzero/border0-go/lib/types/set"
+)
+
 // HostnameAndPort represents a host and port.
 type HostnameAndPort struct {
 	Hostname string `json:"hostname"`
 	Port     uint16 `json:"port"`
-}
-
-// AwsCredentials represents aws credentials.
-type AwsCredentials struct {
-	AwsAccessKeyId     string `json:"aws_access_key_id"`
-	AwsSecretAccessKey string `json:"aws_secret_access_key"`
-	AwsSessionToken    string `json:"aws_session_token,omitempty"`
-	AwsProfile         string `json:"aws_profile,omitempty"`
-	AwsRegion          string `json:"aws_region,omitempty"`
 }
 
 // UsernameAndPassword represents a username and password. Used for basic auth, for example, MySQL
@@ -28,4 +25,25 @@ type TlsConfig struct {
 	CaCertificate string `json:"ca_certificate"`
 	Certificate   string `json:"certificate"`
 	Key           string `json:"key"`
+}
+
+// validateUsernameWithProvider validates a username_provider, username pair.
+func validateUsernameWithProvider(
+	usernameProvider string,
+	username string,
+	allowedEmptyUserProviders set.Set[string],
+) error {
+	if usernameProvider == UsernameProviderDefined || usernameProvider == "" {
+		if username == "" {
+			return fmt.Errorf("username must be provided when username_provider is \"%s\"", UsernameProviderDefined)
+		}
+		return nil
+	}
+	if !allowedEmptyUserProviders.Has(usernameProvider) {
+		return fmt.Errorf("username_provider %s is not valid", usernameProvider)
+	}
+	if username != "" {
+		return fmt.Errorf("username must be empty when username_provider is %s", usernameProvider)
+	}
+	return nil
 }

--- a/vendor/github.com/borderzero/border0-go/types/service/common.go
+++ b/vendor/github.com/borderzero/border0-go/types/service/common.go
@@ -27,6 +27,17 @@ type TlsConfig struct {
 	Key           string `json:"key"`
 }
 
+// Validate validates the HostnameAndPort.
+func (c *HostnameAndPort) Validate() error {
+	if c.Hostname == "" {
+		return fmt.Errorf("hostname is a required field")
+	}
+	if c.Port == 0 {
+		return fmt.Errorf("port is a required field")
+	}
+	return nil
+}
+
 // validateUsernameWithProvider validates a username_provider, username pair.
 func validateUsernameWithProvider(
 	usernameProvider string,

--- a/vendor/github.com/borderzero/border0-go/types/service/configuration.go
+++ b/vendor/github.com/borderzero/border0-go/types/service/configuration.go
@@ -1,5 +1,11 @@
 package service
 
+import (
+	"fmt"
+
+	"github.com/borderzero/border0-go/lib/types/null"
+)
+
 const (
 	// ServiceTypeDatabase is the service type for database services (fka sockets).
 	ServiceTypeDatabase = "database"
@@ -22,4 +28,61 @@ type Configuration struct {
 	HttpServiceConfiguration     *HttpServiceConfiguration     `json:"http_service_configuration,omitempty"`
 	SshServiceConfiguration      *SshServiceConfiguration      `json:"ssh_service_configuration,omitempty"`
 	TlsServiceConfiguration      *TlsServiceConfiguration      `json:"tls_service_configuration,omitempty"`
+}
+
+// Validate validates the Configuration.
+func (c *Configuration) Validate() error {
+	switch c.ServiceType {
+
+	case ServiceTypeDatabase:
+		if !null.All(c.HttpServiceConfiguration, c.SshServiceConfiguration, c.TlsServiceConfiguration) {
+			return fmt.Errorf("service configuration for service type \"database\" can only have database service configuration defined")
+		}
+		if c.DatabaseServiceConfiguration == nil {
+			return fmt.Errorf("service configuration for service type \"database\" must have database service configuration defined")
+		}
+		if err := c.DatabaseServiceConfiguration.Validate(); err != nil {
+			return fmt.Errorf("invalid database service configuration: %v", err)
+		}
+		return nil
+
+	case ServiceTypeHttp:
+		if !null.All(c.DatabaseServiceConfiguration, c.SshServiceConfiguration, c.TlsServiceConfiguration) {
+			return fmt.Errorf("service configuration for service type \"http\" can only have http service configuration defined")
+		}
+		if c.HttpServiceConfiguration == nil {
+			return fmt.Errorf("service configuration for service type \"http\" must have http service configuration defined")
+		}
+		if err := c.HttpServiceConfiguration.Validate(); err != nil {
+			return fmt.Errorf("invalid http service configuration: %v", err)
+		}
+		return nil
+
+	case ServiceTypeSsh:
+		if !null.All(c.HttpServiceConfiguration, c.DatabaseServiceConfiguration, c.TlsServiceConfiguration) {
+			return fmt.Errorf("service configuration for service type \"ssh\" can only have ssh service configuration defined")
+		}
+		if c.SshServiceConfiguration == nil {
+			return fmt.Errorf("service configuration for service type \"ssh\" must have ssh service configuration defined")
+		}
+		if err := c.SshServiceConfiguration.Validate(); err != nil {
+			return fmt.Errorf("invalid ssh service configuration: %v", err)
+		}
+		return nil
+
+	case ServiceTypeTls:
+		if !null.All(c.HttpServiceConfiguration, c.DatabaseServiceConfiguration, c.SshServiceConfiguration) {
+			return fmt.Errorf("service configuration for service type \"tls\" can only have tls service configuration defined")
+		}
+		if c.TlsServiceConfiguration == nil {
+			return fmt.Errorf("service configuration for service type \"tls\" must have tls service configuration defined")
+		}
+		if err := c.TlsServiceConfiguration.Validate(); err != nil {
+			return fmt.Errorf("invalid tls service configuration: %v", err)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("service configuration has invalid service type \"%s\"", c.ServiceType)
+	}
 }

--- a/vendor/github.com/borderzero/border0-go/types/service/database_service_configuration.go
+++ b/vendor/github.com/borderzero/border0-go/types/service/database_service_configuration.go
@@ -1,5 +1,7 @@
 package service
 
+import "github.com/borderzero/border0-go/types/common"
+
 // Database service types supported by Border0. Choose `standard` for self-managed databases.
 // Use `aws_rds` for AWS RDS databases, and select `google_cloudsql` for Google Cloud SQL databases.
 const (
@@ -226,9 +228,9 @@ type AwsRdsUsernameAndPasswordAuthConfiguration struct {
 // AwsRdsIamAuthConfiguration represents auth configuration for AWS RDS databases that use IAM authentication. You must
 // provide AWS credentials and a username. Optionally AWS CA bundle can be supplied to verify the server's certificate.
 type AwsRdsIamAuthConfiguration struct {
-	AwsCredentials
-	Username      string `json:"username"`
-	CaCertificate string `json:"ca_certificate,omitempty"`
+	AwsCredentials common.AwsCredentials `json:"aws_credentials"`
+	Username       string                `json:"username"`
+	CaCertificate  string                `json:"ca_certificate,omitempty"`
 }
 
 // GoogleCloudSqlUsernameAndPasswordAuthConfiguration represents auth configuration for Google Cloud SQL databases that
@@ -248,4 +250,10 @@ type GoogleCloudSqlIamAuthConfiguration struct {
 	Username           string `json:"username"`
 	InstanceId         string `json:"instance_id"`
 	GcpCredentialsJson string `json:"gcp_credentials_json"`
+}
+
+// Validate validates the DatabaseServiceConfiguration.
+func (c *DatabaseServiceConfiguration) Validate() error {
+	// TODO
+	return nil
 }

--- a/vendor/github.com/borderzero/border0-go/types/service/http_service_configuration.go
+++ b/vendor/github.com/borderzero/border0-go/types/service/http_service_configuration.go
@@ -1,7 +1,33 @@
 package service
 
+const (
+	// HttpServiceTypeStandard is the http
+	// service type for standard http services.
+	HttpServiceTypeStandard = "standard"
+
+	// HttpServiceTypeConnectorFileServer is the http service
+	// type for the connector's built-in file webserver.
+	HttpServiceTypeConnectorFileServer = "connector_file_server"
+)
+
 // HttpServiceConfiguration represents service
 // configuration for http services (fka sockets).
 type HttpServiceConfiguration struct {
+	HttpServiceType string `json:"http_service_type"`
+
+	// mutually exclusive fields below
+	StandardHttpServiceConfiguration   *StandardHttpServiceConfiguration   `json:"standard_http_service_configuration,omitempty"`
+	FileServerHttpServiceConfiguration *FileServerHttpServiceConfiguration `json:"fileserver_http_service_configuration,omitempty"`
+}
+
+// StandardHttpServiceConfiguration represents service
+// configuration for standard http services (fka sockets).
+type StandardHttpServiceConfiguration struct {
 	HostnameAndPort // inherited
+}
+
+// FileServerHttpServiceConfiguration represents service
+// configuration for the connector built-in file webserver.
+type FileServerHttpServiceConfiguration struct {
+	TopLevelDirectory string `json:"top_level_directory,omitempty"`
 }

--- a/vendor/github.com/borderzero/border0-go/types/service/http_service_configuration.go
+++ b/vendor/github.com/borderzero/border0-go/types/service/http_service_configuration.go
@@ -23,11 +23,18 @@ type HttpServiceConfiguration struct {
 // StandardHttpServiceConfiguration represents service
 // configuration for standard http services (fka sockets).
 type StandardHttpServiceConfiguration struct {
-	HostnameAndPort // inherited
+	HostnameAndPort        // inherited
+	HostSniHeader   string `json:"host_sni_header,omitempty"`
 }
 
 // FileServerHttpServiceConfiguration represents service
 // configuration for the connector built-in file webserver.
 type FileServerHttpServiceConfiguration struct {
 	TopLevelDirectory string `json:"top_level_directory,omitempty"`
+}
+
+// Validate validates the HttpServiceConfiguration.
+func (c *HttpServiceConfiguration) Validate() error {
+	// TODO
+	return nil
 }

--- a/vendor/github.com/borderzero/border0-go/types/service/ssh_service_configuration.go
+++ b/vendor/github.com/borderzero/border0-go/types/service/ssh_service_configuration.go
@@ -238,11 +238,8 @@ func (c *SshServiceConfiguration) Validate() error {
 
 // Validate validates the AwsEc2ICSshServiceConfiguration.
 func (c *AwsEc2ICSshServiceConfiguration) Validate() error {
-	if c.HostnameAndPort.Hostname == "" {
-		return fmt.Errorf("hostname is a required field")
-	}
-	if c.HostnameAndPort.Port == 0 {
-		return fmt.Errorf("port is a required field")
+	if err := c.HostnameAndPort.Validate(); err != nil {
+		return err
 	}
 	if c.Ec2InstanceId == "" {
 		return fmt.Errorf("ec2_instance_id is a required field")
@@ -307,11 +304,8 @@ func (c *BuiltInSshServiceConfiguration) Validate() error {
 }
 
 func (c *StandardSshServiceConfiguration) Validate() error {
-	if c.HostnameAndPort.Hostname == "" {
-		return fmt.Errorf("hostname is a required field")
-	}
-	if c.HostnameAndPort.Port == 0 {
-		return fmt.Errorf("port is a required field")
+	if err := c.HostnameAndPort.Validate(); err != nil {
+		return err
 	}
 
 	switch c.SshAuthenticationType {

--- a/vendor/github.com/borderzero/border0-go/types/service/tls_service_configuration.go
+++ b/vendor/github.com/borderzero/border0-go/types/service/tls_service_configuration.go
@@ -28,7 +28,7 @@ type TlsServiceConfiguration struct {
 // StandardTlsServiceConfiguration represents service
 // configuration for standard tls services (fka sockets).
 type StandardTlsServiceConfiguration struct {
-	HostnameAndPort // inherited
+	HostnameAndPort
 }
 
 // VpnTlsServiceConfiguration represents service
@@ -42,4 +42,9 @@ type VpnTlsServiceConfiguration struct {
 // configuration for http proxy services over the tls socket.
 type HttpProxyTlsServiceConfiguration struct {
 	HostAllowlist []string `json:"host_allowlist,omitempty"`
+}
+
+func (c *TlsServiceConfiguration) Validate() error {
+	// TODO
+	return nil
 }

--- a/vendor/github.com/borderzero/border0-go/types/service/tls_service_configuration.go
+++ b/vendor/github.com/borderzero/border0-go/types/service/tls_service_configuration.go
@@ -1,7 +1,45 @@
 package service
 
+const (
+	// TlsServiceTypeStandard is the tls
+	// service type for standard tls services.
+	TlsServiceTypeStandard = "standard"
+
+	// TlsServiceTypeVpn is the tls service
+	// type for the connector's built-in vpn.
+	TlsServiceTypeVpn = "vpn"
+
+	// TlsServiceTypeHttpProxy is the tls service type
+	// for the connector's built-in http (forward) proxy.
+	TlsServiceTypeHttpProxy = "http_proxy"
+)
+
 // TlsServiceConfiguration represents service
 // configuration for tls services (fka sockets).
 type TlsServiceConfiguration struct {
+	TlsServiceType string `json:"tls_service_type,omitempty"`
+
+	// mutually exclusive fields below
+	StandardTlsServiceConfiguration  *StandardTlsServiceConfiguration  `json:"standard_tls_service_configuration,omitempty"`
+	VpnTlsServiceConfiguration       *VpnTlsServiceConfiguration       `json:"vpn_tls_service_configuration,omitempty"`
+	HttpProxyTlsServiceConfiguration *HttpProxyTlsServiceConfiguration `json:"http_proxy_tls_service_configuration,omitempty"`
+}
+
+// StandardTlsServiceConfiguration represents service
+// configuration for standard tls services (fka sockets).
+type StandardTlsServiceConfiguration struct {
 	HostnameAndPort // inherited
+}
+
+// VpnTlsServiceConfiguration represents service
+// configuration for vpn services services over the tls socket.
+type VpnTlsServiceConfiguration struct {
+	VpnSubnet string   `json:"vpn_subnet"`
+	Routes    []string `json:"routes,omitempty"`
+}
+
+// HttpProxyTlsServiceConfiguration represents service
+// configuration for http proxy services over the tls socket.
+type HttpProxyTlsServiceConfiguration struct {
+	HostAllowlist []string `json:"host_allowlist,omitempty"`
 }

--- a/vendor/github.com/borderzero/border0-go/types/service/tls_service_configuration.go
+++ b/vendor/github.com/borderzero/border0-go/types/service/tls_service_configuration.go
@@ -1,5 +1,12 @@
 package service
 
+import (
+	"fmt"
+
+	"github.com/borderzero/border0-go/lib/types/netaddr"
+	"github.com/borderzero/border0-go/lib/types/null"
+)
+
 const (
 	// TlsServiceTypeStandard is the tls
 	// service type for standard tls services.
@@ -44,7 +51,92 @@ type HttpProxyTlsServiceConfiguration struct {
 	HostAllowlist []string `json:"host_allowlist,omitempty"`
 }
 
+// Validate validates the TlsServiceConfiguration.
 func (c *TlsServiceConfiguration) Validate() error {
-	// TODO
+	switch c.TlsServiceType {
+
+	case TlsServiceTypeStandard:
+		if !null.All(c.VpnTlsServiceConfiguration, c.HttpProxyTlsServiceConfiguration) {
+			return fmt.Errorf(
+				"tls service type \"%s\" can only have standard tls service configuration defined",
+				TlsServiceTypeStandard)
+		}
+		if c.StandardTlsServiceConfiguration == nil {
+			return fmt.Errorf(
+				"tls service configuration for tls service type \"%s\" must have standard tls service configuration defined",
+				TlsServiceTypeStandard,
+			)
+		}
+		if err := c.StandardTlsServiceConfiguration.Validate(); err != nil {
+			return fmt.Errorf("invalid standard tls service configuration: %v", err)
+		}
+		return nil
+
+	case TlsServiceTypeVpn:
+		if !null.All(c.StandardTlsServiceConfiguration, c.HttpProxyTlsServiceConfiguration) {
+			return fmt.Errorf(
+				"tls service type \"%s\" can only have vpn tls service configuration defined",
+				TlsServiceTypeVpn)
+		}
+		if c.VpnTlsServiceConfiguration == nil {
+			return fmt.Errorf(
+				"tls service configuration for tls service type \"%s\" must have vpn tls service configuration defined",
+				TlsServiceTypeVpn,
+			)
+		}
+		if err := c.VpnTlsServiceConfiguration.Validate(); err != nil {
+			return fmt.Errorf("invalid vpn tls service configuration: %v", err)
+		}
+		return nil
+
+	case TlsServiceTypeHttpProxy:
+		if !null.All(c.StandardTlsServiceConfiguration, c.VpnTlsServiceConfiguration) {
+			return fmt.Errorf(
+				"tls service type \"%s\" can only have http proxy tls service configuration defined",
+				TlsServiceTypeStandard)
+		}
+		if c.HttpProxyTlsServiceConfiguration == nil {
+			return fmt.Errorf(
+				"tls service configuration for tls service type \"%s\" must have http proxy tls service configuration defined",
+				TlsServiceTypeStandard,
+			)
+		}
+		if err := c.HttpProxyTlsServiceConfiguration.Validate(); err != nil {
+			return fmt.Errorf("invalid http proxy tls service configuration: %v", err)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("tls service configuration has invalid tls service type \"%s\"", c.TlsServiceType)
+	}
+}
+
+// Validate validates the StandardTlsServiceConfiguration.
+func (c *StandardTlsServiceConfiguration) Validate() error {
+	if err := c.HostnameAndPort.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Validate validates the VpnTlsServiceConfiguration.
+func (c *VpnTlsServiceConfiguration) Validate() error {
+	if c.VpnSubnet == "" {
+		return fmt.Errorf("vpn_subnet is a required field")
+	}
+	if !netaddr.IsCIDRv4(c.VpnSubnet) {
+		return fmt.Errorf("vpn_subnet \"%s\" is not valid IPv4 CIDR notation", c.VpnSubnet)
+	}
+	for i, route := range c.Routes {
+		if !netaddr.IsCIDRv4(route) {
+			return fmt.Errorf("routes[%d] (\"%s\") is not valid IPv4 CIDR notation", i, route)
+		}
+	}
+	return nil
+}
+
+// Validate validates the HttpProxyTlsServiceConfiguration.
+func (c *HttpProxyTlsServiceConfiguration) Validate() error {
+	// nothing to validate
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -242,9 +242,10 @@ github.com/aws/smithy-go/waiter
 # github.com/bluele/factory-go v0.0.1
 ## explicit; go 1.15
 github.com/bluele/factory-go/factory
-# github.com/borderzero/border0-go v1.3.3
+# github.com/borderzero/border0-go v1.3.4
 ## explicit; go 1.20
 github.com/borderzero/border0-go/lib/types/maps
+github.com/borderzero/border0-go/lib/types/netaddr
 github.com/borderzero/border0-go/lib/types/null
 github.com/borderzero/border0-go/lib/types/pointer
 github.com/borderzero/border0-go/lib/types/regex

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -242,12 +242,15 @@ github.com/aws/smithy-go/waiter
 # github.com/bluele/factory-go v0.0.1
 ## explicit; go 1.15
 github.com/bluele/factory-go/factory
-# github.com/borderzero/border0-go v1.3.2
+# github.com/borderzero/border0-go v1.3.3
 ## explicit; go 1.20
 github.com/borderzero/border0-go/lib/types/maps
+github.com/borderzero/border0-go/lib/types/null
 github.com/borderzero/border0-go/lib/types/pointer
+github.com/borderzero/border0-go/lib/types/regex
 github.com/borderzero/border0-go/lib/types/set
 github.com/borderzero/border0-go/lib/types/slice
+github.com/borderzero/border0-go/types/common
 github.com/borderzero/border0-go/types/connector
 github.com/borderzero/border0-go/types/service
 # github.com/borderzero/border0-proto v1.0.3

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -242,7 +242,7 @@ github.com/aws/smithy-go/waiter
 # github.com/bluele/factory-go v0.0.1
 ## explicit; go 1.15
 github.com/bluele/factory-go/factory
-# github.com/borderzero/border0-go v1.2.1
+# github.com/borderzero/border0-go v1.3.2
 ## explicit; go 1.20
 github.com/borderzero/border0-go/lib/types/maps
 github.com/borderzero/border0-go/lib/types/pointer


### PR DESCRIPTION
## [[ME-1854](https://mysocket.atlassian.net/browse/ME-1854)] Initial Support for HTTP and TLS Sockets in Connector V2

Introduces support for basic http and tls services with connector v2. Note that the config will need to change to allow for the built-in http webserver and its configuration.

Fixes # (issue)
- part of https://mysocket.atlassian.net/browse/ME-1854

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally with an http socket manually written to the staging db

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1854]: https://mysocket.atlassian.net/browse/ME-1854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ