### PR TITLE
ME-1915: change database config names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.8
 	github.com/aws/session-manager-plugin v0.0.0-20230315220744-7b544e9f381d
 	github.com/bluele/factory-go v0.0.1
-	github.com/borderzero/border0-go v1.3.11
+	github.com/borderzero/border0-go v1.3.13
 	github.com/borderzero/border0-proto v1.0.3
 	github.com/borderzero/discovery v0.1.21
 	github.com/brianvoe/gofakeit v3.18.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bluele/factory-go v0.0.1 h1:Wb3nA5Oe9biPfBJNNtZ9rcsf38jNwJV/2ASShHao8Ug=
 github.com/bluele/factory-go v0.0.1/go.mod h1:M5D/YMEfPK1tzRvy/nj1tb0nfvvNY3d9zmgT66sldu0=
-github.com/borderzero/border0-go v1.3.11 h1:4Qmbcot1FkhTWfZMwFGt7vvOT2Ti40Ca2vZ0iHIXZUM=
-github.com/borderzero/border0-go v1.3.11/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
+github.com/borderzero/border0-go v1.3.13 h1:ov98tsV6Uk5bGoPAYIRqmomHKIOrCxKo7vADlD7kH0o=
+github.com/borderzero/border0-go v1.3.13/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
 github.com/borderzero/border0-proto v1.0.3 h1:I7xj7qsNlVvWD0+h7oin2fZbwNDrK0tiHgnmz2ODPr4=
 github.com/borderzero/border0-proto v1.0.3/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
 github.com/borderzero/discovery v0.1.21 h1:2ILAepf7I5/ot/019QrEA3/EnOrk0efdttQmeR2ozwc=

--- a/internal/connector_v2/upstreamdata/database.go
+++ b/internal/connector_v2/upstreamdata/database.go
@@ -94,8 +94,9 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForDatabaseServiceAwsRds(socket *
 		}
 		socket.ConnectorLocalData.RdsIAMAuth = true
 		socket.ConnectorLocalData.UpstreamTLS = pointer.To(true)
-		socket.ConnectorLocalData.AWSRegion = config.IamAuth.AwsRegion
+		socket.ConnectorLocalData.AWSRegion = config.IamAuth.RdsInstanceRegion
 		socket.ConnectorLocalData.UpstreamUsername = u.fetchVariableFromSource(config.IamAuth.Username)
+		socket.ConnectorLocalData.AwsCredentials = config.IamAuth.AwsCredentials
 		if config.IamAuth.CaCertificate != "" {
 			socket.ConnectorLocalData.UpstreamCACertBlock = []byte(u.fetchVariableFromSource(config.IamAuth.CaCertificate))
 		}

--- a/vendor/github.com/aws/session-manager-plugin/src/sessionmanagerplugin/session/session.go
+++ b/vendor/github.com/aws/session-manager-plugin/src/sessionmanagerplugin/session/session.go
@@ -86,12 +86,12 @@ type Session struct {
 	DisplayMode           sessionutil.DisplayMode
 }
 
-// startSession create the datachannel for session
+//startSession create the datachannel for session
 var startSession = func(session *Session, log log.T) error {
 	return session.Execute(log)
 }
 
-// setSessionHandlersWithSessionType set session handlers based on session subtype
+//setSessionHandlersWithSessionType set session handlers based on session subtype
 var setSessionHandlersWithSessionType = func(session *Session, log log.T) error {
 	// SessionType is set inside DataChannel
 	sessionSubType := SessionRegistry[session.SessionType]
@@ -209,7 +209,7 @@ func ValidateInputAndStartSession(args []string, out io.Writer) {
 	}
 }
 
-// Execute create data channel and start the session
+//Execute create data channel and start the session
 func (s *Session) Execute(log log.T) (err error) {
 	fmt.Fprintf(os.Stdout, "\nStarting session with SessionId: %s\n", s.SessionId)
 

--- a/vendor/github.com/borderzero/border0-go/types/service/database_service_configuration.go
+++ b/vendor/github.com/borderzero/border0-go/types/service/database_service_configuration.go
@@ -64,7 +64,8 @@ const (
 //         - password
 //         - ca_certificate (optional)
 //     - iam auth (when authentication type is iam)
-//         - aws credentials: aws_access_key_id, aws_secret_access_key, aws_region, aws_session_token, aws_profile
+//         - rds_instance_region
+//         - aws credentials: aws_access_key_id, aws_secret_access_key, aws_session_token, aws_profile
 //         - username
 //         - ca_certificate (optional)
 // - google cloud sql (when database service type is gcp_cloudsql)
@@ -450,22 +451,24 @@ func (config AwsRdsUsernameAndPasswordAuthConfiguration) Validate() error {
 // AwsRdsIamAuthConfiguration represents auth configuration for AWS RDS databases that use IAM authentication. You must
 // provide AWS credentials and a username. Optionally AWS CA bundle can be supplied to verify the server's certificate.
 type AwsRdsIamAuthConfiguration struct {
-	AwsCredentials common.AwsCredentials `json:"aws_credentials"`
-	AwsRegion      string                `json:"aws_region"`
-	Username       string                `json:"username"`
-	CaCertificate  string                `json:"ca_certificate,omitempty"`
+	AwsCredentials    *common.AwsCredentials `json:"aws_credentials,omitempty"`
+	RdsInstanceRegion string                 `json:"rds_instance_region"`
+	Username          string                 `json:"username"`
+	CaCertificate     string                 `json:"ca_certificate,omitempty"`
 }
 
 // Validate ensures that the `AwsRdsIamAuthConfiguration` has the required field and that the AWS credentials are valid.
 func (config AwsRdsIamAuthConfiguration) Validate() error {
-	if config.AwsRegion == "" {
-		return errors.New("AWS region is required")
+	if config.RdsInstanceRegion == "" {
+		return errors.New("AWS RDS instance region is required")
 	}
 	if config.Username == "" {
 		return errors.New("username is required")
 	}
-	if err := config.AwsCredentials.Validate(); err != nil {
-		return fmt.Errorf("invalid AWS credentials: %w", err)
+	if config.AwsCredentials != nil {
+		if err := config.AwsCredentials.Validate(); err != nil {
+			return fmt.Errorf("invalid AWS credentials: %w", err)
+		}
 	}
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -242,7 +242,7 @@ github.com/aws/smithy-go/waiter
 # github.com/bluele/factory-go v0.0.1
 ## explicit; go 1.15
 github.com/bluele/factory-go/factory
-# github.com/borderzero/border0-go v1.3.11
+# github.com/borderzero/border0-go v1.3.13
 ## explicit; go 1.20
 github.com/borderzero/border0-go/lib/types/maps
 github.com/borderzero/border0-go/lib/types/netaddr


### PR DESCRIPTION
# Description

Change upstream database config names:

- Change AWS RDS IAM auth `AwsRegion` to `RdsInstanceRegion`
- Change AWS RDS IAM auth `AwsCredentials` to pointer/optional

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works