### PR TITLE
[ME-1942] Migrate LaunchConfiguration to LaunchTemplate (cfn)

### DIFF
--- a/internal/connector_v2/install/aws_cfn_template.go
+++ b/internal/connector_v2/install/aws_cfn_template.go
@@ -165,6 +165,10 @@ Resources:
       MinSize: '1'
       MaxSize: '1'
       DesiredCapacity: '1'
+      Tags:
+        - Key: Name
+          Value: Border0-Connector
+          PropagateAtLaunch: true
       LaunchTemplate:
         LaunchTemplateId: !Ref ConnectorInstanceLaunchTemplate
         Version: !GetAtt ConnectorInstanceLaunchTemplate.LatestVersionNumber

--- a/internal/connector_v2/install/aws_cfn_template.go
+++ b/internal/connector_v2/install/aws_cfn_template.go
@@ -136,22 +136,28 @@ Resources:
       Roles:
         - !Ref ConnectorInstanceRole
 
-  ConnectorInstanceLaunchConfiguration:
-    Type: 'AWS::AutoScaling::LaunchConfiguration'
+  ConnectorInstanceLaunchTemplate:
+    Type: 'AWS::EC2::LaunchTemplate'
     Properties:
-      IamInstanceProfile: !Ref ConnectorInstanceProfile
-      ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64}}'
-      InstanceType: !Ref InstanceType
-      SecurityGroups:
-        - !Ref ConnectorInstanceSecurityGroup
-      AssociatePublicIpAddress: true
-      UserData:
-        Fn::Base64:
-          !Sub |
-            #!/bin/bash -xe
-            sudo curl https://download.border0.com/linux_arm64/border0 -o /usr/local/bin/border0
-            sudo chmod +x /usr/local/bin/border0
-            sudo border0 connector install --v2 --daemon-only --token from:aws:ssm:${Border0TokenSsmParameter}
+      LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Arn: !GetAtt ConnectorInstanceProfile.Arn
+        ImageId: '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64}}'
+        InstanceType: !Ref InstanceType
+        NetworkInterfaces:
+          - DeviceIndex: 0
+            AssociatePublicIpAddress: true
+            DeleteOnTermination: true
+            Groups:
+            - !Ref ConnectorInstanceSecurityGroup
+        UserData:
+          Fn::Base64:
+            !Sub |
+              #!/bin/bash -xe
+              sudo curl https://download.border0.com/linux_arm64/border0 -o /usr/local/bin/border0
+              sudo chmod +x /usr/local/bin/border0
+              sudo border0 connector install --v2 --daemon-only --token from:aws:ssm:${Border0TokenSsmParameter}
 
   ConnectorInstanceAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'
@@ -159,7 +165,9 @@ Resources:
       MinSize: '1'
       MaxSize: '1'
       DesiredCapacity: '1'
-      LaunchConfigurationName: !Ref ConnectorInstanceLaunchConfiguration
+      LaunchTemplate:
+        LaunchTemplateId: !Ref ConnectorInstanceLaunchTemplate
+        Version: !GetAtt ConnectorInstanceLaunchTemplate.LatestVersionNumber
       VPCZoneIdentifier:
         - !Ref SubnetId
       MetricsCollection:


### PR DESCRIPTION
## [[ME-1942](https://mysocket.atlassian.net/browse/ME-1942)] Migrate LaunchConfiguration to LaunchTemplate (cfn)

Migrate LaunchConfiguration to LaunchTemplate (because LaunchConfiguration is deprecating), see https://docs.aws.amazon.com/autoscaling/ec2/userguide/migrate-to-launch-templates.html.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1942

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The connector installer with the new template has been tested.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1942]: https://mysocket.atlassian.net/browse/ME-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ