### PR TITLE
ME-1938: run build and release jobs in parallel

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -11,84 +11,149 @@ on:
       - internal/**
       - lib/**
 
-permissions:
-  id-token: write
-  contents: read
-  packages: write
-
 jobs:
-  build-and-release:
+  build:
+    name: Build CLI
     runs-on: ubuntu-latest
-    env:
-      ENV: "prod"
-      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-
+    strategy:
+      matrix:
+        target: ["windows-amd64", "linux-amd64", "linux-arm64", "linux-arm", "linux-armv6", "linux-386", "darwin-amd64", "darwin-arm64", "openbsd-amd64"]
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: Print Versions
+        run: |
+           go version
+      - name: Build for ${{ matrix.target }}
+        run: |
+          make moddownload
+          make build-${{ matrix.target }}
+      - name: Figure out border0 file name
+        run: |
+          BORDER0_BIN=${{ matrix.target }}
+          BORDER0_BIN=${BORDER0_BIN/-/_}
+          echo ${BORDER0_BIN}
+          echo "BORDER0_BIN=border0_${BORDER0_BIN}" >> $GITHUB_ENV
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          path: |
+            bin/${{ env.BORDER0_BIN }}
+          retention-days: 1
 
+  release:
+    needs: build
+    name: Release CLI
+    runs-on: ubuntu-latest
+    env:
+      ENV: "prod"
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: List artifacts
+        run: |
+          tree ./artifacts
+      - name: Move to files around
+        run: |
+          mkdir -p ./bin
+          for file in $(find ./artifacts -name "border0_*" -type f); do mv $file ./bin; done
+          tree ./bin
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-region: us-east-2
           role-to-assume: ${{ secrets.PROD_BUILD_AND_DEPLOY_ROLE }}
           role-session-name: BuildAndDeploy4border0cli
-          role-duration-seconds: 2400 # 40 minutes
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '1.20.1' # The Go version to download (if necessary) and use.
-      - run: go version
-
+          role-duration-seconds: 900 # 15 minutes
+          mask-aws-account-id: true
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y python3 python3-boto3
-
-      - name: Print Versions
-        run: |
-           go version
-
       - name: Generate git repo version string
         run: |
           BORDER0_VERSION=$(git describe --long --dirty --tags)
           echo ${BORDER0_VERSION}
           echo "BORDER0_VERSION=${BORDER0_VERSION}" >> $GITHUB_ENV
-
-      - name: where am i?
+      - name: Run make release
         run: |
-          pwd
-          ls
-
-      - name: Run Make release
-        run: |
-          make all
           make release
-          make release-border0
-
       - name: Invalidate CloudFront cache for download.border0.com
         run: |
           aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DISTRIBUTION_ID} --paths "/*"
+      - name: Send slack notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,repo,message,author,ref,job,took # (default: repo,message)
+          job_name: Release CLI
+          custom_payload: |
+            {
+              text: "Continuous Deployment - Border0 CLI",
+              attachments: [{
+                color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+                text: `${process.env.AS_WORKFLOW} - ${process.env.AS_JOB} (${process.env.AS_MESSAGE}) of ${process.env.AS_REPO} @${process.env.AS_REF} by ${process.env.AS_AUTHOR} ${{ job.status }} in ${process.env.AS_TOOK}`,
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+          MATRIX_CONTEXT: ${{ toJson(matrix) }} # required
+        if: always() # pick up events even if the job failed or canceled.
 
-      - name: See dist bin directory
+  docker:
+    needs: build
+    name: Release Docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: List artifacts
         run: |
-          ls -la bin
-          pwd
-
+          tree ./artifacts
+      - name: Move to files around
+        run: |
+          mkdir -p ./bin
+          for file in $(find ./artifacts -name "border0_*" -type f); do mv $file ./bin; done
+          tree ./bin
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Generate git repo version string
+        run: |
+          BORDER0_VERSION=$(git describe --long --dirty --tags)
+          echo ${BORDER0_VERSION}
+          echo "BORDER0_VERSION=${BORDER0_VERSION}" >> $GITHUB_ENV
       - name: Configure the image tag variables
         run: |
           BRANCH="${{ github.ref_name }}"
+          BRANCH=${BRANCH//\//_} # replace slash (/) with underscore (_) in branch name
           if [[ "$BRANCH" == "main" ]] ; then RELEASE="latest" ; else RELEASE="rc" ; fi
           echo -e "RELEASE=${RELEASE}\nBRANCH=${BRANCH}" >> $GITHUB_ENV
-
       - name: Build and push
         run: |
           docker buildx create --use
@@ -99,9 +164,27 @@ jobs:
           -t ghcr.io/${{ github.repository_owner }}/border0:${RELEASE} \
           --push .
           docker buildx ls
+      - name: Send slack notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,repo,message,author,ref,job,took # (default: repo,message)
+          job_name: Release Docker
+          custom_payload: |
+            {
+              text: "Continuous Deployment - Border0 CLI Docker Image",
+              attachments: [{
+                color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+                text: `${process.env.AS_WORKFLOW} - ${process.env.AS_JOB} (${process.env.AS_MESSAGE}) of ${process.env.AS_REPO} @${process.env.AS_REF} by ${process.env.AS_AUTHOR} ${{ job.status }} in ${process.env.AS_TOOK}`,
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+          MATRIX_CONTEXT: ${{ toJson(matrix) }} # required
+        if: always() # pick up events even if the job failed or canceled.
 
   trigger-app-build:
-    needs: build-and-release
+    needs: [release, docker]
     runs-on: ubuntu-latest
     steps:
       # cross repo workflow trigger

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,16 +5,13 @@ jobs:
   test:
     name: unit tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go_version: ["1.20.1"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go_version }}
+          go-version-file: go.mod
       - name: Print version info
         run: |
           which go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM alpine
 ARG TARGETOS TARGETARCH
-COPY ./bin/mysocketctl_${TARGETOS}_${TARGETARCH} /border0
+COPY ./bin/border0_${TARGETOS}_${TARGETARCH} /border0
 RUN chmod ogu+x /border0
 ENTRYPOINT [ "/border0" ]
 CMD ["help"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOFMT=$(GOCMD)fmt
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
-BINARY_NAME=mysocketctl
+BINARY_NAME=border0
 BUCKET=pub-mysocketctl-bin
 
 DATE := $(shell git log -1 --format=%cd --date=format:"%Y%m%d")
@@ -18,81 +18,48 @@ FLAGS := -ldflags "-s -w -X github.com/borderzero/border0-cli/cmd.version=$(VERS
 
 all: lint moddownload test build
 
+# Release for all platforms.
 release:
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_windows_amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_armv6
-	CGO_ENABLED=0 GOOS=linux GOARCH=386 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_386
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_amd64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_arm64
-	CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_openbsd_amd64
-
-	shasum -a 256 ./bin/mysocketctl_darwin_amd64 | awk '{print $$1}' > ./bin/mysocketctl_darwin_amd64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_amd64-sha256-checksum.txt ${BUCKET} darwin_amd64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_amd64 ${BUCKET} darwin_amd64/mysocketctl
-
-	shasum -a 256 ./bin/mysocketctl_darwin_arm64 | awk '{print $$1}' > ./bin/mysocketctl_darwin_arm64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_arm64-sha256-checksum.txt ${BUCKET} darwin_arm64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_arm64 ${BUCKET} darwin_arm64/mysocketctl
-
-	shasum -a 256 ./bin/mysocketctl_openbsd_amd64 | awk '{print $$1}' > ./bin/mysocketctl_openbsd_amd64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_openbsd_amd64-sha256-checksum.txt ${BUCKET} openbsd_amd64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_openbsd_amd64 ${BUCKET} openbsd_amd64/mysocketctl
-
-	shasum -a 256 ./bin/mysocketctl_linux_amd64 | awk '{print $$1}' > ./bin/mysocketctl_linux_amd64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_amd64-sha256-checksum.txt ${BUCKET} linux_amd64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_amd64 ${BUCKET} linux_amd64/mysocketctl
-
-	#This is for Raspberrypi
-	shasum -a 256 ./bin/mysocketctl_linux_arm64 | awk '{print $$1}' > ./bin/mysocketctl_linux_arm64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm64-sha256-checksum.txt ${BUCKET} linux_arm64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm64 ${BUCKET} linux_arm64/mysocketctl
-
-	#This is for Raspberrypi 32bit
-	shasum -a 256 ./bin/mysocketctl_linux_arm | awk '{print $$1}' > ./bin/mysocketctl_linux_arm-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm-sha256-checksum.txt ${BUCKET} linux_arm/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm ${BUCKET} linux_arm/mysocketctl
-
-	#This is for Raspberrypi arm v6 32bit
-	shasum -a 256 ./bin/mysocketctl_linux_armv6 | awk '{print $$1}' > ./bin/mysocketctl_linux_armv6-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_armv6-sha256-checksum.txt ${BUCKET} linux_armv6/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_armv6 ${BUCKET} linux_armv6/mysocketctl
-
-	#This is for 32bit linux
-	shasum -a 256 ./bin/mysocketctl_linux_386 | awk '{print $$1}' > ./bin/mysocketctl_linux_386-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_386-sha256-checksum.txt ${BUCKET} linux_386/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_linux_386 ${BUCKET} linux_386/mysocketctl
-
-	shasum -a 256 ./bin/mysocketctl_windows_amd64 | awk '{print $$1}' > ./bin/mysocketctl_windows_amd64-sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_windows_amd64-sha256-checksum.txt ${BUCKET} windows_amd64/sha256-checksum.txt
-	python3 ./s3upload.py ./bin/mysocketctl_windows_amd64 ${BUCKET} windows_amd64/mysocketctl.exe
-
+	# Release for Windows 64bit
+	shasum -a 256 ./bin/$(BINARY_NAME)_windows_amd64 | awk '{print $$1}' > ./bin/$(BINARY_NAME)_windows_amd64-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_windows_amd64-sha256-checksum.txt ${BUCKET} windows_amd64/sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_windows_amd64 ${BUCKET} windows_amd64/$(BINARY_NAME).exe
+	# Release for Linux 64bit
+	shasum -a 256 ./bin/$(BINARY_NAME)_linux_amd64 | awk '{print $$1}' > ./bin/$(BINARY_NAME)_linux_amd64-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_linux_amd64-sha256-checksum.txt ${BUCKET} linux_amd64/sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_linux_amd64 ${BUCKET} linux_amd64/$(BINARY_NAME)
+	# Release for Linux 32bit
+	shasum -a 256 ./bin/$(BINARY_NAME)_linux_386 | awk '{print $$1}' > ./bin/$(BINARY_NAME)_linux_386-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_linux_386-sha256-checksum.txt ${BUCKET} linux_386/sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_linux_386 ${BUCKET} linux_386/$(BINARY_NAME)
+	# Release for Raspberry Pi 64bit
+	shasum -a 256 ./bin/$(BINARY_NAME)_linux_arm64 | awk '{print $$1}' > ./bin/$(BINARY_NAME)_linux_arm64-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_linux_arm64-sha256-checksum.txt ${BUCKET} linux_arm64/sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_linux_arm64 ${BUCKET} linux_arm64/$(BINARY_NAME)
+	# Release for Raspberry Pi 32bit
+	shasum -a 256 ./bin/$(BINARY_NAME)_linux_arm | awk '{print $$1}' > ./bin/$(BINARY_NAME)_linux_arm-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_linux_arm-sha256-checksum.txt ${BUCKET} linux_arm/sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_linux_arm ${BUCKET} linux_arm/$(BINARY_NAME)
+	# Release for Raspberry Pi ARM v6 32bit
+	shasum -a 256 ./bin/$(BINARY_NAME)_linux_armv6 | awk '{print $$1}' > ./bin/$(BINARY_NAME)_linux_armv6-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_linux_armv6-sha256-checksum.txt ${BUCKET} linux_armv6/sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_linux_armv6 ${BUCKET} linux_armv6/$(BINARY_NAME)
+	# Release for Intel Mac
+	shasum -a 256 ./bin/$(BINARY_NAME)_darwin_amd64 | awk '{print $$1}' > ./bin/$(BINARY_NAME)_darwin_amd64-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_darwin_amd64-sha256-checksum.txt ${BUCKET} darwin_amd64/sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_darwin_amd64 ${BUCKET} darwin_amd64/$(BINARY_NAME)
+	# Release for Apple Silicon Mac
+	shasum -a 256 ./bin/$(BINARY_NAME)_darwin_arm64 | awk '{print $$1}' > ./bin/$(BINARY_NAME)_darwin_arm64-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_darwin_arm64-sha256-checksum.txt ${BUCKET} darwin_arm64/sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_darwin_arm64 ${BUCKET} darwin_arm64/$(BINARY_NAME)
+	# Release for OpenBSD 64bit
+	shasum -a 256 ./bin/$(BINARY_NAME)_openbsd_amd64 | awk '{print $$1}' > ./bin/$(BINARY_NAME)_openbsd_amd64-sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_openbsd_amd64-sha256-checksum.txt ${BUCKET} openbsd_amd64/sha256-checksum.txt
+	python3 ./s3upload.py ./bin/$(BINARY_NAME)_openbsd_amd64 ${BUCKET} openbsd_amd64/$(BINARY_NAME)
+	# Publish the latest version checksum file
 	echo ${VERSION} > latest_version.txt
 	python3 ./s3upload.py latest_version.txt ${BUCKET} latest_version.txt
 	rm latest_version.txt
-
-release-border0:
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_amd64 ${BUCKET} darwin_amd64/border0
-	python3 ./s3upload.py ./bin/mysocketctl_darwin_arm64 ${BUCKET} darwin_arm64/border0
-	python3 ./s3upload.py ./bin/mysocketctl_linux_amd64 ${BUCKET} linux_amd64/border0
-	python3 ./s3upload.py ./bin/mysocketctl_openbsd_amd64 ${BUCKET} openbsd_amd64/border0
-
-	#This is for Raspberrypi
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm64 ${BUCKET} linux_arm64/border0
-
-	#This is for Raspberrypi 32bit
-	python3 ./s3upload.py ./bin/mysocketctl_linux_arm ${BUCKET} linux_arm/border0
-
-	#This is for Windows
-	python3 ./s3upload.py ./bin/mysocketctl_windows_amd64 ${BUCKET} windows_amd64/border0.exe
-
-	#This is for Raspberrypi armv6 32bit
-	python3 ./s3upload.py ./bin/mysocketctl_linux_armv6 ${BUCKET} linux_armv6/border0
-
-	#This is for 32bit linux
-	python3 ./s3upload.py ./bin/mysocketctl_linux_386 ${BUCKET} linux_386/border0
 
 moddownload:
 	go mod tidy
@@ -107,27 +74,37 @@ build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) $(FLAGS) -o $(BINARY_NAME) -v
 	cp $(BINARY_NAME) border0
 
-build-all:
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_windows_amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_armv6
-	CGO_ENABLED=0 GOOS=linux GOARCH=386 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_386
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_amd64
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_arm64
-	CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_openbsd_amd64
+# Cross compile for all supported platforms in parallel
+build-all: build-windows-amd64 build-linux-amd64 build-linux-arm64 build-linux-arm build-linux-armv6 build-linux-386 build-darwin-amd64 build-darwin-arm64 build-openbsd-amd64
 
-build-linux-multiarch:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_amd64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_armv6
-	CGO_ENABLED=0 GOOS=linux GOARCH=386 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_386
+build-windows-amd64:
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_windows_amd64
 
 build-linux-amd64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_amd64
 
+build-linux-arm64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm64
+
+build-linux-arm:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_arm
+
+build-linux-armv6:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_armv6
+
+build-linux-386:
+	CGO_ENABLED=0 GOOS=linux GOARCH=386 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_linux_386
+
+build-darwin-amd64:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_amd64
+
+build-darwin-arm64:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_darwin_arm64
+
+build-openbsd-amd64:
+	CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 go build $(FLAGS) -o ./bin/$(BINARY_NAME)_openbsd_amd64
+
+build-linux-multiarch: build-linux-amd64 build-linux-arm64 build-linux-arm build-linux-armv6 build-linux-386
 
 deb-package-amd64:
 	./build-deb.sh $(VERSION) amd64
@@ -183,7 +160,6 @@ rpm-repository:
 	@echo "Creating repo for RPM"
 	./generate-rpm-repo.sh
 
-
 lint:
 	@echo "running go fmt"
 	$(GOFMT) -w .
@@ -199,4 +175,3 @@ clean:
 run:
 	$(GOBUILD) $(FLAGS) -o $(BINARY_NAME) -v ./...
 	./$(BINARY_NAME)
-


### PR DESCRIPTION
# Description

Run build and release jobs in parallel from:

- github action workflow `build_and_release.yml` so it builds for all platform combinations in different VMs
- `Makefile` jobs like `make build-all` now can be run with `-j` option as `make build-all -j`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested with `Makefile` and github actions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works