### PR TITLE
[ME-1982] Fix Connector Installer on Windows

### DIFF
--- a/internal/service_daemon/common.go
+++ b/internal/service_daemon/common.go
@@ -4,6 +4,12 @@ import (
 	"strings"
 )
 
+const (
+	notInstalledMessageDarwin  = "is not installed"
+	notInstalledMessageLinux   = "is not installed"
+	notInstalledMessageWindows = "does not exist"
+)
+
 // Service represents a service daemon.
 type Service interface {
 	Install(args ...string) (string, error)
@@ -17,10 +23,16 @@ type Service interface {
 func IsInstalled(service Service) (bool, error) {
 	status, err := service.Status()
 	if err != nil {
-		if err.Error() != "Service is not installed" {
-			return false, err
+		for _, notInstalledMsg := range []string{
+			notInstalledMessageDarwin,
+			notInstalledMessageLinux,
+			notInstalledMessageWindows,
+		} {
+			if strings.Contains(err.Error(), notInstalledMsg) {
+				return false, nil
+			}
 		}
-		return false, nil
+		return false, err
 	}
 	return strings.Contains(status, "is running") || strings.Contains(status, "stopped"), nil
 }


### PR DESCRIPTION
## [[ME-1982](https://mysocket.atlassian.net/browse/ME-1982)] Attempt at Fixing Connector Install on Windows

The message that we check for to determine whether the system is installed is different for windows... so the installation fails.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1982

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

On a windows machine in the office. The installer still fails at a later stage but this time because we are running a non-release version of the software (potentially, as per stack overflow).

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1982]: https://mysocket.atlassian.net/browse/ME-1982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ