### PR TITLE
ME-1938: fix rpm and deb build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,9 @@ moddownload:
 
 build:
 	$(GOBUILD) $(FLAGS) -o $(BINARY_NAME) -v
-	-rm -f border0
-	cp $(BINARY_NAME) border0
 
 build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) $(FLAGS) -o $(BINARY_NAME) -v
-	cp $(BINARY_NAME) border0
 
 # Cross compile for all supported platforms in parallel
 build-all: build-windows-amd64 build-linux-amd64 build-linux-arm64 build-linux-arm build-linux-armv6 build-linux-386 build-darwin-amd64 build-darwin-arm64 build-openbsd-amd64


### PR DESCRIPTION
# Description

Fix broken rpm and deb build since `BINARY_NAME` was changed from `mysocketctl` to `border0`

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested with `make build`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works