### PR TITLE
fix(ME-1894): use outer tls connection for connectorAuth and inner tls connection for e2e encryption

### DIFF
--- a/cmd/client/tls/tls.go
+++ b/cmd/client/tls/tls.go
@@ -79,7 +79,8 @@ var clientTlsCmd = &cobra.Command{
 				}
 
 				go func() {
-					conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
+					var conn net.Conn
+					conn, err = tls.Dial("tcp", fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
 					if err != nil {
 						fmt.Printf("failed to connect to %s:%d: %s\n", hostname, info.Port, err)
 					}
@@ -96,6 +97,7 @@ var clientTlsCmd = &cobra.Command{
 				}()
 			}
 		} else {
+			var conn net.Conn
 			conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
 			if err != nil {
 				return fmt.Errorf("failed to connect to %s:%d: %w", hostname, info.Port, err)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -871,7 +871,7 @@ func ConnectorAuthConnectWithConn(conn net.Conn, tlsConfig *tls.Config) error {
 	return err
 }
 
-func ConnectorAuthConnectWithConnV2(conn net.Conn, tlsConfig *tls.Config, connectorAuthOnly bool) (*tls.Conn, error) {
+func ConnectorAuthConnectWithConnV2(conn net.Conn, tlsConfig *tls.Config, connectorAuthOnly bool) (net.Conn, error) {
 	connectorConn := tls.Client(conn, tlsConfig)
 	if err := connectorConn.Handshake(); err != nil {
 		return nil, fmt.Errorf("failed to authenticate to connector: %w", err)
@@ -883,9 +883,11 @@ func ConnectorAuthConnectWithConnV2(conn net.Conn, tlsConfig *tls.Config, connec
 			conn.Close()
 			return nil, fmt.Errorf("failed to write to proxy: %w", err)
 		}
-	}
 
-	return connectorConn, nil
+		return conn, nil
+	} else {
+		return connectorConn, nil
+	}
 }
 
 func handleConnection(src net.Conn, dst net.Conn) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -871,23 +871,23 @@ func ConnectorAuthConnectWithConn(conn net.Conn, tlsConfig *tls.Config) error {
 	return err
 }
 
-func ConnectorAuthConnectWithConnV2(conn net.Conn, tlsConfig *tls.Config, connectorAuthOnly bool) (net.Conn, error) {
+func ConnectorAuthConnectWithConnV2(conn net.Conn, tlsConfig *tls.Config, ConnectorAuthenticationEnabled bool) (net.Conn, error) {
 	connectorConn := tls.Client(conn, tlsConfig)
 	if err := connectorConn.Handshake(); err != nil {
 		return nil, fmt.Errorf("failed to authenticate to connector: %w", err)
 	}
 
-	if connectorAuthOnly {
-		_, err := conn.Write([]byte("BORDER0-CLIENT-CONNECTOR-AUTHENTICATED"))
-		if err != nil {
-			conn.Close()
-			return nil, fmt.Errorf("failed to write to proxy: %w", err)
-		}
-
-		return conn, nil
-	} else {
+	if !ConnectorAuthenticationEnabled {
 		return connectorConn, nil
 	}
+
+	_, err := conn.Write([]byte("BORDER0-CLIENT-CONNECTOR-AUTHENTICATED"))
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to write to proxy: %w", err)
+	}
+
+	return conn, nil
 }
 
 func handleConnection(src net.Conn, dst net.Conn) {


### PR DESCRIPTION
# Description

use outer tls connection for connectorAuth and inner tls connection for e2e encryption.

Fixes # (ME-1894)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
