### PR TITLE
[ME-1905] Add RDS DB Connect Permissions To Connector V2 CFN

### DIFF
--- a/internal/connector_v2/install/aws_cfn_template.go
+++ b/internal/connector_v2/install/aws_cfn_template.go
@@ -81,6 +81,14 @@ Resources:
                   - 'ssm:GetParameter'
                   - 'ssm:GetParameters'
                 Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Border0TokenSsmParameter}'
+        # Allow generating temporary user credentials for database IAM access.
+        - PolicyName: GenerateTemporaryDatabaseCredsForRds
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: 'rds-db:connect'
+                Resource: !Sub 'arn:aws:rds-db:*:${AWS::AccountId}:dbuser:*'
         # Allow sending public keys to any ec2 instance (for ec2 instance connect).
         - PolicyName: SendSshPublicKeysToEc2Instances
           PolicyDocument:


### PR DESCRIPTION
## [[ME-1905](https://mysocket.atlassian.net/browse/ME-1905)] Add RDS DB Connect Permissions To Connector V2 CFN

Adds the IAM permissions for connector instance to generate temporary user credentials for RDS DBs.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1905

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This was tested against a live AWS environment.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1905]: https://mysocket.atlassian.net/browse/ME-1905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ