### PR TITLE
[NEEDS TESTING] [ME-1918] Use /run instead of /var/run in linux systemd template

### DIFF
--- a/internal/service_daemon/service_daemon.go
+++ b/internal/service_daemon/service_daemon.go
@@ -4,7 +4,9 @@
 package service_daemon
 
 import (
+	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/takama/daemon"
 )
@@ -18,6 +20,18 @@ func New(name, description string) (Service, error) {
 	daemon, err := daemon.New(name, description, deamonType)
 	if err != nil {
 		return nil, err
+	}
+	// the default template for linux has a legacy path...
+	if runtime.GOOS == "linux" {
+		if err = daemon.SetTemplate(
+			strings.ReplaceAll(
+				daemon.GetTemplate(),
+				"/var/run/",
+				"/run/",
+			),
+		); err != nil {
+			return nil, fmt.Errorf("failed to set service template: %v", err)
+		}
 	}
 	return daemon, err
 }


### PR DESCRIPTION
## [[ME-1918](https://mysocket.atlassian.net/browse/ME-1918)] Use /run instead of /var/run in linux systemd template

The library we use to install systemd units references a legacy path. This change replaces it with the recommended path.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1918

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1918]: https://mysocket.atlassian.net/browse/ME-1918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ