### PR TITLE
ME-1938: fix another error from rpm and deb build

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -121,6 +121,11 @@ jobs:
     needs: build
     name: Release Docker
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -12,7 +12,7 @@ mkdir -p border0_${VERSION}_${ARCH}/etc/border0
 mkdir -p border0_${VERSION}_${ARCH}/DEBIAN
 
 echo "Copying files..."
-cp ./bin/mysocketctl_linux_${ARCH} border0_${VERSION}_${ARCH}/usr/bin/border0
+cp ./bin/border0_linux_${ARCH} border0_${VERSION}_${ARCH}/usr/bin/border0
 cp -pvr DEBIAN/* border0_${VERSION}_${ARCH}/DEBIAN/
 
 echo "Creating control file..."

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -70,8 +70,8 @@ fi
 rpmdev-setuptree
 echo "setting up directories..."
 
-cp $HOME/bin/mysocketctl_linux_${FILE_ARCH} $HOME/rpmbuild/SOURCES/border0
-cp $HOME/CENTOS/post-install.sh  $HOME/rpmbuild/SOURCES/post-install.sh 
+cp $HOME/bin/border0_linux_${FILE_ARCH} $HOME/rpmbuild/SOURCES/border0
+cp $HOME/CENTOS/post-install.sh  $HOME/rpmbuild/SOURCES/post-install.sh
 
 # Write the SPEC file
 cat <<EOL >$HOME/rpmbuild/SPECS/border0.spec
@@ -97,9 +97,9 @@ mkdir -p %{buildroot}/usr/bin
 cp %{SOURCE0} %{buildroot}/usr/bin/border0
 chmod +x %{buildroot}/usr/bin/border0
 
-%post -f %{_sourcedir}/post-install.sh 
+%post -f %{_sourcedir}/post-install.sh
 
-%postun -f %{_sourcedir}/post-install.sh 
+%postun -f %{_sourcedir}/post-install.sh
 
 %files
 /usr/bin/border0


### PR DESCRIPTION
# Description

Fix broken rpm and deb build since `BINARY_NAME` was changed from `mysocketctl` to `border0`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested with triggering github action workflow.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works