### PR TITLE
[ME-2226] Limit Length of Connector Token Name in Installers

### DIFF
--- a/internal/connector_v2/install/aws.go
+++ b/internal/connector_v2/install/aws.go
@@ -100,7 +100,7 @@ func RunCloudInstallWizardForAWS(ctx context.Context, cliVersion string) error {
 		fmt.Printf("warning: failed to enable AWS plugins: %v\n", err)
 	}
 
-	border0Token, err := generateNewBorder0ConnectorToken(ctx, border0Connector.ConnectorID, cliVersion, runId)
+	border0Token, err := generateNewBorder0ConnectorToken(ctx, border0Connector.ConnectorID, cliVersion, fmt.Sprintf("%s-token", maxString(runId, 50)))
 	if err != nil {
 		return fmt.Errorf("failed to create new Border0 token: %v", err)
 	}

--- a/internal/connector_v2/install/common.go
+++ b/internal/connector_v2/install/common.go
@@ -12,6 +12,13 @@ import (
 	"github.com/borderzero/border0-go/types/service"
 )
 
+func maxString(s string, max int) string {
+	if len(s) > max {
+		return s[:max]
+	}
+	return s
+}
+
 func getUniqueConnectorName(ctx context.Context, version, prefix string) (string, error) {
 	border0Client := border0.NewAPI(border0.WithVersion(version))
 

--- a/internal/connector_v2/install/local.go
+++ b/internal/connector_v2/install/local.go
@@ -38,7 +38,7 @@ func RunInstallWizard(
 		if err != nil {
 			return fmt.Errorf("failed to get system hostname: %v", err)
 		}
-		connectorName, err := getUniqueConnectorName(ctx, version, hostname)
+		connectorName, err := getUniqueConnectorName(ctx, version, maxString(hostname, 40))
 		if err != nil {
 			return fmt.Errorf("failed to determine unique name for connector: %v", err)
 		}
@@ -50,7 +50,7 @@ func RunInstallWizard(
 			ctx,
 			border0Connector.ConnectorID,
 			version,
-			fmt.Sprintf("%s-token", connectorName),
+			fmt.Sprintf("%s-token", maxString(connectorName, 50)),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create new connector token: %v", err)

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -26,7 +26,7 @@ const (
 	download_url = "https://download.border0.com"
 )
 
-var ErrUnauthorized = errors.New("unaouthorized")
+var ErrUnauthorized = errors.New("unauthorized")
 
 type ErrorMessage struct {
 	ErrorMessage string `json:"error_message,omitempty"`


### PR DESCRIPTION
## [[ME-2226](https://mysocket.atlassian.net/browse/ME-2226)] Limit Length of Connector Token Name in Installers

Limit the length of the token name so that it doesnt break the http request.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2226

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Installing the connector locally and on AWS with the new code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-2226]: https://mysocket.atlassian.net/browse/ME-2226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ