### PR TITLE
[WIP] actions: run build and release jobs in parallel

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -4,135 +4,145 @@ run-name: Build and release (${{ github.ref_type }}=${{ github.ref_name }})
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
-    paths:
-      - client/**
-      - cmd/**
-      - internal/**
-      - lib/**
-
-permissions:
-  id-token: write
-  contents: read
-  packages: write
+    #branches: [ main ]
+    #paths:
+    #  - client/**
+    #  - cmd/**
+    #  - internal/**
+    #  - lib/**
 
 jobs:
-  build-and-release:
+  build:
     runs-on: ubuntu-latest
-    env:
-      ENV: "prod"
-      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-
+    strategy:
+      matrix:
+        target: ["windows-amd64", "linux-amd64", "linux-arm64", "linux-arm", "linux-armv6", "linux-386", "darwin-amd64", "darwin-arm64", "openbsd-amd64"]
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.20.7' # The Go version to download (if necessary) and use.
+      - run: go version
+      - name: Print Versions
+        run: |
+           go version
+      - name: Build for ${{ matrix.target }}
+        run: |
+          make moddownload
+          make build-${{ matrix.target }}
+      - name: Figure out border0 file name
+        run: |
+          BORDER0_BIN=${{ matrix.target }}
+          BORDER0_BIN=${BORDER0_BIN/-/_}
+          echo ${BORDER0_BIN}
+          echo "BORDER0_BIN=border0_${BORDER0_BIN}" >> $GITHUB_ENV
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          path: |
+            bin/${{ env.BORDER0_BIN }}
+          retention-days: 1
 
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      ENV: "prod"
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+      - name: List files
+        run: |
+          ls -ahl --color
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: us-east-2
           role-to-assume: ${{ secrets.PROD_BUILD_AND_DEPLOY_ROLE }}
           role-session-name: BuildAndDeploy4border0cli
-          role-duration-seconds: 2400 # 40 minutes
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '1.20.1' # The Go version to download (if necessary) and use.
-      - run: go version
-
+          role-duration-seconds: 900 # 15 minutes
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y python3 python3-boto3
-
-      - name: Print Versions
-        run: |
-           go version
-
       - name: Generate git repo version string
         run: |
           BORDER0_VERSION=$(git describe --long --dirty --tags)
           echo ${BORDER0_VERSION}
           echo "BORDER0_VERSION=${BORDER0_VERSION}" >> $GITHUB_ENV
-
-      - name: where am i?
+      - name: Run make release
         run: |
-          pwd
-          ls
-
-      - name: Run Make release
-        run: |
-          make all
           make release
-          make release-border0
+      #- name: Invalidate CloudFront cache for download.border0.com
+      #  run: |
+      #    aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DISTRIBUTION_ID} --paths "/*"
+      #- name: Login to GitHub Container Registry
+      #  uses: docker/login-action@v2
+      #  with:
+      #    registry: ghcr.io
+      #    username: ${{ github.actor }}
+      #    password: ${{ secrets.GITHUB_TOKEN }}
+      #- name: Configure the image tag variables
+      #  run: |
+      #    BRANCH="${{ github.ref_name }}"
+      #    if [[ "$BRANCH" == "main" ]] ; then RELEASE="latest" ; else RELEASE="rc" ; fi
+      #    echo -e "RELEASE=${RELEASE}\nBRANCH=${BRANCH}" >> $GITHUB_ENV
+      #- name: Build and push
+      #  run: |
+      #    docker buildx create --use
+      #    docker buildx build \
+      #    --platform windows/amd64,darwin/amd64,darwin/arm64,linux/amd64,linux/arm64,linux/arm \
+      #    -t ghcr.io/${{ github.repository_owner }}/border0:${BORDER0_VERSION} \
+      #    -t ghcr.io/${{ github.repository_owner }}/border0:${BRANCH} \
+      #    -t ghcr.io/${{ github.repository_owner }}/border0:${RELEASE} \
+      #    --push .
+      #    docker buildx ls
 
-      - name: Invalidate CloudFront cache for download.border0.com
-        run: |
-          aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DISTRIBUTION_ID} --paths "/*"
+  #trigger-app-build:
+  #  needs: release
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    # cross repo workflow trigger
+  #    # it tells mysocketio/client repo to run build_and_release.yml workflow, which re-download cli and
+  #    # packs the latest cli into the desktop app installer bundles, this trigger does not bump the version,
+  #    # so it only ensures new desktop app downloads include the updated cli binary
+  #    - name: Trigger client repo to rebuild
+  #      uses: actions/github-script@v6
+  #      with:
+  #        github-token: ${{ secrets.CLIENT_REPO_ACTIONS_TOKEN }}
+  #        script: |
+  #          await github.rest.actions.createWorkflowDispatch({
+  #            owner: 'mysocketio',
+  #            repo: 'client',
+  #            workflow_id: 'build_and_release.yml',
+  #            ref: 'main'
+  #          })
 
-      - name: See dist bin directory
-        run: |
-          ls -la bin
-          pwd
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Configure the image tag variables
-        run: |
-          BRANCH="${{ github.ref_name }}"
-          if [[ "$BRANCH" == "main" ]] ; then RELEASE="latest" ; else RELEASE="rc" ; fi
-          echo -e "RELEASE=${RELEASE}\nBRANCH=${BRANCH}" >> $GITHUB_ENV
-
-      - name: Build and push
-        run: |
-          docker buildx create --use
-          docker buildx build \
-          --platform windows/amd64,darwin/amd64,darwin/arm64,linux/amd64,linux/arm64,linux/arm \
-          -t ghcr.io/${{ github.repository_owner }}/border0:${BORDER0_VERSION} \
-          -t ghcr.io/${{ github.repository_owner }}/border0:${BRANCH} \
-          -t ghcr.io/${{ github.repository_owner }}/border0:${RELEASE} \
-          --push .
-          docker buildx ls
-
-  trigger-app-build:
-    needs: build-and-release
-    runs-on: ubuntu-latest
-    steps:
-      # cross repo workflow trigger
-      # it tells mysocketio/client repo to run build_and_release.yml workflow, which re-download cli and
-      # packs the latest cli into the desktop app installer bundles, this trigger does not bump the version,
-      # so it only ensures new desktop app downloads include the updated cli binary
-      - name: Trigger client repo to rebuild
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.CLIENT_REPO_ACTIONS_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'mysocketio',
-              repo: 'client',
-              workflow_id: 'build_and_release.yml',
-              ref: 'main'
-            })
-
-      # cross repo workflow trigger
-      # it tells mysocketio/client repo to run bump_version_and_create_pr.yml workflow, which automatically
-      # bump the version in wails.json, and create a PR, this trigger bumps version in desktop app repo, once
-      # the PR is merged, a new build and release will be triggered, existing users will be notified for the
-      # new version, and new downloads will also include the updated cli binary
-      - name: Trigger client repo to create PR
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.CLIENT_REPO_ACTIONS_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'mysocketio',
-              repo: 'client',
-              workflow_id: 'bump_version_and_create_pr.yml',
-              ref: 'main'
-            })
+  #    # cross repo workflow trigger
+  #    # it tells mysocketio/client repo to run bump_version_and_create_pr.yml workflow, which automatically
+  #    # bump the version in wails.json, and create a PR, this trigger bumps version in desktop app repo, once
+  #    # the PR is merged, a new build and release will be triggered, existing users will be notified for the
+  #    # new version, and new downloads will also include the updated cli binary
+  #    - name: Trigger client repo to create PR
+  #      uses: actions/github-script@v6
+  #      with:
+  #        github-token: ${{ secrets.CLIENT_REPO_ACTIONS_TOKEN }}
+  #        script: |
+  #          await github.rest.actions.createWorkflowDispatch({
+  #            owner: 'mysocketio',
+  #            repo: 'client',
+  #            workflow_id: 'bump_version_and_create_pr.yml',
+  #            ref: 'main'
+  #          })

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOFMT=$(GOCMD)fmt
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
-BINARY_NAME=mysocketctl
+BINARY_NAME=border0
 BUCKET=pub-mysocketctl-bin
 
 DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
@@ -18,81 +18,48 @@ FLAGS := -ldflags "-s -w -X github.com/borderzero/border0-cli/cmd.version=$(VERS
 
 all: lint moddownload test build
 
+# Release for all platforms.
 release:
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_windows_amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_armv6
-	CGO_ENABLED=0 GOOS=linux GOARCH=386 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_386
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_amd64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_arm64
-	CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_openbsd_amd64
-
-	shasum -a 256 ./bin/mysocketctl_darwin_amd64 | awk '{print $$1}' > ./bin/mysocketctl_darwin_amd64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_amd64-sha256-checksum.txt ${BUCKET} darwin_amd64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_amd64 ${BUCKET} darwin_amd64/mysocketctl
-
-	shasum -a 256 ./bin/mysocketctl_darwin_arm64 | awk '{print $$1}' > ./bin/mysocketctl_darwin_arm64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_arm64-sha256-checksum.txt ${BUCKET} darwin_arm64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_arm64 ${BUCKET} darwin_arm64/mysocketctl
-
-	shasum -a 256 ./bin/mysocketctl_openbsd_amd64 | awk '{print $$1}' > ./bin/mysocketctl_openbsd_amd64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_openbsd_amd64-sha256-checksum.txt ${BUCKET} openbsd_amd64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_openbsd_amd64 ${BUCKET} openbsd_amd64/mysocketctl
-
-	shasum -a 256 ./bin/mysocketctl_linux_amd64 | awk '{print $$1}' > ./bin/mysocketctl_linux_amd64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_amd64-sha256-checksum.txt ${BUCKET} linux_amd64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_amd64 ${BUCKET} linux_amd64/mysocketctl
-
-	#This is for Raspberrypi
-	shasum -a 256 ./bin/mysocketctl_linux_arm64 | awk '{print $$1}' > ./bin/mysocketctl_linux_arm64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm64-sha256-checksum.txt ${BUCKET} linux_arm64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm64 ${BUCKET} linux_arm64/mysocketctl
-
-	#This is for Raspberrypi 32bit
-	shasum -a 256 ./bin/mysocketctl_linux_arm | awk '{print $$1}' > ./bin/mysocketctl_linux_arm-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm-sha256-checksum.txt ${BUCKET} linux_arm/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm ${BUCKET} linux_arm/mysocketctl
-
-	#This is for Raspberrypi arm v6 32bit
-	shasum -a 256 ./bin/mysocketctl_linux_armv6 | awk '{print $$1}' > ./bin/mysocketctl_linux_armv6-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_armv6-sha256-checksum.txt ${BUCKET} linux_armv6/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_armv6 ${BUCKET} linux_armv6/mysocketctl
-
-	#This is for 32bit linux
-	shasum -a 256 ./bin/mysocketctl_linux_386 | awk '{print $$1}' > ./bin/mysocketctl_linux_386-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_386-sha256-checksum.txt ${BUCKET} linux_386/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_386 ${BUCKET} linux_386/mysocketctl
-
-	shasum -a 256 ./bin/mysocketctl_windows_amd64 | awk '{print $$1}' > ./bin/mysocketctl_windows_amd64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_windows_amd64-sha256-checksum.txt ${BUCKET} windows_amd64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_windows_amd64 ${BUCKET} windows_amd64/mysocketctl.exe
-
+	# Release for Windows 64bit
+	shasum -a 256 ./windows-amd64/bin/$(BINARY_NAME)_windows_amd64 | awk '{print $$1}' > ./windows-amd64/bin/$(BINARY_NAME)_windows_amd64-sha256-checksum.txt
+	python3 ./s3upload.py ./windows-amd64/bin/$(BINARY_NAME)_windows_amd64-sha256-checksum.txt ${BUCKET} windows_amd64/sha256-checksum.txt
+	python3 ./s3upload.py ./windows-amd64/bin/$(BINARY_NAME)_windows_amd64 ${BUCKET} windows_amd64/$(BINARY_NAME).exe
+	# Release for Linux 64bit
+	shasum -a 256 ./linux-amd64/bin/$(BINARY_NAME)_linux_amd64 | awk '{print $$1}' > ./linux-amd64/bin/$(BINARY_NAME)_linux_amd64-sha256-checksum.txt
+	python3 ./s3upload.py ./linux-amd64/bin/$(BINARY_NAME)_linux_amd64-sha256-checksum.txt ${BUCKET} linux_amd64/sha256-checksum.txt
+	python3 ./s3upload.py ./linux-amd64/bin/$(BINARY_NAME)_linux_amd64 ${BUCKET} linux_amd64/$(BINARY_NAME)
+	# Release for Linux 32bit
+	shasum -a 256 ./linux-386/bin/$(BINARY_NAME)_linux_386 | awk '{print $$1}' > ./linux-386/bin/$(BINARY_NAME)_linux_386-sha256-checksum.txt
+	python3 ./s3upload.py ./linux-386/bin/$(BINARY_NAME)_linux_386-sha256-checksum.txt ${BUCKET} linux_386/sha256-checksum.txt
+	python3 ./s3upload.py ./linux-386/bin/$(BINARY_NAME)_linux_386 ${BUCKET} linux_386/$(BINARY_NAME)
+	# Release for Raspberry Pi 64bit
+	shasum -a 256 ./linux-arm64/bin/$(BINARY_NAME)_linux_arm64 | awk '{print $$1}' > ./linux-arm64/bin/$(BINARY_NAME)_linux_arm64-sha256-checksum.txt
+	python3 ./s3upload.py ./linux-arm64/bin/$(BINARY_NAME)_linux_arm64-sha256-checksum.txt ${BUCKET} linux_arm64/sha256-checksum.txt
+	python3 ./s3upload.py ./linux-arm64/bin/$(BINARY_NAME)_linux_arm64 ${BUCKET} linux_arm64/$(BINARY_NAME)
+	# Release for Raspberry Pi 32bit
+	shasum -a 256 ./linux-arm/bin/$(BINARY_NAME)_linux_arm | awk '{print $$1}' > ./linux-arm/bin/$(BINARY_NAME)_linux_arm-sha256-checksum.txt
+	python3 ./s3upload.py ./linux-arm/bin/$(BINARY_NAME)_linux_arm-sha256-checksum.txt ${BUCKET} linux_arm/sha256-checksum.txt
+	python3 ./s3upload.py ./linux-arm/bin/$(BINARY_NAME)_linux_arm ${BUCKET} linux_arm/$(BINARY_NAME)
+	# Release for Raspberry Pi ARM v6 32bit
+	shasum -a 256 ./linux-armv6/bin/$(BINARY_NAME)_linux_armv6 | awk '{print $$1}' > ./linux-armv6/bin/$(BINARY_NAME)_linux_armv6-sha256-checksum.txt
+	python3 ./s3upload.py ./linux-armv6/bin/$(BINARY_NAME)_linux_armv6-sha256-checksum.txt ${BUCKET} linux_armv6/sha256-checksum.txt
+	python3 ./s3upload.py ./linux-armv6/bin/$(BINARY_NAME)_linux_armv6 ${BUCKET} linux_armv6/$(BINARY_NAME)
+	# Release for Intel Mac
+	shasum -a 256 ./darwin-amd64/bin/$(BINARY_NAME)_darwin_amd64 | awk '{print $$1}' > ./darwin-amd64/bin/$(BINARY_NAME)_darwin_amd64-sha256-checksum.txt
+	python3 ./s3upload.py ./darwin-amd64/bin/$(BINARY_NAME)_darwin_amd64-sha256-checksum.txt ${BUCKET} darwin_amd64/sha256-checksum.txt
+	python3 ./s3upload.py ./darwin-amd64/bin/$(BINARY_NAME)_darwin_amd64 ${BUCKET} darwin_amd64/$(BINARY_NAME)
+	# Release for Apple Silicon Mac
+	shasum -a 256 ./darwin-arm64/bin/$(BINARY_NAME)_darwin_arm64 | awk '{print $$1}' > ./darwin-arm64/bin/$(BINARY_NAME)_darwin_arm64-sha256-checksum.txt
+	python3 ./s3upload.py ./darwin-arm64/bin/$(BINARY_NAME)_darwin_arm64-sha256-checksum.txt ${BUCKET} darwin_arm64/sha256-checksum.txt
+	python3 ./s3upload.py ./darwin-arm64/bin/$(BINARY_NAME)_darwin_arm64 ${BUCKET} darwin_arm64/$(BINARY_NAME)
+	# Release for OpenBSD 64bit
+	shasum -a 256 ./openbsd-amd64/bin/$(BINARY_NAME)_openbsd_amd64 | awk '{print $$1}' > ./openbsd-amd64/bin/$(BINARY_NAME)_openbsd_amd64-sha256-checksum.txt
+	python3 ./s3upload.py ./openbsd-amd64/bin/$(BINARY_NAME)_openbsd_amd64-sha256-checksum.txt ${BUCKET} openbsd_amd64/sha256-checksum.txt
+	python3 ./s3upload.py ./openbsd-amd64/bin/$(BINARY_NAME)_openbsd_amd64 ${BUCKET} openbsd_amd64/$(BINARY_NAME)
+	# Publish the latest version checksum file
 	echo ${VERSION} > latest_version.txt
 	python3 ./s3upload.py latest_version.txt ${BUCKET} latest_version.txt
 	rm latest_version.txt
-
-release-border0:
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_amd64 ${BUCKET} darwin_amd64/border0
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_arm64 ${BUCKET} darwin_arm64/border0
-	python3 ./s3upload.py ./bin/mysocketctl_linux_amd64 ${BUCKET} linux_amd64/border0
-	python3 ./s3upload.py ./bin/mysocketctl_openbsd_amd64 ${BUCKET} openbsd_amd64/border0
-
-	#This is for Raspberrypi
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm64 ${BUCKET} linux_arm64/border0
-
-	#This is for Raspberrypi 32bit
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm ${BUCKET} linux_arm/border0
-
-	#This is for Windows
-	python3 ./s3upload.py ./bin/mysocketctl_windows_amd64 ${BUCKET} windows_amd64/border0.exe
-
-	#This is for Raspberrypi armv6 32bit
-	python3 ./s3upload.py ./bin/mysocketctl_linux_armv6 ${BUCKET} linux_armv6/border0
-
-	#This is for 32bit linux
-	python3 ./s3upload.py ./bin/mysocketctl_linux_386 ${BUCKET} linux_386/border0
 
 moddownload:
 	go mod tidy
@@ -107,27 +74,37 @@ build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) $(FLAGS) -o $(BINARY_NAME) -v
 	cp $(BINARY_NAME) border0
 
-build-all:
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_windows_amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_armv6
-	CGO_ENABLED=0 GOOS=linux GOARCH=386 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_386
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_amd64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_arm64
-	CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_openbsd_amd64
+# Cross compile for all supported platforms in parallel
+build-all: build-windows-amd64 build-linux-amd64 build-linux-arm64 build-linux-arm build-linux-armv6 build-linux-386 build-darwin-amd64 build-darwin-arm64 build-openbsd-amd64
 
-build-linux-multiarch:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_armv6
-	CGO_ENABLED=0 GOOS=linux GOARCH=386 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_386
+build-windows-amd64:
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_windows_amd64
 
 build-linux-amd64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_amd64
 
+build-linux-arm64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm64
+
+build-linux-arm:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm
+
+build-linux-armv6:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_armv6
+
+build-linux-386:
+	CGO_ENABLED=0 GOOS=linux GOARCH=386 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_386
+
+build-darwin-amd64:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_amd64
+
+build-darwin-arm64:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_arm64
+
+build-openbsd-amd64:
+	CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_openbsd_amd64
+
+build-linux-multiarch: build-linux-amd64 build-linux-arm64 build-linux-arm build-linux-armv6 build-linux-386
 
 deb-package-amd64:
 	./build-deb.sh $(VERSION) amd64
@@ -183,7 +160,6 @@ rpm-repository:
 	@echo "Creating repo for RPM"
 	./generate-rpm-repo.sh
 
-
 lint:
 	@echo "running go fmt"
 	$(GOFMT) -w .
@@ -199,4 +175,3 @@ clean:
 run:
 	$(GOBUILD) $(FLAGS) -o $(BINARY_NAME) -v ./...
 	./$(BINARY_NAME)
-


### PR DESCRIPTION
# Description

Run build and release jobs in parallel from:

- github action workflow `build_and_release.yml` so it builds for all platform combinations in different VMs
- `Makefile` jobs like `make build-all` now can be run with `-j` option as `make build-all -j`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested with `Makefile` and github actions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
