### PR TITLE
ME-2287 prevent large vpn subnet size

### DIFF
--- a/internal/vpnlib/iputil.go
+++ b/internal/vpnlib/iputil.go
@@ -7,7 +7,6 @@ import (
 
 const (
 	ipv4HeaderLengthBytes = 20
-	subnetMaxSize         = 30
 )
 
 func cidrToUsableIPs(cidr string) ([]string, uint8, error) {
@@ -17,9 +16,6 @@ func cidrToUsableIPs(cidr string) ([]string, uint8, error) {
 	}
 
 	subnetSize, _ := ipnet.Mask.Size()
-	if subnetSize > subnetMaxSize {
-		return nil, 0, fmt.Errorf("invalid cidr range, must have at least 2 usable addresses (i.e. /30 or less), got %d", subnetSize)
-	}
 
 	var ips []string
 	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); incIp(ip) {


### PR DESCRIPTION
Prevent users from providing  `--vpn-subnet 0.0.0.0/0` as that may, on some systems, exhaust memory. For now, a hard limit to a /16 max, which should be more than sufficient

```
$ sudo ./border0-cli socket connect vpn myvpn  --vpn-subnet 0.0.0.0/0 --route 172.16.0.0/24
Welcome to Border0.com
myvpn - tls://myvpn-border0-demo.border0.io

=======================================================
Logs
=======================================================
2023/11/13 12:42:12 Failed to create IP Pool: invalid cidr range, VPN subnet size to large. Cannot be more than a /16), got 0.0.0.0/0

```

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
