### PR TITLE
[ME-1900] Overrides Support in VarSource library

### DIFF
--- a/lib/varsource/utils.go
+++ b/lib/varsource/utils.go
@@ -1,0 +1,27 @@
+package varsource
+
+import (
+	"fmt"
+	"strings"
+)
+
+func parseVariableDefinitionParts(input string) (string, map[string]string, error) {
+	data := make(map[string]string)
+
+	parts := strings.Split(input, ",")
+	if len(parts) == 0 {
+		return "", nil, fmt.Errorf("invalid input: %s", input)
+	}
+
+	firstValue := parts[0]
+
+	for _, part := range parts[1:] {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			return "", nil, fmt.Errorf("invalid key-value pair: %s", part)
+		}
+		data[kv[0]] = kv[1]
+	}
+
+	return firstValue, data, nil
+}

--- a/lib/varsource/variable_source.go
+++ b/lib/varsource/variable_source.go
@@ -26,7 +26,7 @@ type VariableSource interface {
 // NewDefaultVariableSource returns the default VariableSource implementation.
 func NewDefaultVariableSource() VariableSource {
 	return NewMultipleUpstreamVariableSource(
-		WithTopLevelPrefix("from:"),
+		WithTopLevelPrefix(defaultTopLevelPrefix),
 		WithEnvVariableUpstream(),
 		WithFileVariableUpstream(),
 		WithAWSSSMVariableUpstream(),


### PR DESCRIPTION
## [[ME-1900](https://mysocket.atlassian.net/browse/ME-1900)] Overrides Support in VarSource library

Need to be able to set the region to get an ssm parameter from a different aws region

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1900

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally overriding my token's location with:

```
BORDER0_TOKEN=from:aws:ssm:cool-token,aws_region=us-west-2,aws_profile=dev ./border0 connector start --v2
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1900]: https://mysocket.atlassian.net/browse/ME-1900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ