### PR TITLE
[ME-2233] Hide email and password flags for admin login

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -214,6 +214,8 @@ func init() {
 	// now make the disableBrowser and qr flags hidden
 	loginCmd.Flags().MarkHidden("disable-browser")
 	loginCmd.Flags().MarkHidden("qr")
+	loginCmd.Flags().MarkHidden("email")
+	loginCmd.Flags().MarkHidden("password")
 
 	rootCmd.AddCommand(loginCmd)
 }


### PR DESCRIPTION
## [[ME-2233](https://mysocket.atlassian.net/browse/ME-2233)] Hide email and password flags for admin login

Programmatic basic login is no longer allowed.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2233

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

N/A just hiding the flags. Testing they still work.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2233]: https://mysocket.atlassian.net/browse/ME-2233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ