### PR TITLE
[ME-2102] Propagate Upstream Variable Fetch Errors

### DIFF
--- a/internal/connector_v2/upstreamdata/top_level.go
+++ b/internal/connector_v2/upstreamdata/top_level.go
@@ -51,7 +51,7 @@ func (u *UpstreamDataBuilder) Build(s *models.Socket, config service.Configurati
 func (u *UpstreamDataBuilder) fetchVariableFromSource(field string) string {
 	val, err := u.vs.GetVariable(context.Background(), field)
 	if err != nil {
-		fmt.Printf("error evaluating variable %s: %v\n", field, err)
+		u.logger.Info("error fetching variable from upstream source", zap.String("variable_definition", field), zap.Error(err))
 		return field
 	}
 	return val


### PR DESCRIPTION
## [[ME-2102](https://mysocket.atlassian.net/browse/ME-2102)] Propagate Upstream Variable Fetch Errors

I was trying to use upstream variables in parameter store in an AWS-installer-based connector and it didnt work, I had to get on the box and start a new connector to get the log locally:

```
error evaluating variable from:aws:ssm:/demo/mysql-db-password: failed to get value for variable definition "aws:ssm:/demo/mysql-db-password": failed to get ssm parameter "/demo/mysql-db-password": operation error SSM: GetParameter, https response error StatusCode: 400, RequestID: 006a388f-65ce-4fe4-99b8-a425c676e9a4, api error AccessDeniedException: User: arn:aws:sts::[[HIDDEN-ACCOUNT]]:assumed-role/border0-aws-connector-169582-ConnectorInstanceRole-9WAMQWJ2HHGC/i-031796992a1755b0d is not authorized to perform: ssm:GetParameter on resource: arn:aws:ssm:us-east-1:[[HIDDEN-ACCOUNT]]:parameter/demo/mysql-db-password because no identity-based policy allows the ssm:GetParameter action
```

This change should bring the error to the admin portal.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2102

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Deployed the code to a test AWS account.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2102]: https://mysocket.atlassian.net/browse/ME-2102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ