### PR TITLE
use socket upstream username in local ssh server

### DIFF
--- a/cmd/socket.go
+++ b/cmd/socket.go
@@ -660,7 +660,11 @@ var socketConnectCmd = &cobra.Command{
 				return err
 			}
 		case localssh:
-			sshServer, err := ssh.NewServer(logger.Logger, socket.Organization.Certificates["ssh_public_key"])
+			opts := []ssh.Option{}
+			if socket.UpstreamUsername != "" {
+				opts = append(opts, ssh.WithUsername(socket.UpstreamUsername))
+			}
+			sshServer, err := ssh.NewServer(logger.Logger, socket.Organization.Certificates["ssh_public_key"], opts...)
 			if err != nil {
 				return err
 			}

--- a/internal/border0/socket.go
+++ b/internal/border0/socket.go
@@ -67,6 +67,7 @@ type Socket struct {
 	SocketID                         string
 	SocketType                       string
 	UpstreamType                     string
+	UpstreamUsername                 string
 	ConnectorAuthenticationEnabled   bool
 	EndToEndEncryptionEnabled        bool
 	ConnectorAuthenticationTLSConfig *tls.Config
@@ -125,10 +126,16 @@ func NewSocket(ctx context.Context, border0API api.API, nameOrID string, logger 
 
 	sckContext, sckCancel := context.WithCancel(context.Background())
 
+	var upstreamUsername string
+	if socketFromApi.UpstreamUsername != nil {
+		upstreamUsername = *socketFromApi.UpstreamUsername
+	}
+
 	return &Socket{
 		SocketID:                       socketFromApi.SocketID,
 		SocketType:                     socketFromApi.SocketType,
 		UpstreamType:                   socketFromApi.UpstreamType,
+		UpstreamUsername:               upstreamUsername,
 		ConnectorAuthenticationEnabled: socketFromApi.ConnectorAuthenticationEnabled,
 		EndToEndEncryptionEnabled:      socketFromApi.EndToEndEncryptionEnabled,
 		border0API:                     border0API,


### PR DESCRIPTION
# Description

if socket has upstream username in db/api, use it when creating the local ssh server

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested with:

```shell
border0 socket create --name test-ssh-username --type ssh --upstream_username rollie
border0 socket connect test-ssh-username --sshserver
```

And then log into my SSH socket.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code