### PR TITLE
[ME-2115] Handle Border0 Token SSM Params With Slash

### DIFF
--- a/cmd/connector.go
+++ b/cmd/connector.go
@@ -303,6 +303,7 @@ func connectorInstallAws(cmd *cobra.Command) {
 		}
 	}()
 
+	loginCmd.Run(cmd, []string{})
 	if err := install.RunCloudInstallWizardForAWS(ctx, version); err != nil {
 		fmt.Printf("\nError: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## [[ME-2115](https://mysocket.atlassian.net/browse/ME-2115)] Handle Border0 Token SSM Params With Slash

Ssm parameters can begin with a slash character (`/`). When they do, the slash must be ommitted from the resource ARN in IAM policies that reference them. This takes care of that.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2115

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Ran the installer with tokens stored in each of:
- a path without a '/' as the first character
- a path with a `/` as the first character

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2115]: https://mysocket.atlassian.net/browse/ME-2115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ