### PR TITLE
[ME-1898] Add ECS Permissions To Connector Cloud Install CFN

### DIFF
--- a/internal/connector_v2/install/aws_cfn_template.go
+++ b/internal/connector_v2/install/aws_cfn_template.go
@@ -97,6 +97,7 @@ Resources:
               - Effect: Allow
                 Action: 'ssm:StartSession'
                 Resource:
+                  - !Sub 'arn:aws:ecs:*:${AWS::AccountId}:task/*'
                   - !Sub 'arn:aws:ec2:*:${AWS::AccountId}:instance/*'
                   - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:document/AWS-StartSSHSession'
               - Effect: Allow


### PR DESCRIPTION
## [[ME-1898](https://mysocket.atlassian.net/browse/ME-1898)] Add ECS Permissions To Connector Cloud Install CFN

Need to be able to start ssm sessions against ecs tasks too

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1898

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

N/A

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
