### PR TITLE
ME-2116 fix for upgrading border0 cli between partitions

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -153,7 +153,13 @@ var upgradeVersionCmd = &cobra.Command{
 			// After copying the new binary, set its permissions to the original permissions
 			err = os.Chmod(binary_path, originalPermissions)
 			if err != nil {
-				log.Fatalf("Error restoring permissions on the new binary: %v\n", err)
+				log.Printf("error restoring permissions on the new binary: %v\n", err)
+				// Optionally, revert to the backup file
+				revertErr := os.Rename(backupPath, binary_path)
+				if revertErr != nil {
+					log.Printf("Error reverting to the backup binary: %v\n", revertErr)
+				}
+				log.Fatal("Reverted to the old version of the border0 cli due to an error while restoring permissions on the new binary")
 			}
 
 			// Execute the new binary just to make sure it's working


### PR DESCRIPTION
# Description

This fixes the issue where /tmp and the location of border0 cli are on different partitions.
then a simple rename doesnt work and you see something like
```
sh-5.2$ sudo border0 version upgrade
Upgrading /usr/local/bin/border0 to version v1.1-496-gc91658e
2023/09/28 16:38:51 rename /tmp/border0-v1.1-496-gc91658e1883797401 /usr/local/bin/border0: invalid cross-device link
```


Fixes # ME-2116 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
