### PR TITLE
[ME-1828] Handle TLS Sockets in Connector V2

### DIFF
--- a/internal/connector_v2/upstreamdata/tls.go
+++ b/internal/connector_v2/upstreamdata/tls.go
@@ -12,12 +12,46 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForTlsService(s *models.Socket, c
 		return fmt.Errorf("got tls service with no tls service configuration")
 	}
 
-	// hostname, port := u.fetchVariableFromSource(config.Hostname), int(config.Port)
+	switch config.TlsServiceType {
+	case service.TlsServiceTypeStandard:
+		return u.buildUpstreamDataForTlsServiceStandard(s, config.StandardTlsServiceConfiguration)
+	case service.TlsServiceTypeHttpProxy:
+		return u.buildUpstreamDataForTlsServiceVpn(s, config.VpnTlsServiceConfiguration)
+	case service.TlsServiceTypeVpn:
+		return u.buildUpstreamDataForTlsServiceHttpProxy(s, config.HttpProxyTlsServiceConfiguration)
+	default:
+		return fmt.Errorf("unsupported tls service type: %s", config.TlsServiceType)
+	}
+}
 
-	// s.ConnectorData.TargetHostname = hostname
-	// s.ConnectorData.Port = port
-	// s.TargetHostname = hostname
-	// s.TargetPort = port
+func (u *UpstreamDataBuilder) buildUpstreamDataForTlsServiceStandard(s *models.Socket, config *service.StandardTlsServiceConfiguration) error {
+	if config == nil {
+		return fmt.Errorf("got standard tls service with no standard tls service configuration")
+	}
+
+	hostname, port := config.Hostname, int(config.Port)
+	s.ConnectorData.TargetHostname = hostname
+	s.ConnectorData.Port = port
+	s.TargetHostname = hostname
+	s.TargetPort = port
 
 	return nil
+}
+
+func (u *UpstreamDataBuilder) buildUpstreamDataForTlsServiceVpn(s *models.Socket, config *service.VpnTlsServiceConfiguration) error {
+	if config == nil {
+		return fmt.Errorf("got vpn tls service with no vpn tls service configuration")
+	}
+
+	// FIXME: this needs to be implemented in the proxy config, not just populate here...
+	return fmt.Errorf("VPN TLS services not yet supported by connector v2")
+}
+
+func (u *UpstreamDataBuilder) buildUpstreamDataForTlsServiceHttpProxy(s *models.Socket, config *service.HttpProxyTlsServiceConfiguration) error {
+	if config == nil {
+		return fmt.Errorf("got http proxy tls service with no http proxy tls service configuration")
+	}
+
+	// FIXME: this needs to be implemented in the proxy config, not just populate here...
+	return fmt.Errorf("HTTP PROXY TLS services not yet supported by connector v2")
 }


### PR DESCRIPTION
## [[ME-1828](https://mysocket.atlassian.net/browse/ME-1828)] Handle TLS Sockets in Connector V2

Handle sockets with TLS config in connector v2.
Will tackle HTTP proxy and VPN types separately -- that work is WIP in a different branch.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1828

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally with a TLS socket.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1828]: https://mysocket.atlassian.net/browse/ME-1828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ