### PR TITLE
[ME-1927] SQL Proxy Can't Handle Special Chars in Username/Password

### DIFF
--- a/internal/sqlauthproxy/postgres.go
+++ b/internal/sqlauthproxy/postgres.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -95,8 +96,16 @@ func newPostgresHandler(c Config) (*postgresHandler, error) {
 		strSslSettings = "?" + strings.Join(sslSettings, "&")
 	}
 
-	dsn := fmt.Sprintf("postgres://%s:%s@%s:%d%s", c.Username, c.Password, c.Hostname, c.Port, strSslSettings)
-	config, err := pgconn.ParseConfig(dsn)
+	config, err := pgconn.ParseConfig(
+		fmt.Sprintf(
+			"postgres://%s:%s@%s:%d%s",
+			url.QueryEscape(c.Username),
+			url.QueryEscape(c.Password),
+			c.Hostname,
+			c.Port,
+			strSslSettings,
+		),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## [[ME-1927](https://mysocket.atlassian.net/browse/ME-1927)] SQL Proxy Can't Handle Special Chars in Username/Password

Even worse than not handling it well is that the error log printed to stdout includes the whole URL...

## Example error:

> This database has been killed - the password below get's ya nothing

```
{"msg":"sql proxy failed","socket_id":"08768891-b309-420a-b753-cc29be4b1710","error":"sqlauthproxy: cannot parse `postgres://postgres:xxxxxx@[[OBFUSCATED_RDS_IDENTIFIER]].us-east-1.rds.amazonaws.com:5432?sslmode=prefer`: failed to parse as URL (parse \"postgres://postgres:[+}[&8wiEaoB%GOMGR]8AyL(b7M2@[[OBFUSCATED_RDS_IDENTIFIER]].us-east-1.rds.amazonaws.com:5432?sslmode=prefer\": net/url: invalid userinfo)"}
```

We use the library https://github.com/jackc/pgconn, similar issue for not handling special characters was opened here https://github.com/jackc/pgconn/issues/18, suggested workaround/fix is to url encode the username/password. Maintainers provide an example here https://go.dev/play/p/mGxMXWo_x9N

Proof of fix working for our example string: https://go.dev/play/p/Ppk4gh-_KnA

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1927

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested against the database that yielded the error above, it succeeded after this change.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1927]: https://mysocket.atlassian.net/browse/ME-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ