### PR TITLE
[ME-2083] Set connector user to SUDO_USER if present

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/borderzero/border0-cli/internal/api/models"
 	"github.com/borderzero/border0-cli/internal/util"
 	"github.com/borderzero/border0-go/types/connector"
+	"github.com/borderzero/border0-go/types/service"
 	"github.com/golang-jwt/jwt"
 	"golang.org/x/sync/errgroup"
 )
@@ -353,8 +354,17 @@ func (a *Border0API) DetachPolicies(ctx context.Context, socketID string, policy
 }
 
 // CreateConnector creates a new border0 connector (v2)
-func (a *Border0API) CreateConnector(ctx context.Context, name string, description string, enableBuiltInSshService bool) (*models.Connector, error) {
+func (a *Border0API) CreateConnector(
+	ctx context.Context,
+	name string,
+	description string,
+	enableBuiltInSshService bool,
+	builtInSshServiceConfig *service.BuiltInSshServiceConfiguration,
+) (*models.Connector, error) {
 	payload := &models.Connector{Name: name, Description: description, BuiltInSshServiceEnabled: enableBuiltInSshService}
+	if builtInSshServiceConfig != nil {
+		payload.BuiltInSshServiceConfiguration = builtInSshServiceConfig
+	}
 
 	var connector models.Connector
 	err := a.Request(http.MethodPost, "connector", &connector, payload, true)

--- a/internal/api/models/connector.go
+++ b/internal/api/models/connector.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/borderzero/border0-go/types/connector"
+	"github.com/borderzero/border0-go/types/service"
 )
 
 // ConnectorList represents a list of connectors
@@ -13,15 +14,16 @@ type ConnectorList struct {
 
 // Connector represents a cloud-managed Border0 Connector.
 type Connector struct {
-	Name                     string                 `json:"name"`
-	ConnectorID              string                 `json:"connector_id"`
-	BuiltInSshServiceEnabled bool                   `json:"built_in_ssh_service_enabled"`
-	Description              string                 `json:"description"`
-	ActiveTokens             int                    `json:"active_tokens"`
-	Metadata                 map[string]interface{} `json:"metadata"`
-	CreatedAt                *time.Time             `json:"created_at"`
-	UpdatedAt                *time.Time             `json:"updated_at"`
-	LastSeenAt               *time.Time             `json:"last_seen_at"`
+	Name                           string                                  `json:"name"`
+	ConnectorID                    string                                  `json:"connector_id"`
+	BuiltInSshServiceEnabled       bool                                    `json:"built_in_ssh_service_enabled"`
+	BuiltInSshServiceConfiguration *service.BuiltInSshServiceConfiguration `json:"built_in_ssh_service_configuration,omitempty"`
+	Description                    string                                  `json:"description"`
+	ActiveTokens                   int                                     `json:"active_tokens"`
+	Metadata                       map[string]interface{}                  `json:"metadata"`
+	CreatedAt                      *time.Time                              `json:"created_at"`
+	UpdatedAt                      *time.Time                              `json:"updated_at"`
+	LastSeenAt                     *time.Time                              `json:"last_seen_at"`
 }
 
 // ConnectorTokenRequest represents a request to create a token for a Border0 Connector.

--- a/internal/connector_v2/install/aws.go
+++ b/internal/connector_v2/install/aws.go
@@ -90,7 +90,7 @@ func RunCloudInstallWizardForAWS(ctx context.Context, cliVersion string) error {
 		return fmt.Errorf("failed to prompt for AWS SSM Parameter path for Border0 token: %v", err)
 	}
 
-	border0Connector, err := createNewBorder0Connector(ctx, border0ConnectorName, "AWS Cloud-Install Border0 Connector", cliVersion)
+	border0Connector, err := createNewBorder0Connector(ctx, border0ConnectorName, "AWS Cloud-Install Border0 Connector", cliVersion, false)
 	if err != nil {
 		return fmt.Errorf("failed to create new Border0 connector: %v", err)
 	}

--- a/internal/connector_v2/install/local.go
+++ b/internal/connector_v2/install/local.go
@@ -42,7 +42,7 @@ func RunInstallWizard(
 		if err != nil {
 			return fmt.Errorf("failed to determine unique name for connector: %v", err)
 		}
-		border0Connector, err := createNewBorder0Connector(ctx, connectorName, "CLI-Installed Border0 Connector", version)
+		border0Connector, err := createNewBorder0Connector(ctx, connectorName, "CLI-Installed Border0 Connector", version, true)
 		if err != nil {
 			return fmt.Errorf("failed to create new connector: %v", err)
 		}


### PR DESCRIPTION
## [[ME-2083](https://mysocket.atlassian.net/browse/ME-2083)] Set Connector User to SUDO_USER if present for local connector installer

Sets the username of the built-in ssh server to SUDO_USER if present during installation (for local installer locally).

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2083

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested a local and an aws installation.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2083]: https://mysocket.atlassian.net/browse/ME-2083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ