### PR TITLE
[ME-1982] Remove UnImplemented Connector Stop Command

### DIFF
--- a/cmd/connector.go
+++ b/cmd/connector.go
@@ -284,14 +284,6 @@ var connectorStartCmd = &cobra.Command{
 	},
 }
 
-var connectorStopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "stop ad-hoc connector process",
-	Run: func(cmd *cobra.Command, args []string) {
-		connector.NewConnectorService(*config.NewConfig(), nil, version).Stop()
-	},
-}
-
 func connectorInstallAws(cmd *cobra.Command) {
 	ctx := cmd.Context()
 
@@ -444,7 +436,6 @@ func init() {
 	connectorStartCmd.Flag("service").Hidden = true
 
 	connectorCmd.AddCommand(connectorStartCmd)
-	connectorCmd.AddCommand(connectorStopCmd)
 	connectorCmd.AddCommand(connectorStatusCmd)
 	connectorCmd.AddCommand(connectorInstallCmd)
 	connectorCmd.AddCommand(connectorUnInstallCmd)

--- a/internal/connector/service.go
+++ b/internal/connector/service.go
@@ -188,11 +188,6 @@ func (c *ConnectorService) StartWithPlugins(ctx context.Context, cfg config.Conf
 	return nil
 }
 
-func (c ConnectorService) Stop() error {
-	log.Println("stopping the connector service")
-	return nil
-}
-
 func (c *ConnectorService) StartSocketWorker(ctx context.Context, connectorCore *core.ConnectorCore, socketUpdateCh chan []models.Socket, group *errgroup.Group) {
 	group.Go(func() error {
 		for {


### PR DESCRIPTION
## [[ME-1982](https://mysocket.atlassian.net/browse/ME-1982)] Remove UnImplemented Connector Stop Command

This does nothing other than print a misleading message...

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-1982

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

N/A

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-1982]: https://mysocket.atlassian.net/browse/ME-1982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ