### PR TITLE
[ME-1881] Fix: Uninstall When Service Stopped

### DIFF
--- a/cmd/connector.go
+++ b/cmd/connector.go
@@ -284,6 +284,11 @@ func connectorInstallAws(cmd *cobra.Command) {
 }
 
 func connectorInstallLocal(cmd *cobra.Command) {
+	// flag validation
+	if !daemonOnly && token != "" {
+		fmt.Printf("\nError: --token can only be populated when --daemon-only is set")
+		os.Exit(1)
+	}
 	if !daemonOnly {
 		loginCmd.Run(cmd, []string{})
 	}

--- a/internal/connector_v2/install/local.go
+++ b/internal/connector_v2/install/local.go
@@ -46,11 +46,6 @@ func RunInstallWizard(
 		return errors.New("service already installed")
 	}
 
-	// flag validation
-	if !daemonOnly && token != "" {
-		return errors.New("--token can only be populated when --daemon-only is set")
-	}
-
 	connectorToken := ""
 	if !daemonOnly {
 		// get the system hostname to derive the connector name off of

--- a/internal/service_daemon/common.go
+++ b/internal/service_daemon/common.go
@@ -22,5 +22,5 @@ func IsInstalled(service Service) (bool, error) {
 		}
 		return false, nil
 	}
-	return strings.Contains(status, "is running"), nil
+	return strings.Contains(status, "is running") || strings.Contains(status, "stopped"), nil
 }


### PR DESCRIPTION
# [[ME-1881](https://mysocket.atlassian.net/browse/ME-1881)] Fix: Uninstall When Service Stopped

Fixes a bug where the connector cannot be uninstalled when the service is stopped.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1881

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested uninstalling with a stopped service

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1881]: https://mysocket.atlassian.net/browse/ME-1881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ