### PR TITLE
[ME-1965] [ME-1966] Various Connector Installer Improvements

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/borderzero/border0-cli/internal/api/models"
+	"github.com/borderzero/border0-go/types/connector"
 	"github.com/golang-jwt/jwt"
 	"golang.org/x/sync/errgroup"
 )
@@ -398,6 +399,38 @@ func (a *Border0API) CreateConnectorToken(ctx context.Context, connectorId strin
 	}
 
 	return &tk, nil
+}
+
+// GetDefaultPluginConfiguration returns the default configuration for a given plugin type.
+func (a *Border0API) GetDefaultPluginConfiguration(ctx context.Context, pluginType string) (*connector.PluginConfiguration, error) {
+	var plugin *models.ConnectorPlugin
+	err := a.Request(http.MethodGet, fmt.Sprintf("connector/plugins/defaults/%s", pluginType), &plugin, nil, true)
+	if err != nil {
+		return nil, err
+	}
+	return &plugin.Configuration, nil
+}
+
+// CreatePlugin creates a new connector plugin.
+func (a *Border0API) CreatePlugin(
+	ctx context.Context,
+	connectorId string,
+	enabled bool,
+	pluginType string,
+	pluginConfiguration *connector.PluginConfiguration,
+) (*models.ConnectorPlugin, error) {
+	payload := &models.ConnectorPluginRequest{
+		ConnectorId:   connectorId,
+		Enabled:       enabled,
+		PluginType:    pluginType,
+		Configuration: pluginConfiguration,
+	}
+	var plugin *models.ConnectorPlugin
+	err := a.Request(http.MethodPost, "connector/plugins", &plugin, payload, true)
+	if err != nil {
+		return nil, err
+	}
+	return plugin, nil
 }
 
 func (a *Border0API) GetPolicyByName(ctx context.Context, name string) (*models.Policy, error) {

--- a/internal/api/models/connector.go
+++ b/internal/api/models/connector.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"time"
+
+	"github.com/borderzero/border0-go/types/connector"
 )
 
 // ConnectorList represents a list of connectors
@@ -35,4 +37,20 @@ type ConnectorToken struct {
 	Name          string `json:"name,omitempty"`
 	ExpiresAt     string `json:"expires_at,omitempty"`
 	Token         string `json:"token,omitempty"`
+}
+
+// ConnectorPluginRequest represents a request to create a plugin for a Border0 Connector.
+type ConnectorPluginRequest struct {
+	ConnectorId   string                         `json:"connector_id"`
+	Enabled       bool                           `json:"enabled"`
+	PluginType    string                         `json:"plugin_type"`
+	Configuration *connector.PluginConfiguration `json:"configuration"`
+}
+
+// ConnectorPlugin represents a plugin for a Border0 Connector.
+type ConnectorPlugin struct {
+	ID            string                        `json:"id"`
+	Enabled       bool                          `json:"enabled"`
+	PluginType    string                        `json:"plugin_type"`
+	Configuration connector.PluginConfiguration `json:"configuration"`
 }


### PR DESCRIPTION
## [[ME-1965](https://mysocket.atlassian.net/browse/ME-1965)] [[ME-1966](https://mysocket.atlassian.net/browse/ME-1966)] Various Connector Installer Improvements

- Fixes `border0 connector status` in `OS=darwin` (MacOS), which was trying to run `systemctl` (wrong tool for OS)
- Enables AWS Discovery Plugins during the AWS Connector Installer

```
... output before ommitted

🚀 Border0 connector "aws-connector-2" created successfully!
🚀 Border0 connector plugin "aws_ec2_discovery" enabled successfully!
🚀 Border0 connector plugin "aws_ecs_discovery" enabled successfully!
🚀 Border0 connector plugin "aws_rds_discovery" enabled successfully!
🚀 Border0 connector token "border0-aws-connector-1694459528" created successfully!
🚀 SSM Parameter "border0-aws-connector-2-token-1" created successfully!
🚀 CloudFormation stack "border0-aws-connector-1694459528" creation initiated, events below:

... output after ommitted
```

<img width="1005" alt="Screenshot 2023-09-11 at 12 18 59 PM" src="https://github.com/borderzero/border0-cli/assets/16856511/d9066065-8a2c-4d3d-8cb0-8f0a76c3de8d">

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1965
- https://mysocket.atlassian.net/browse/ME-1966

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Both changes tested thoroughly using a modified local version of the CLI.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1965]: https://mysocket.atlassian.net/browse/ME-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ME-1966]: https://mysocket.atlassian.net/browse/ME-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ