### PR TITLE
fix: ssh local session: use username from config if set

### DIFF
--- a/internal/ssh/session/local_session.go
+++ b/internal/ssh/session/local_session.go
@@ -69,8 +69,8 @@ func (s *localSessionHandler) Proxy(conn net.Conn) {
 		downstreamSshReqs:  reqs,
 	}
 
-	if s.config.Socket.UpstreamUsername != nil && *s.config.Socket.UpstreamUsername != "" {
-		session.username = *s.config.Socket.UpstreamUsername
+	if s.config.Username != "" {
+		session.username = s.config.Username
 	} else {
 		session.username = sshConn.User()
 	}


### PR DESCRIPTION
# Description

In the new built-in ssh server we use the wrong username option.
Fixes # (ME-2156)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested in staging

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
