### PR TITLE
ME-1867: Centos9 Docker based worker for RPM build GH Action

### DIFF
--- a/.github/workflows/build_and_release_rpm_repo.yml
+++ b/.github/workflows/build_and_release_rpm_repo.yml
@@ -55,7 +55,6 @@ jobs:
 
       - name: where am i?
         run: |
-          gpg -k
           pwd
           ls
 
@@ -71,7 +70,7 @@ jobs:
         run: |
           mkdir -p $PWD/rpm
           docker build -t rpm-builder -f .github/docker/Dockerfile .
-          docker run -ti --rm \
+          docker run --rm \
             -v $PWD/bin:/root/bin \
             -v $PWD/rpm:/root/rpm \
             --env FILE_ARCH="amd64" \

--- a/.github/workflows/build_and_release_rpm_repo.yml
+++ b/.github/workflows/build_and_release_rpm_repo.yml
@@ -73,6 +73,7 @@ jobs:
           docker run --rm \
             -v $PWD/bin:/root/bin \
             -v $PWD/rpm:/root/rpm \
+            -v $PWD/CENTOS:/root/CENTOS \
             --env FILE_ARCH="amd64" \
             --env PGP_PRIVATE_KEY="$PGP_PRIVATE_KEY" \
             --env BORDER0_VERSION="$BORDER0_VERSION" \

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 # vendor/
 bin/
 repos/
+deb/
+rpm/
 /mysocketctl_*
 /mysocketctl-go
 /border0_*

--- a/CENTOS/post-install.sh
+++ b/CENTOS/post-install.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+function create_config_file {
+  echo "Creating config file..."
+  echo """
+token: ${BORDER0_CONNECTOR_TOKEN}
+""" >/etc/border0/border0.yaml
+}
+
+function check_and_replace {
+  if [ -f /usr/local/bin/border0 ]; then
+    echo "Replacing /usr/local/bin/border0 with symlink to /usr/bin/border0"
+    rm /usr/local/bin/border0
+    ln -s /usr/bin/border0 /usr/local/bin/border0
+  fi
+}
+
+case "$1" in
+1)
+  # This corresponds to initial installation
+  check_and_replace
+  if [ -n "$BORDER0_CONNECTOR_TOKEN" ]; then
+    border0 connector install --v2 --daemon-only
+    create_config_file
+  else
+    if [ -f /etc/systemd/system/border0.service ]; then
+      echo "Looks like border0.service is already installed."
+      exit 0
+    fi
+    echo "Running Border0 Connector Install."
+    attempts=3
+    while [ $attempts -gt 0 ]; do
+      read -p "Do you want to proceed? (y/n) " choice
+      case "$choice" in
+      y | Y)
+        echo "Running 'border0 connector install --v2'"
+        border0 connector install --v2
+        break
+        ;;
+      n | N)
+        echo "You can always execute 'border0 connector install --v2' to install the connector later."
+        break
+        ;;
+      *)
+        echo -e "Invalid choice. \nYou can always execute 'border0 connector install --v2' to install the connector later."
+        let "attempts--"
+        if [ $attempts -eq 0 ]; then
+          echo "Exceeded maximum number of attempts."
+          break
+        fi
+        continue
+        ;;
+      esac
+    done
+  fi
+  ;;
+2)
+  # This corresponds to upgrade
+  echo "Upgrading Border0 Connector..."
+  if systemctl is-active --quiet border0.service; then
+    echo "Restarting border0.service..."
+    systemctl restart border0.service
+  fi
+  ;;
+0)
+echo "Package is being purged"
+if systemctl is-enabled --quiet border0.service; then systemctl disable border0.service; fi
+if systemctl is-active --quiet border0.service; then systemctl stop border0.service; fi
+if [ -f /etc/systemd/system/border0.service ]; then rm /etc/systemd/system/border0.service; fi
+
+systemctl daemon-reload
+
+if [ -f /usr/local/bin/border0 ]; then rm /usr/local/bin/border0; fi
+if [ -f /usr/bin/border0 ]; then rm /usr/bin/border0; fi
+if [ -d /etc/border0 ]; then rm -rf /etc/border0; fi
+
+;;
+*)
+  echo "Unknown argument: $1"
+  ;;
+esac

--- a/CENTOS/post-uninstall.sh
+++ b/CENTOS/post-uninstall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo "Package is being purged"
+if systemctl is-enabled --quiet border0.service; then systemctl disable border0.service; fi
+if systemctl is-active --quiet border0.service; then systemctl stop border0.service; fi
+if [ -f /etc/systemd/system/border0.service ]; then rm /etc/systemd/system/border0.service; fi
+
+systemctl daemon-reload
+
+if [ -f /usr/local/bin/border0 ]; then rm /usr/local/bin/border0; fi
+if [ -f /usr/bin/border0 ]; then rm /usr/bin/border0; fi
+if [ -d /etc/border0 ]; then rm -rf /etc/border0; fi

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -71,6 +71,7 @@ rpmdev-setuptree
 echo "setting up directories..."
 
 cp $HOME/bin/mysocketctl_linux_${FILE_ARCH} $HOME/rpmbuild/SOURCES/border0
+cp $HOME/CENTOS/post-install.sh  $HOME/rpmbuild/SOURCES/post-install.sh 
 
 # Write the SPEC file
 cat <<EOL >$HOME/rpmbuild/SPECS/border0.spec
@@ -96,16 +97,9 @@ mkdir -p %{buildroot}/usr/bin
 cp %{SOURCE0} %{buildroot}/usr/bin/border0
 chmod +x %{buildroot}/usr/bin/border0
 
-%post
-echo "Post install script received: $1"
-if [ $1 -eq 1 ]; then
-    # This is a fresh install
-    echo "Fresh install script goes here"
-elif [ $1 -eq 2 ]; then
-    # This is an upgrade
-    echo "Upgrading script gpes here"
-fi
+%post -f %{_sourcedir}/post-install.sh 
 
+%postun -f %{_sourcedir}/post-install.sh 
 
 %files
 /usr/bin/border0

--- a/create-rpm-builder.sh
+++ b/create-rpm-builder.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 docker build -t rpm-builder -f .github/docker/Dockerfile .
 
-docker run -ti --rm \
+docker run --rm \
     -v $PWD/bin:/root/bin \
     -v $PWD/rpm:/root/rpm \
+    -v $PWD/CENTOS:/root/CENTOS \
     --env FILE_ARCH="amd64" \
     --env PGP_PRIVATE_KEY="$(gpg --armor --export-secret-keys support@border0.com)" \
     --env BORDER0_VERSION="$(git describe --long --tags)" \


### PR DESCRIPTION
# Description

Final touches for the RPM build logic
fix for docker: process the input device is not a TTY

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

manually from a branch
https://github.com/borderzero/border0-cli/actions/runs/5953845165/job/16149048153
https://github.com/borderzero/border0-cli/actions/runs/5954074296

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
