### PR TITLE
[ME-2012] Upgrade Discovery Lib For RDP & VNC Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/bluele/factory-go v0.0.1
 	github.com/borderzero/border0-go v1.3.13
 	github.com/borderzero/border0-proto v1.0.3
-	github.com/borderzero/discovery v0.1.21
+	github.com/borderzero/discovery v0.1.22
 	github.com/brianvoe/gofakeit v3.18.0+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/creack/pty v1.1.18

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/borderzero/border0-go v1.3.13 h1:ov98tsV6Uk5bGoPAYIRqmomHKIOrCxKo7vAD
 github.com/borderzero/border0-go v1.3.13/go.mod h1:Yll5qVCxLLICOwODQEG3O/D5Q7AtuLgbbDoj06shFaQ=
 github.com/borderzero/border0-proto v1.0.3 h1:I7xj7qsNlVvWD0+h7oin2fZbwNDrK0tiHgnmz2ODPr4=
 github.com/borderzero/border0-proto v1.0.3/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
-github.com/borderzero/discovery v0.1.21 h1:2ILAepf7I5/ot/019QrEA3/EnOrk0efdttQmeR2ozwc=
-github.com/borderzero/discovery v0.1.21/go.mod h1:Sd3HkMwhvipGDnkSDaLe9vfVvB8/hAb+xUimv+bRji8=
+github.com/borderzero/discovery v0.1.22 h1:ZOHLvXTzOIDxCMNF0KJ0Xfz0Kv9bcfIp0h8AL+Pajlc=
+github.com/borderzero/discovery v0.1.22/go.mod h1:Sd3HkMwhvipGDnkSDaLe9vfVvB8/hAb+xUimv+bRji8=
 github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=
 github.com/brianvoe/gofakeit v3.18.0+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/vendor/github.com/aws/session-manager-plugin/src/sessionmanagerplugin/session/session.go
+++ b/vendor/github.com/aws/session-manager-plugin/src/sessionmanagerplugin/session/session.go
@@ -86,12 +86,12 @@ type Session struct {
 	DisplayMode           sessionutil.DisplayMode
 }
 
-// startSession create the datachannel for session
+//startSession create the datachannel for session
 var startSession = func(session *Session, log log.T) error {
 	return session.Execute(log)
 }
 
-// setSessionHandlersWithSessionType set session handlers based on session subtype
+//setSessionHandlersWithSessionType set session handlers based on session subtype
 var setSessionHandlersWithSessionType = func(session *Session, log log.T) error {
 	// SessionType is set inside DataChannel
 	sessionSubType := SessionRegistry[session.SessionType]
@@ -209,7 +209,7 @@ func ValidateInputAndStartSession(args []string, out io.Writer) {
 	}
 }
 
-// Execute create data channel and start the session
+//Execute create data channel and start the session
 func (s *Session) Execute(log log.T) (err error) {
 	fmt.Fprintf(os.Stdout, "\nStarting session with SessionId: %s\n", s.SessionId)
 

--- a/vendor/github.com/borderzero/discovery/resource.go
+++ b/vendor/github.com/borderzero/discovery/resource.go
@@ -31,8 +31,14 @@ const (
 	// ResourceTypeNetworkPostgresqlServer is the resource type for network-reachable PostgreSQL servers.
 	ResourceTypeNetworkPostgresqlServer = "network_postgresql_server"
 
+	// ResourceTypeNetworkRdpServer is the resource type for network-reachable RDP servers.
+	ResourceTypeNetworkRdpServer = "network_rdp_server"
+
 	// ResourceTypeNetworkSshServer is the resource type for network-reachable SSH servers.
 	ResourceTypeNetworkSshServer = "network_ssh_server"
+
+	// ResourceTypeNetworkVncServer is the resource type for network-reachable VNC servers.
+	ResourceTypeNetworkVncServer = "network_vnc_server"
 
 	// Ec2InstanceSsmStatusOnline represents the SSM status of an EC2 instance that is associated and online.
 	Ec2InstanceSsmStatusOnline = "online"
@@ -193,9 +199,25 @@ type NetworkPostgresqlServerDetails struct {
 	// add any new fields as needed here
 }
 
+// NetworkRdpServerDetails represents the details
+// of a discovered RDP server on the network.
+type NetworkRdpServerDetails struct {
+	NetworkBaseDetails // extends
+
+	// add any new fields as needed here
+}
+
 // NetworkSshServerDetails represents the details
 // of a discovered SSH server on the network.
 type NetworkSshServerDetails struct {
+	NetworkBaseDetails // extends
+
+	// add any new fields as needed here
+}
+
+// NetworkVncServerDetails represents the details
+// of a discovered VNC server on the network.
+type NetworkVncServerDetails struct {
 	NetworkBaseDetails // extends
 
 	// add any new fields as needed here
@@ -214,7 +236,9 @@ type Resource struct {
 	NetworkHttpsServerDetails      *NetworkHttpsServerDetails      `json:"network_https_server_details,omitempty"`
 	NetworkMysqlServerDetails      *NetworkMysqlServerDetails      `json:"network_mysql_server_details,omitempty"`
 	NetworkPostgresqlServerDetails *NetworkPostgresqlServerDetails `json:"network_postgresql_server_details,omitempty"`
+	NetworkRdpServerDetails        *NetworkRdpServerDetails        `json:"network_rdp_server_details,omitempty"`
 	NetworkSshServerDetails        *NetworkSshServerDetails        `json:"network_ssh_server_details,omitempty"`
+	NetworkVncServerDetails        *NetworkVncServerDetails        `json:"network_vnc_server_details,omitempty"`
 
 	// add any new resource details here
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -257,7 +257,7 @@ github.com/borderzero/border0-go/types/service
 # github.com/borderzero/border0-proto v1.0.3
 ## explicit; go 1.20
 github.com/borderzero/border0-proto/connector
-# github.com/borderzero/discovery v0.1.21
+# github.com/borderzero/discovery v0.1.22
 ## explicit; go 1.20
 github.com/borderzero/discovery
 github.com/borderzero/discovery/discoverers


### PR DESCRIPTION
## [[ME-2012](https://mysocket.atlassian.net/browse/ME-2012)] Upgrade Discovery Lib For RDP & VNC Support

No-Code change to support discovering networked rdp and vnc servers in connector v2.

`go get -u github.com/borderzero/discovery && go mod tidy && go mod vendor`

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2012

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This was tested locally by running this modified CLI against the production Border0 API and seeing the results in the portal.

<img width="1512" alt="Screenshot 2023-09-14 at 3 38 40 PM" src="https://github.com/borderzero/border0-cli/assets/16856511/423d0b93-0b46-4ca7-9d14-c9740ee4906f">

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-2012]: https://mysocket.atlassian.net/browse/ME-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ