### PR TITLE
[ME-1872] Handle Static AWS Credentials for Connector V2

### DIFF
--- a/internal/api/models/socket.go
+++ b/internal/api/models/socket.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/borderzero/border0-go/types/common"
 )
 
 const (
@@ -57,6 +59,7 @@ type ConnectorLocalData struct {
 	AWSECSContainers             []string
 	AwsEC2InstanceId             string
 	AWSEC2InstanceConnectEnabled bool
+	AwsCredentials               *common.AwsCredentials
 }
 
 func (c *ConnectorData) Tags() map[string]string {

--- a/internal/connector_v2/upstreamdata/ssh.go
+++ b/internal/connector_v2/upstreamdata/ssh.go
@@ -39,6 +39,7 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForSshServiceAwsEc2Ic(s *models.S
 	s.ConnectorLocalData.AwsEC2InstanceId = config.Ec2InstanceId
 	s.AWSRegion = config.Ec2InstanceRegion
 	s.ConnectorLocalData.AWSEC2InstanceConnectEnabled = true
+	s.ConnectorLocalData.AwsCredentials = config.AwsCredentials
 
 	return nil
 }
@@ -55,8 +56,8 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForSshServiceAwsSsm(s *models.Soc
 		}
 		s.UpstreamType = UpstreamTypeAwsSSM
 		s.ConnectorLocalData.AwsEC2InstanceId = config.AwsSsmEc2TargetConfiguration.Ec2InstanceId
-		s.ConnectorLocalData.AWSRegion = config.AwsSsmEc2TargetConfiguration.Ec2InstanceRegion
 		s.AWSRegion = config.AwsSsmEc2TargetConfiguration.Ec2InstanceRegion
+		s.ConnectorLocalData.AwsCredentials = config.AwsSsmEc2TargetConfiguration.AwsCredentials
 		return nil
 
 	case service.SsmTargetTypeEcs:
@@ -66,9 +67,9 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForSshServiceAwsSsm(s *models.Soc
 
 		s.UpstreamType = UpstreamTypeAwsSSM
 		s.ConnectorLocalData.AWSECSCluster = config.AwsSsmEcsTargetConfiguration.EcsClusterName
-		s.ConnectorLocalData.AWSECSServices = []string{config.AwsSsmEcsTargetConfiguration.EcsServiceName}
-		s.ConnectorLocalData.AWSRegion = config.AwsSsmEcsTargetConfiguration.EcsClusterRegion
 		s.AWSRegion = config.AwsSsmEcsTargetConfiguration.EcsClusterRegion
+		s.ConnectorLocalData.AWSECSServices = []string{config.AwsSsmEcsTargetConfiguration.EcsServiceName}
+		s.ConnectorLocalData.AwsCredentials = config.AwsSsmEcsTargetConfiguration.AwsCredentials
 		return nil
 
 	default:

--- a/internal/sqlauthproxy/handler.go
+++ b/internal/sqlauthproxy/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/borderzero/border0-cli/internal/api/models"
 	"github.com/borderzero/border0-cli/internal/cloudsql"
+	"github.com/borderzero/border0-go/types/common"
 	"go.uber.org/zap"
 )
 
@@ -27,6 +28,7 @@ type Config struct {
 	UpstreamKeyFile  string
 	UpstreamTLS      bool
 	AwsRegion        string
+	AwsCredentials   *common.AwsCredentials
 	DialerFunc       func(context.Context, string, string) (net.Conn, error)
 }
 
@@ -72,6 +74,7 @@ func BuildHandlerConfig(logger *zap.Logger, socket models.Socket) (*Config, erro
 		Password:         socket.ConnectorLocalData.UpstreamPassword,
 		UpstreamType:     socket.UpstreamType,
 		AwsRegion:        socket.ConnectorLocalData.AWSRegion,
+		AwsCredentials:   socket.ConnectorLocalData.AwsCredentials,
 		UpstreamCAFile:   socket.ConnectorLocalData.UpstreamCACertFile,
 		UpstreamCertFile: socket.ConnectorLocalData.UpstreamCertFile,
 		UpstreamKeyFile:  socket.ConnectorLocalData.UpstreamKeyFile,

--- a/internal/sqlauthproxy/mysql.go
+++ b/internal/sqlauthproxy/mysql.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	"github.com/borderzero/border0-cli/internal/border0"
+	"github.com/borderzero/border0-cli/internal/util"
 	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/server"
 	"go.uber.org/zap"
@@ -50,11 +50,10 @@ func newMysqlHandler(c Config) (*mysqlHandler, error) {
 	var options []func(*client.Conn)
 	var awsCredentials aws.CredentialsProvider
 	if c.RdsIam {
-		cfg, err := config.LoadDefaultConfig(context.TODO())
+		cfg, err := util.GetAwsConfig(context.Background(), c.AwsRegion, c.AwsCredentials)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load aws config: %s", err)
+			return nil, fmt.Errorf("failed to initialize AWS client: %v", err)
 		}
-
 		awsCredentials = cfg.Credentials
 	}
 

--- a/internal/sqlauthproxy/postgres.go
+++ b/internal/sqlauthproxy/postgres.go
@@ -15,9 +15,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	"github.com/borderzero/border0-cli/internal/border0"
+	"github.com/borderzero/border0-cli/internal/util"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgproto3/v2"
 	"go.uber.org/zap"
@@ -33,11 +33,10 @@ type postgresHandler struct {
 func newPostgresHandler(c Config) (*postgresHandler, error) {
 	var awsCredentials aws.CredentialsProvider
 	if c.RdsIam {
-		cfg, err := config.LoadDefaultConfig(context.TODO())
+		cfg, err := util.GetAwsConfig(context.Background(), c.AwsRegion, c.AwsCredentials)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load aws config: %s", err)
+			return nil, fmt.Errorf("failed to initialize AWS client: %v", err)
 		}
-
 		awsCredentials = cfg.Credentials
 	}
 

--- a/internal/util/awsconfig.go
+++ b/internal/util/awsconfig.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/borderzero/border0-go/lib/types/pointer"
+	"github.com/borderzero/border0-go/types/common"
+)
+
+// GetAwsConfig builds an aws.Config given some options.
+func GetAwsConfig(
+	ctx context.Context,
+	awsRegion string,
+	creds *common.AwsCredentials,
+) (*aws.Config, error) {
+	opts := []func(*config.LoadOptions) error{}
+
+	if awsRegion != "" {
+		opts = append(opts, config.WithRegion(awsRegion))
+	}
+	if creds != nil {
+		if pointer.ValueOrZero(creds.AwsProfile) != "" {
+			opts = append(opts, config.WithSharedConfigProfile(*creds.AwsProfile))
+		}
+		if pointer.ValueOrZero(creds.AwsAccessKeyId) != "" && pointer.ValueOrZero(creds.AwsSecretAccessKey) != "" {
+			opts = append(opts, config.WithCredentialsProvider(
+				credentials.NewStaticCredentialsProvider(
+					pointer.ValueOrZero(creds.AwsAccessKeyId),
+					pointer.ValueOrZero(creds.AwsSecretAccessKey),
+					pointer.ValueOrZero(creds.AwsSessionToken),
+				),
+			))
+		}
+	}
+
+	awsConfig, err := config.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load aws config: %v", err)
+	}
+
+	return &awsConfig, nil
+}


### PR DESCRIPTION
## [[ME-1872](https://mysocket.atlassian.net/browse/ME-1872)] Handle Static AWS Credentials for Connector V2

Currently, we support overriding AWS credentials for SSM and EC2 Instance Connect (ssh sockets). But we don't pay attention to those credentials in the CLI. 

This change introduces making use of any given AWS credentials.

Fixes # (issue):
- https://mysocket.atlassian.net/browse/ME-1872

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been thoroughly tested against live sockets by providing static credentials.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1872]: https://mysocket.atlassian.net/browse/ME-1872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ