### PR TITLE
[ME-1877] Infer Connector Version In Start/Install, Expose V2

### DIFF
--- a/CENTOS/post-install.sh
+++ b/CENTOS/post-install.sh
@@ -12,14 +12,14 @@ case "$1" in
   # New installation
   echo "Performing new installation."
   if [ -n "$BORDER0_TOKEN" ]; then
-    border0 connector install --v2 --daemon-only
+    border0 connector install --daemon-only
     create_config_file
   else
     if [ -f /etc/systemd/system/border0.service ]; then
       echo "Looks like border0.service is already installed."
       exit 0
     fi
-    echo -e "BORDER0_TOKEN is not set.\nPlease run the install manually... \n'border0 connector install --v2'"
+    echo -e "BORDER0_TOKEN is not set.\nPlease run the install manually... \n'border0 connector install'"
   fi
   ;;
 2)

--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -22,13 +22,13 @@ configure)
     if [ "$DEBIAN_FRONTEND" = "noninteractive" ]; then
       echo "Running in non-interactive mode."
       if [ -n "$BORDER0_TOKEN" ]; then
-        border0 connector install --v2 --daemon-only
+        border0 connector install --daemon-only
         create_config_file
       else
-        echo -e "BORDER0_TOKEN is not set.\nPlease run the install manually... \n'border0 connector install --v2'"
+        echo -e "BORDER0_TOKEN is not set.\nPlease run the install manually... \n'border0 connector install'"
       fi
     elif [ -n "$BORDER0_TOKEN" ]; then
-      border0 connector install --v2 --daemon-only
+      border0 connector install --daemon-only
       create_config_file
     else
       echo "Running Border0 Connector Install."
@@ -37,16 +37,16 @@ configure)
         read -p "Do you want to proceed? (y/n) " choice
         case "$choice" in
         y | Y)
-          echo "Running 'border0 connector install --v2'"
-          border0 connector install --v2
+          echo "Running 'border0 connector install'"
+          border0 connector install
           break
           ;;
         n | N)
-          echo "You can always execute 'border0 connector install --v2' to install the connector later."
+          echo "You can always execute 'border0 connector install' to install the connector later."
           break
           ;;
         *)
-          echo -e "Invalid choice. \nYou can always execute 'border0 connector install --v2' to install the connector later."
+          echo -e "Invalid choice. \nYou can always execute 'border0 connector install' to install the connector later."
           let "attempts--"
           if [ $attempts -eq 0 ]; then
             echo "Exceeded maximum number of attempts."

--- a/cmd/connector.go
+++ b/cmd/connector.go
@@ -9,15 +9,12 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"os/user"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"syscall"
 	"time"
 
-	"github.com/borderzero/border0-cli/internal/api/models"
 	"github.com/borderzero/border0-cli/internal/connector"
 	"github.com/borderzero/border0-cli/internal/connector/config"
 	"github.com/borderzero/border0-cli/internal/connector_v2/install"
@@ -54,18 +51,7 @@ var (
 // hidden variables used for connector v2 only
 var token string
 var daemonOnly bool
-var v2 bool
 var connectorId string
-
-type TemplateConnectorConfig struct {
-	Connector struct {
-		Name string `yaml:"name"`
-	} `yaml:"connector"`
-	Credentials struct {
-		Token string `yaml:"token"`
-	} `yaml:"credentials"`
-	Sockets []map[string]Socket `yaml:"sockets"`
-}
 
 type Socket struct {
 	Type      string `yaml:"type"`
@@ -133,24 +119,6 @@ func displayServiceStatus(serviceName string) {
 	}
 }
 
-func makeConfigPath() string {
-	if runtime.GOOS == "windows" {
-		u, err := user.Current()
-		if err != nil {
-			log.Fatal(err)
-		}
-		homedir := u.HomeDir
-		serviceConfigPath = filepath.Join(homedir, "border0")
-	}
-
-	// check if serviceConfigPath exists and create it if not
-	if _, err := os.Stat(serviceConfigPath); os.IsNotExist(err) {
-		os.MkdirAll(serviceConfigPath, 0755)
-	}
-
-	return filepath.Join(serviceConfigPath, defaultConfigFileName)
-}
-
 var connectorStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "start the connector in foreground ad-hoc mode",
@@ -159,6 +127,52 @@ var connectorStartCmd = &cobra.Command{
 		defer log.Sync()
 
 		SetRlimit()
+
+		v2 := false
+
+		var configPath string
+		configPathFromEnv := os.Getenv("BORDER0_CONFIG_FILE")
+		// check if the config file is provided as a flag or environment variable
+		if connectorConfig != "" {
+			configPath = connectorConfig
+		} else if configPathFromEnv != "" {
+			configPath = configPathFromEnv
+		} else {
+			// check if defaultConfigFileName "border0.yaml" exists in the current directory
+			// if not check if it exists in the serviceConfigPath directory
+			if _, err := os.Stat(defaultConfigFileName); err == nil {
+				configPath = filepath.Join(defaultConfigFileName)
+				log.Info("using config file in the current directory", zap.String("config_path", configPath))
+			} else if _, err := os.Stat(serviceConfigPath + defaultConfigFileName); err == nil {
+				configPath = filepath.Join(serviceConfigPath + defaultConfigFileName)
+				log.Info("using config file in the service config directory", zap.String("config_path", configPath))
+			} else {
+				log.Debug("no legacy connector config found, defaulting to connector v2", zap.String("error", err.Error()))
+				v2 = true
+			}
+		}
+
+		parser := config.NewConfigParser()
+
+		var cfg *config.Config
+		if !v2 {
+			log.Info("reading the config", zap.String("config_path", configPath))
+
+			parsedCfg, err := parser.Parse(configPath)
+			if err == nil && parsedCfg != nil {
+				cfg = parsedCfg
+			}
+			if err != nil {
+				log.Debug("failed to parse legacy connector config, defaulting to connector v2", zap.String("error", err.Error()))
+				v2 = true
+			}
+			if !v2 {
+				if err := cfg.Validate(); err != nil {
+					log.Debug("failed to validate legacy connector config, defaulting to connector v2", zap.String("error", err.Error()))
+					v2 = true
+				}
+			}
+		}
 
 		if v2 {
 			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
@@ -173,28 +187,17 @@ var connectorStartCmd = &cobra.Command{
 			}
 
 			connectorv2.NewConnectorService(ctx, log, version, config).Start()
-		} else {
-			var configPath string
-			configPathFromEnv := os.Getenv("BORDER0_CONFIG_FILE")
+			return
+		}
 
-			// check if the config file is provided as a flag or environment variable
-			if connectorConfig != "" {
-				configPath = connectorConfig
+		svc, err := config.StartSSMSession(cfg)
+		if err != nil {
+			log.Error("failed to start ssm session", zap.String("error", err.Error()))
+		}
 
-			} else if configPathFromEnv != "" {
-				configPath = configPathFromEnv
-			} else {
-				// check if defaultConfigFileName "border0.yaml" exists in the current directory
-				// if not check if it exists in the serviceConfigPath directory
-				if _, err := os.Stat(defaultConfigFileName); err == nil {
-					configPath = filepath.Join(defaultConfigFileName)
-					log.Info("using config file in the current directory", zap.String("config_path", configPath))
-				} else if _, err := os.Stat(serviceConfigPath + defaultConfigFileName); err == nil {
-					configPath = filepath.Join(serviceConfigPath + defaultConfigFileName)
-					log.Info("using config file in the service config directory", zap.String("config_path", configPath))
-				} else {
-					log.Fatal("no default " + defaultConfigFileName + " config file found, neither in the current directory nor in '" + serviceConfigPath + "' please specify a config file with the --config flag")
-				}
+		if svc != nil {
+			if err := parser.LoadSSMInConfig(svc, cfg); err != nil {
+				log.Error("failed to load ssm config", zap.String("error", err.Error()))
 			}
 
 			parser := config.NewConfigParser()
@@ -218,33 +221,10 @@ var connectorStartCmd = &cobra.Command{
 				if err := parser.LoadSSMInConfig(svc, cfg); err != nil {
 					log.Error("failed to load ssm config", zap.String("error", err.Error()))
 				}
+			}
 
-				parser := config.NewConfigParser()
-
-				log.Info("reading the config", zap.String("config_path", configPath))
-				cfg, err := parser.Parse(configPath)
-				if err != nil {
-					log.Fatal("failed to parse config", zap.String("error", err.Error()))
-				}
-
-				if err := cfg.Validate(); err != nil {
-					log.Fatal("failed to validate config", zap.String("error", err.Error()))
-				}
-
-				svc, err := config.StartSSMSession(cfg)
-				if err != nil {
-					log.Error("failed to start ssm session", zap.String("error", err.Error()))
-				}
-
-				if svc != nil {
-					if err := parser.LoadSSMInConfig(svc, cfg); err != nil {
-						log.Error("failed to load ssm config", zap.String("error", err.Error()))
-					}
-				}
-
-				if err := connector.NewConnectorService(*cfg, log, version).Start(); err != nil {
-					log.Error("failed to start connector", zap.String("error", err.Error()))
-				}
+			if err := connector.NewConnectorService(*cfg, log, version).Start(); err != nil {
+				log.Error("failed to start connector", zap.String("error", err.Error()))
 			}
 		}
 	},
@@ -313,169 +293,11 @@ var connectorInstallCmd = &cobra.Command{
 	Use:   "install",
 	Short: "install the connector service on the machine",
 	Run: func(cmd *cobra.Command, args []string) {
-
-		if v2 {
-			if aws {
-				connectorInstallAws(cmd)
-				return
-			}
-			connectorInstallLocal(cmd)
+		if aws {
+			connectorInstallAws(cmd)
 			return
 		}
-
-		if !util.RunningAsAdministrator() {
-			log.Println("Error: command must be ran as system administrator")
-			os.Exit(1)
-		}
-		service, err := service_daemon.New(serviceName, serviceDescription)
-		if err != nil {
-			log.Println("Error: ", err)
-			os.Exit(1)
-		}
-		installed, err := service_daemon.IsInstalled(service)
-		if err != nil {
-			log.Printf("Error: failed to check whether service is already installed: %v", err)
-			os.Exit(1)
-		}
-		if installed {
-			log.Println("Service already installed")
-			os.Exit(1)
-		}
-
-		disableBrowser = true
-		loginCmd.Run(cmd, []string{})
-
-		client, err := http.NewClient()
-		if err != nil {
-			log.Fatalf("Error: %v", err)
-		}
-
-		hostname, err := util.GetFormattedHostname()
-		if err != nil {
-			log.Fatalf("Error: %v", err)
-		}
-
-		now := time.Now()
-		oneYearLater := now.AddDate(1, 0, 0)
-		oneYearFromNow := oneYearLater.Unix()
-
-		tokenName := fmt.Sprintf("Connector %s", hostname)
-		// s := models.Socket{}
-		t := models.Token{}
-		newToken := &models.Token{
-			Name:      tokenName,
-			Role:      "connector",
-			ExpiresAt: oneYearFromNow,
-		}
-		err = client.WithVersion(version).Request("POST", "organizations/tokens", &t, newToken)
-		if err != nil {
-			log.Fatalf(fmt.Sprintf("Error: %v", err))
-		}
-
-		configPath := makeConfigPath()
-
-		// staging with setting the new socket name
-		socketName := hostname
-		// function to check if the socket name exists
-		socketExists := func(name string) bool {
-			err := client.Request("GET", "socket/"+name, &models.Socket{}, nil)
-			return err == nil
-		}
-
-		// now we check if the socketName socket exists
-		err = client.Request("GET", "socket/"+socketName, &models.Socket{}, nil)
-		if err == nil {
-			// ask user to provide a new socket name
-			fmt.Printf("Socket '%s' already exists.\n", socketName)
-			socketName = fmt.Sprintf("%s-%s", hostname, randString(5))
-			fmt.Printf("Provide a new socket name, eg: '%s'? :", socketName)
-			reader := bufio.NewReader(os.Stdin)
-			text, _ := reader.ReadString('\n')
-			text = strings.TrimSpace(text)
-			if len(text) != 0 {
-				text = strings.TrimSpace(text)
-				text = strings.ToLower(text) // Convert the input text to lowercase
-				validInput := regexp.MustCompile(`^[a-zA-Z0-9-]{3,}$`)
-				if !validInput.MatchString(text) {
-					fmt.Printf("I got '%v', that looks invalid. Using randomized name.\n", socketName)
-				} else {
-					socketName = text
-				}
-			}
-			// let's check if the socket already exists
-			if !socketExists(socketName) {
-				fmt.Printf("Using '%s' as socket name.\n", socketName)
-			} else {
-				fmt.Println("Generating randomized name.")
-				socketName = fmt.Sprintf("%s-%s", hostname, randString(5))
-			}
-		}
-
-		// we are going to generate out template connector config yaml file
-		config := TemplateConnectorConfig{}
-		config.Connector.Name = fmt.Sprintf("%s-cntr", strings.ToLower(hostname))
-		config.Credentials.Token = t.Token
-
-		sshServerSocket := Socket{
-			Type:      "ssh",
-			SSHServer: true,
-		}
-		config.Sockets = append(config.Sockets, map[string]Socket{socketName: sshServerSocket})
-
-		yamlData, err := yaml.Marshal(&config)
-		if err != nil {
-			log.Fatalf("Error marshaling YAML data: %v", err)
-		}
-
-		// Now we write the file
-		f, err := os.Create(configPath)
-		if err != nil {
-			log.Fatalf("error: %v", err)
-		}
-		defer f.Close()
-		_, err = f.WriteString(string(yamlData))
-		if err != nil {
-			log.Fatalf("error: %v", err)
-		}
-		// now we set the permissions to 0644
-		if err := os.Chmod(configPath, 0644); err != nil {
-			log.Fatalf("error: %v", err)
-		}
-
-		// Now we install the service
-		installResult, err := service.Install("connector", "start", "--config", configPath)
-		if err != nil {
-			log.Fatalf("error: %v %v", installResult, err)
-		}
-		fmt.Println("\n", installResult)
-		// Also start the service
-		startResult, err := service.Start()
-		if err != nil {
-			log.Fatalf("error: %v %v", startResult, err)
-		}
-		fmt.Println(startResult)
-
-		attempts := 10
-		var socket *models.Socket
-		for i := 0; i < attempts; i++ {
-			// lets check if the socket exists
-			err = client.Request("GET", "socket/"+socketName, &socket, nil)
-			if err == nil {
-				// socket exists
-				break
-			}
-			fmt.Println("Waiting for socket to be created...")
-			time.Sleep(2 * time.Second)
-		}
-		// now lets get the socket
-
-		if socket == nil {
-			log.Fatalf("Error: failed to get newly created socket after %d attempts", attempts)
-		}
-
-		socketURL := fmt.Sprintf("https://client.border0.com/#/ssh/%s", socket.Dnsname)
-		printThis := fmt.Sprintf("\n🚀 Service started successfully.\nYou can now connect to this machine using the following url: \n%s", socketURL)
-		fmt.Println(printThis)
+		connectorInstallLocal(cmd)
 	},
 }
 
@@ -582,20 +404,10 @@ var connectorStatusCmd = &cobra.Command{
 
 func init() {
 	connectorStartCmd.Flags().StringVarP(&connectorConfig, "config", "f", "", "yaml configuration file for connector service, see https://docs.border0.com for more info")
-	connectorStartCmd.Flags().BoolVarP(&v2, "v2", "", false, "use connector v2")
 	connectorStartCmd.Flags().StringVarP(&connectorId, "connector-id", "", "", "connector id to use with connector control stream")
-	connectorInstallCmd.Flags().BoolVarP(&v2, "v2", "", false, "use connector v2")
 	connectorInstallCmd.Flags().BoolVarP(&aws, "aws", "", false, "true to run the connector installation wizard for AWS")
 	connectorInstallCmd.Flags().BoolVarP(&daemonOnly, "daemon-only", "d", false, "Install the daemon only, do not create connector")
 	connectorInstallCmd.Flags().StringVarP(&token, "token", "t", "", "Border0 token for use by the installed connector")
-
-	// hide connector v2 related flags for now
-	connectorStartCmd.Flag("v2").Hidden = true
-	connectorStartCmd.Flag("connector-id").Hidden = true
-	connectorInstallCmd.Flag("v2").Hidden = true
-	connectorInstallCmd.Flag("aws").Hidden = true
-	connectorInstallCmd.Flag("daemon-only").Hidden = true
-	connectorInstallCmd.Flag("token").Hidden = true
 
 	connectorCmd.AddCommand(connectorStartCmd)
 	connectorCmd.AddCommand(connectorStopCmd)

--- a/internal/connector_v2/config/config.go
+++ b/internal/connector_v2/config/config.go
@@ -24,7 +24,7 @@ const (
 
 	envNameAndValueDelimeter = "="
 
-	defaultCredentialsFilePath = ".border0/config.yml"
+	defaultCredentialsFilePath = ".border0/config.yaml"
 
 	defaultConnectorServer = "capi.border0.com:443"
 	defaultTunnelServer    = "tunnel.border0.com"

--- a/internal/connector_v2/install/aws_cfn_template.go
+++ b/internal/connector_v2/install/aws_cfn_template.go
@@ -157,7 +157,7 @@ Resources:
               #!/bin/bash -xe
               sudo curl https://download.border0.com/linux_arm64/border0 -o /usr/local/bin/border0
               sudo chmod +x /usr/local/bin/border0
-              sudo border0 connector install --v2 --daemon-only --token from:aws:ssm:${Border0TokenSsmParameter}
+              sudo border0 connector install --daemon-only --token from:aws:ssm:${Border0TokenSsmParameter}
 
   ConnectorInstanceAutoScalingGroup:
     Type: 'AWS::AutoScaling::AutoScalingGroup'

--- a/internal/connector_v2/install/local.go
+++ b/internal/connector_v2/install/local.go
@@ -92,7 +92,7 @@ func RunInstallWizard(
 	}
 
 	// Now we install the service
-	installResult, err := service.Install("connector", "start", "--v2", "--config", configFile)
+	installResult, err := service.Install("connector", "start", "--config", configFile)
 	if err != nil {
 		return fmt.Errorf("failed to install service: %v", err)
 	}


### PR DESCRIPTION
## [[ME-1877](https://mysocket.atlassian.net/browse/ME-1877)] Infer Connector Version In Start/Install, Expose V2

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1877

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## (1) When you have a valid **legacy** connector config file

With the following **valid** config in the right place:

<details>

```
11:33 $ cat /etc/border0/border0.yaml
connector:
   name: "my-awesome-connector"
   aws-region: "us-east-1"

credentials:
   token: [[ HIDDEN TOKEN ]]

sockets:
   - ssh-connector-lab:
       port: 22
       host: 127.0.0.1
       type: ssh
       sshserver: true
```

</details>

```
✔ ~/go/src/github.com/borderzero/border0-cli [ME-1877_v2_installer_as_default|✔]
11:31 $ AWS_PROFILE=demo BORDER0_LOG_LEVEL=debug BORDER0_TOKEN=$(cat ~/.border0/token) ./border0 connector start --connector-id 8f31bb64-6077-4540-b031-2b907d44ef9d
{"level":"info","ts":"2023-09-06T11:31:59-07:00","msg":"using config file in the service config directory","config_path":"/etc/border0/border0.yaml"}
{"level":"info","ts":"2023-09-06T11:31:59-07:00","msg":"reading the config","config_path":"/etc/border0/border0.yaml"}
{"level":"info","ts":"2023-09-06T11:31:59-07:00","msg":"reading the config","config_path":"/etc/border0/border0.yaml"}
2023/09/06 11:31:59 starting the connector service
{"level":"info","ts":"2023-09-06T11:31:59-07:00","msg":"using token defined in config file"}
{"level":"info","ts":"2023-09-06T11:31:59-07:00","msg":"receiving an update"}
{"level":"info","ts":"2023-09-06T11:31:59-07:00","msg":"sockets found","plugin_name":"StaticSocketFinder","local connector sockets":1,"api sockets":3,"connected sockets":0}
2023/09/06 11:31:59 creating a socket: ssh-connector-lab
{"level":"info","ts":"2023-09-06T11:31:59-07:00","msg":"number of sockets to connect: ","plugin_name":"StaticSocketFinder","sockets to connect":1}
{"level":"info","ts":"2023-09-06T11:31:59-07:00","msg":"found new socket to connect"}
Welcome to Border0.com
ssh-connector-lab - https://client.border0.com/#/ssh/ssh-connector-lab-docs0.border0.io

=======================================================
Logs
=======================================================
{"level":"info","ts":"2023-09-06T11:32:13-07:00","msg":"new ssh session for adriano@border0.com (as user adriano)"}
{"level":"info","ts":"2023-09-06T11:32:29-07:00","msg":"receiving an update"}
{"level":"info","ts":"2023-09-06T11:32:29-07:00","msg":"sockets found","plugin_name":"StaticSocketFinder","local connector sockets":1,"api sockets":4,"connected sockets":1}
{"level":"info","ts":"2023-09-06T11:32:29-07:00","msg":"number of sockets to connect: ","plugin_name":"StaticSocketFinder","sockets to connect":1}
{"level":"info","ts":"2023-09-06T11:32:59-07:00","msg":"receiving an update"}
{"level":"info","ts":"2023-09-06T11:32:59-07:00","msg":"sockets found","plugin_name":"StaticSocketFinder","local connector sockets":1,"api sockets":4,"connected sockets":1}
{"level":"info","ts":"2023-09-06T11:32:59-07:00","msg":"number of sockets to connect: ","plugin_name":"StaticSocketFinder","sockets to connect":1}
```

## (2) When you have an invalid **legacy** connector config file

With the following config in the right place:

<details>

```
✔ ~/go/src/github.com/borderzero/border0-cli [ME-1877_v2_installer_as_default|✔]
11:33 $ cat /etc/border0/border0.yaml
connector:
   bad: "my-awesome-connector"
```

</details>


```
✔ ~/go/src/github.com/borderzero/border0-cli [ME-1877_v2_installer_as_default|✔]
11:30 $ BORDER0_LOG_LEVEL=debug BORDER0_TOKEN=$(cat ~/.border0/token) ./border0 connector start --connector-id 8f31bb64-6077-4540-b031-2b907d44ef9d
{"level":"info","ts":"2023-09-06T11:30:10-07:00","msg":"using config file in the service config directory","config_path":"/etc/border0/border0.yaml"}
{"level":"info","ts":"2023-09-06T11:30:10-07:00","msg":"reading the config","config_path":"/etc/border0/border0.yaml"}
{"level":"debug","ts":"2023-09-06T11:30:10-07:00","msg":"failed to parse legacy connector config, defaulting to connector v2","error":"1 error(s) decoding:\n\n* 'Credentials' expected a map, got 'string'"}
{"level":"info","ts":"2023-09-06T11:30:10-07:00","msg":"starting the connector service"}
{"level":"info","ts":"2023-09-06T11:30:10-07:00","msg":"connecting to connector server","server":"capi.border0.com:443"}
{"level":"debug","ts":"2023-09-06T11:30:10-07:00","msg":"collected connector metadata","metadata":{}}
{"level":"info","ts":"2023-09-06T11:30:10-07:00","msg":"new socket","socket":"58732d9a-1ca2-46ba-b173-a54bce7018e0"}
{"level":"info","ts":"2023-09-06T11:30:10-07:00","msg":"socket config","config":{"socket_id":"58732d9a-1ca2-46ba-b173-a54bce7018e0","socket_type":"ssh","recording_enabled":true}}
Welcome to Border0.com
bewbew-ssh - https://client.border0.com/#/ssh/bewbew-ssh-docs0.border0.io

=======================================================
Logs
=======================================================
```

## (3) When you have a connector v2 config file

With the following config in the right place:

<details>

```
✔ ~/go/src/github.com/borderzero/border0-cli [ME-1877_v2_installer_as_default|✔]
11:33 $ cat /etc/border0/border0.yaml
token: [[ HIDDEN CONNECTOR TOKEN ]]
```

</details>

```
✔ ~/go/src/github.com/borderzero/border0-cli [ME-1877_v2_installer_as_default|✔]
11:42 $ BORDER0_LOG_LEVEL=debug ./border0 connector start --config /etc/border0/border0.yaml
{"level":"info","ts":"2023-09-06T11:43:09-07:00","msg":"reading the config","config_path":"/etc/border0/border0.yaml"}
{"level":"debug","ts":"2023-09-06T11:43:09-07:00","msg":"failed to validate legacy connector config, defaulting to connector v2","error":"connector.name is required"}
{"level":"info","ts":"2023-09-06T11:43:09-07:00","msg":"starting the connector service"}
{"level":"info","ts":"2023-09-06T11:43:09-07:00","msg":"connecting to connector server","server":"capi.border0.com:443"}
{"level":"debug","ts":"2023-09-06T11:43:10-07:00","msg":"collected connector metadata","metadata":{}}
{"level":"info","ts":"2023-09-06T11:43:10-07:00","msg":"new socket","socket":"58732d9a-1ca2-46ba-b173-a54bce7018e0"}
{"level":"info","ts":"2023-09-06T11:43:10-07:00","msg":"socket config","config":{"socket_id":"58732d9a-1ca2-46ba-b173-a54bce7018e0","socket_type":"ssh","recording_enabled":true}}
Welcome to Border0.com
bewbew-ssh - https://client.border0.com/#/ssh/bewbew-ssh-docs0.border0.io

=======================================================
Logs
=======================================================
```


## (4) When you don't have a legacy connector config file

```
✔ ~/go/src/github.com/borderzero/border0-cli [ME-1877_v2_installer_as_default|✔]
11:38 $ AWS_PROFILE=demo BORDER0_LOG_LEVEL=debug BORDER0_TOKEN=$(cat ~/.border0/token) ./border0 connector start --connector-id 8f31bb64-6077-4540-b031-2b907d44ef9d
{"level":"debug","ts":"2023-09-06T11:38:24-07:00","msg":"no legacy connector config found, defaulting to connector v2","error":"stat /etc/border0/border0.yaml: no such file or directory"}
{"level":"info","ts":"2023-09-06T11:38:24-07:00","msg":"starting the connector service"}
{"level":"info","ts":"2023-09-06T11:38:24-07:00","msg":"connecting to connector server","server":"capi.border0.com:443"}
{"level":"info","ts":"2023-09-06T11:38:25-07:00","msg":"new socket","socket":"58732d9a-1ca2-46ba-b173-a54bce7018e0"}
{"level":"info","ts":"2023-09-06T11:38:25-07:00","msg":"socket config","config":{"socket_id":"58732d9a-1ca2-46ba-b173-a54bce7018e0","socket_type":"ssh","recording_enabled":true}}
Welcome to Border0.com
bewbew-ssh - https://client.border0.com/#/ssh/bewbew-ssh-docs0.border0.io

=======================================================
Logs
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-1877]: https://mysocket.atlassian.net/browse/ME-1877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ