### PR TITLE
[ME-1981] Abstract Platform Specific SFTP Logic, Hide "child" Command Tree

### DIFF
--- a/internal/process/common.go
+++ b/internal/process/common.go
@@ -1,0 +1,9 @@
+package process
+
+// Parameters represents process parameters.
+type Parameters struct {
+	UID    int
+	GID    int
+	User   string // NOT USED
+	Groups []int
+}

--- a/internal/process/setup.go
+++ b/internal/process/setup.go
@@ -1,0 +1,40 @@
+//go:build !windows
+// +build !windows
+
+package process
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+
+	"go.uber.org/zap"
+)
+
+// SetupUserAndGroups changes the uid, gid, and groups of the current process.
+func SetupUserAndGroups(logger *zap.Logger, params *Parameters) error {
+	euid := os.Geteuid()
+	egid := os.Getegid()
+	if euid != 0 && params.UID != euid {
+		return fmt.Errorf("command must be run as root or with sudo")
+	}
+	// darwin allows a maximum of 16 groups
+	if runtime.GOOS == "darwin" && len(params.Groups) > 16 {
+		params.Groups = params.Groups[:16]
+	}
+	if err := syscall.Setgroups(params.Groups); err != nil {
+		return fmt.Errorf("failed to set groups: %w", err)
+	}
+	if egid != params.GID {
+		if err := syscall.Setgid(params.GID); err != nil {
+			return fmt.Errorf("failed to set gid: %w", err)
+		}
+	}
+	if euid != params.UID {
+		if err := syscall.Setuid(params.UID); err != nil {
+			return fmt.Errorf("failed to set uid: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/process/setup_windows.go
+++ b/internal/process/setup_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+// +build windows
+
+package process
+
+import "go.uber.org/zap"
+
+// SetupUserAndGroups on Windows is a NO-OP because Windows doesn't support
+// changing uid, gid, or groups in the same way as the other platforms.
+func SetupUserAndGroups(logger *zap.Logger, params *Parameters) error {
+	logger.Warn("Changing a process' uid, gid, and groups is not supported on Windows...")
+	return nil
+}


### PR DESCRIPTION
## [[ME-1981](https://mysocket.atlassian.net/browse/ME-1981)] Abstract Platform Specific SFTP Logic, Hide "child" Command Tree

- Abstracts away platform specific code for SFTP process management (setting uid, gid, groups)
- Hides the `child` command tree so that it isnt invoked manually by curious customers
- Fixes the broken CLI build due to syscall package compilation failures on Windows

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1981

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The build succeeds -- more testing can be done later.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1981]: https://mysocket.atlassian.net/browse/ME-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ