### PR TITLE
ME-1776: adding the PGP signing for RPM repo

### DIFF
--- a/generate-rpm-repo.sh
+++ b/generate-rpm-repo.sh
@@ -9,6 +9,10 @@ echo "GPG key exported to $REPO_DIR/RPM-GPG-KEY"
 createrepo $REPO_DIR
 echo "Repo created in $REPO_DIR"
 
+# sign the repo
+echo "Signing the repo..."
+gpg --detach-sign --armor $REPO_DIR/repodata/repomd.xml
+
 # Generate .repo file
 echo "Generating .repo file..."
 cat <<EOL | tee $REPO_FILE_PATH


### PR DESCRIPTION
# Description

We have forgotten to sign the RPM repo
```
root@b0-opensuse-15:/# sudo zypper refresh
Warning: File 'repomd.xml' from repository 'border0-repo' is unsigned.

    Note: Signing data enables the recipient to verify that no modifications occurred after the data
    were signed. Accepting data with no, wrong or unknown signature can lead to a corrupted system
    and in extreme cases even to a system compromise.

    Note: File 'repomd.xml' is the repositories master index file. It ensures the integrity of the
    whole repo.

    Warning: We can't verify that no one meddled with this file, so it might not be trustworthy
    anymore! You should not continue unless you know it's safe.

File 'repomd.xml' from repository 'border0-repo' is unsigned, continue? [yes/no] (no): yes
```
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested on suse

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
