### PR TITLE
[ME-2216] Fix Hostkey Directory Existence Check Bug

### DIFF
--- a/internal/util/hostkey.go
+++ b/internal/util/hostkey.go
@@ -17,6 +17,7 @@ const (
 	sshHostKeyFile    = "ssh_host_ecdsa_key"
 )
 
+// Hostkey returns the ssh signer for the connector host.
 func Hostkey() (*ssh.Signer, error) {
 	var keyFilePath string
 	if _, err := os.Stat(serviceConfigPath + sshHostKeyFile); err == nil {
@@ -81,15 +82,15 @@ func Hostkey() (*ssh.Signer, error) {
 }
 
 func storeHostkey(key []byte, path, filename string) error {
-	if _, err := os.Stat(path); err == nil {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
 		if err := os.MkdirAll(path, 0700); err != nil {
-			return fmt.Errorf("failed to create directory %s %w", path, err)
+			return fmt.Errorf("failed to create directory %s: %w", path, err)
 		}
+	} else if err != nil {
+		return fmt.Errorf("failed to check directory %s: %w", path, err)
 	}
-
 	if err := os.WriteFile(path+filename, key, 0600); err != nil {
-		return fmt.Errorf("failed to write host key: %w", err)
+		return fmt.Errorf("failed to write host key to %s%s: %w", path, filename, err)
 	}
-
 	return nil
 }


### PR DESCRIPTION
## [[ME-2216](https://mysocket.atlassian.net/browse/ME-2216)] Fix Hostkey Directory Existence Check Bug

The bug is we try to create the directory if `err == nil`, instead we should try to create the directory if `err != nil` (and more specifically if `os.IsNotExist(err)`.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2216

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

N/A still mostly an experimental feature that there is no way to opt-in or opt-out of and is fully API-controlled. No customers are affected by this code change.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2216]: https://mysocket.atlassian.net/browse/ME-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ