### PR TITLE
fix: add sleep again

### DIFF
--- a/internal/ssh/server_unix.go
+++ b/internal/ssh/server_unix.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/creack/pty"
@@ -100,6 +101,7 @@ func execCmd(s ssh.Session, cmd exec.Cmd, uid, gid uint64, username string) {
 
 		go func() {
 			defer wg.Done()
+			time.Sleep(200 * time.Millisecond)
 			io.Copy(s, f)
 			s.CloseWrite()
 		}()


### PR DESCRIPTION
# Description

Add small sleep before starting io.Copy. This was removed in the last PR.
fix: ME-1981

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested using ec2 instance.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
