### PR TITLE
ME-1879: restart systemd unit after upgrade if it's enabled

### DIFF
--- a/CENTOS/post-install.sh
+++ b/CENTOS/post-install.sh
@@ -3,14 +3,15 @@
 function create_config_file {
   echo "Creating config file..."
   echo """
-token: ${BORDER0_CONNECTOR_TOKEN}
+token: ${BORDER0_TOKEN}
 """ >/etc/border0/border0.yaml
 }
 
 case "$1" in
 1)
-  # This corresponds to initial installation
-  if [ -n "$BORDER0_CONNECTOR_TOKEN" ]; then
+  # New installation
+  echo "Performing new installation."
+  if [ -n "$BORDER0_TOKEN" ]; then
     border0 connector install --v2 --daemon-only
     create_config_file
   else
@@ -18,54 +19,30 @@ case "$1" in
       echo "Looks like border0.service is already installed."
       exit 0
     fi
-    echo "Running Border0 Connector Install."
-    attempts=3
-    while [ $attempts -gt 0 ]; do
-      read -p "Do you want to proceed? (y/n) " choice
-      case "$choice" in
-      y | Y)
-        echo "Running 'border0 connector install --v2'"
-        border0 connector install --v2
-        break
-        ;;
-      n | N)
-        echo "You can always execute 'border0 connector install --v2' to install the connector later."
-        break
-        ;;
-      *)
-        echo -e "Invalid choice. \nYou can always execute 'border0 connector install --v2' to install the connector later."
-        let "attempts--"
-        if [ $attempts -eq 0 ]; then
-          echo "Exceeded maximum number of attempts."
-          break
-        fi
-        continue
-        ;;
-      esac
-    done
+    echo -e "BORDER0_TOKEN is not set.\nPlease run the install manually... \n'border0 connector install --v2'"
   fi
   ;;
 2)
-  # This corresponds to upgrade
+  # Upgrade
   echo "Upgrading Border0 Connector..."
   if systemctl is-active --quiet border0.service; then
     echo "Restarting border0.service..."
     systemctl restart border0.service
+  else
+    echo -e "Looks like border0.service is not running.\nyou can check the status with 'systemctl status border0.service'\nIt can be started with 'systemctl start border0.service'"
   fi
   ;;
 0)
-echo "Package is being purged"
-if systemctl is-enabled --quiet border0.service; then systemctl disable border0.service; fi
-if systemctl is-active --quiet border0.service; then systemctl stop border0.service; fi
-if [ -f /etc/systemd/system/border0.service ]; then rm /etc/systemd/system/border0.service; fi
-
-systemctl daemon-reload
-
-if [ -f /usr/local/bin/border0 ]; then rm /usr/local/bin/border0; fi
-if [ -f /usr/bin/border0 ]; then rm /usr/bin/border0; fi
-if [ -d /etc/border0 ]; then rm -rf /etc/border0; fi
-
-;;
+  # Uninstall
+  echo "Package is being purged"
+  if systemctl is-enabled --quiet border0.service; then systemctl disable border0.service; fi
+  if systemctl is-active --quiet border0.service; then systemctl stop border0.service; fi
+  if [ -f /etc/systemd/system/border0.service ]; then rm /etc/systemd/system/border0.service; fi
+  systemctl daemon-reload
+  if [ -f /usr/local/bin/border0 ]; then rm /usr/local/bin/border0; fi
+  if [ -f /usr/bin/border0 ]; then rm /usr/bin/border0; fi
+  if [ -d /etc/border0 ]; then rm -rf /etc/border0; fi
+  ;;
 *)
   echo "Unknown argument: $1"
   ;;

--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -3,61 +3,60 @@
 function create_config_file {
   echo "Creating config file..."
   echo """
-token: ${BORDER0_CONNECTOR_TOKEN}
+token: ${BORDER0_TOKEN}
 """ >/etc/border0/border0.yaml
 }
 
 case "$1" in
 configure)
-  if [ "$DEBIAN_FRONTEND" = "noninteractive" ]; then
-    echo "Running in non-interactive mode."
-    if [ -n "$BORDER0_CONNECTOR_TOKEN" ]; then
+  if [ -n "$2" ]; then
+    echo "Upgrading Border0 Connector from version $2"
+    if systemctl is-active --quiet border0.service; then
+      echo "Restarting border0.service..."
+      systemctl restart border0.service
+    else
+      echo -e "Looks like border0.service is not running.\nyou can check the status with 'systemctl status border0.service'\nIt can be started with 'systemctl start border0.service'"
+    fi
+  else
+    echo "New installation."
+    if [ "$DEBIAN_FRONTEND" = "noninteractive" ]; then
+      echo "Running in non-interactive mode."
+      if [ -n "$BORDER0_TOKEN" ]; then
+        border0 connector install --v2 --daemon-only
+        create_config_file
+      else
+        echo -e "BORDER0_TOKEN is not set.\nPlease run the install manually... \n'border0 connector install --v2'"
+      fi
+    elif [ -n "$BORDER0_TOKEN" ]; then
       border0 connector install --v2 --daemon-only
       create_config_file
     else
-      echo -e "BORDER0_CONNECTOR_TOKEN is not set.\nPlease run the install manually... \n'border0 connector install --v2'"
-    fi
-  elif [ -n "$BORDER0_CONNECTOR_TOKEN" ]; then
-    border0 connector install --v2 --daemon-only
-    create_config_file
-  else
-    if [ -f /etc/systemd/system/border0.service ]; then
-      echo "Looks like border0.service is already installed."
-      exit 0
-    fi
-    echo "Running Border0 Connector Install."
-    attempts=3
-    while [ $attempts -gt 0 ]; do
-      read -p "Do you want to proceed? (y/n) " choice
-      case "$choice" in
-      y | Y)
-        echo "Running 'border0 connector install --v2'"
-        border0 connector install --v2
-        break
-        ;;
-      n | N)
-        echo "You can always execute 'border0 connector install --v2' to install the connector later."
-        break
-        ;;
-      *)
-        echo -e "Invalid choice. \nYou can always execute 'border0 connector install --v2' to install the connector later."
-        let "attempts--"
-        if [ $attempts -eq 0 ]; then
-          echo "Exceeded maximum number of attempts."
+      echo "Running Border0 Connector Install."
+      attempts=2
+      while [ $attempts -gt 0 ]; do
+        read -p "Do you want to proceed? (y/n) " choice
+        case "$choice" in
+        y | Y)
+          echo "Running 'border0 connector install --v2'"
+          border0 connector install --v2
           break
-        fi
-        continue
-        ;;
-      esac
-    done
-  fi
-
-  ;;
-upgrade)
-  echo "Upgrading Border0 Connector..."
-  if systemctl is-active --quiet border0.service; then
-    echo "Restarting border0.service..."
-    systemctl restart border0.service
+          ;;
+        n | N)
+          echo "You can always execute 'border0 connector install --v2' to install the connector later."
+          break
+          ;;
+        *)
+          echo -e "Invalid choice. \nYou can always execute 'border0 connector install --v2' to install the connector later."
+          let "attempts--"
+          if [ $attempts -eq 0 ]; then
+            echo "Exceeded maximum number of attempts."
+            break
+          fi
+          continue
+          ;;
+        esac
+      done
+    fi
   fi
   ;;
 *)


### PR DESCRIPTION
Fixes # ME-1879

# Description

restarting our service uppon upgrade
we are also covering inactive service during upgrade
RPM does not offer interactive mode

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
on AWS instance
```
root@connector-00-dev-us-east-2:/usr/bin# apt-get upgrade
Reading package lists... Done
Building dependency tree
Reading state information... Done
Calculating upgrade... Done
The following packages will be upgraded:
  border0 
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 24 MB of archives.
After this operation, 7282 kB of additional disk space will be used.
Do you want to continue? [Y/n]
Get:1 https://download.border0.com/deb stable/main amd64 border0 amd64 1.1-444-g7ffb681 [15.3 MB]
...
(Reading database ... 141985 files and directories currently installed.)
Preparing to unpack .../border0_1.1-444-g7ffb681_amd64.deb ...
Unpacking border0 (1.1-444-g7ffb681) over (1.1-438-gee92c2e) ...
Setting up border0 (1.1-444-g7ffb681) ...
Upgrading Border0 Connector from version 1.1-438-gee92c2e
Restarting border0.service...
```
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
