### PR TITLE
[ME-2065] Future-proof Border0 Certificate Username

### DIFF
--- a/internal/api/models/socket.go
+++ b/internal/api/models/socket.go
@@ -136,6 +136,8 @@ type Socket struct {
 	ConnectorData      *ConnectorData      `json:"-"`
 	ConnectorLocalData *ConnectorLocalData `json:"-"`
 
+	IsBorder0Certificate bool `json:"-"`
+
 	UpstreamCertFile      string `json:"-"`
 	UpstreamKeyFile       string `json:"-"`
 	UpstreamCACertFile    string `json:"-"`

--- a/internal/connector_v2/upstreamdata/ssh.go
+++ b/internal/connector_v2/upstreamdata/ssh.go
@@ -109,9 +109,11 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForSshServiceStandard(s *models.S
 		case service.UsernameProviderDefined, "":
 			// NOTE: for border0 certificate sockets, the role of the connector is to just forward bytes
 			// between the proxy and the origin. The signed certificate comes directly from the proxy, and
-			// username from clients (e.g. the web client). Which is why we do not populate the username here.
+			// username from clients (e.g. the web client). However, there are plans of changing that behaviour
+			// so we set the username here anyways even though it is currently a NO-OP.
 
-			// s.ConnectorLocalData.UpstreamUsername = u.fetchVariableFromSource(config.Border0CertificateAuthConfiguration.Username)
+			s.IsBorder0Certificate = true
+			s.ConnectorLocalData.UpstreamUsername = u.fetchVariableFromSource(config.Border0CertificateAuthConfiguration.Username)
 		case service.UsernameProviderPromptClient:
 			// do nothing
 		default:

--- a/internal/ssh/proxy.go
+++ b/internal/ssh/proxy.go
@@ -88,6 +88,11 @@ func BuildProxyConfig(logger *zap.Logger, socket models.Socket, AWSRegion, AWSPr
 
 	isNormalSSHSocket := socket.UpstreamType != "aws-ssm" && socket.UpstreamType != "aws-ec2connect" && !socket.ConnectorLocalData.AWSEC2InstanceConnectEnabled && !socket.EndToEndEncryptionEnabled
 	if isNormalSSHSocket {
+		// For connector v2 sockets CAN have an upsream username set
+		// so the check below would not pass - so we add this new one.
+		if socket.IsBorder0Certificate {
+			return nil, nil
+		}
 		if socket.ConnectorLocalData.UpstreamUsername == "" && socket.ConnectorLocalData.UpstreamPassword == "" {
 			if len(socket.ConnectorLocalData.UpstreamIdentityPrivateKey) == 0 && socket.ConnectorLocalData.UpstreamIdentifyFile == "" {
 				return nil, nil


### PR DESCRIPTION
## [[ME-2065](https://mysocket.atlassian.net/browse/ME-2065)] Future-proof Border0 Certificate Username

Future-proof the border0 certificate username option.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2065

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested with border0 certificate sockets with connector v2.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2065]: https://mysocket.atlassian.net/browse/ME-2065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ