### PR TITLE
ME-2300 Policy tester in cli

### DIFF
--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -314,13 +314,21 @@ var policyTestCmd = &cobra.Command{
 			}
 			fmt.Println("\nThe following actions would be allowed:")
 			// pretty print the actions
-			jsonData, _ := json.MarshalIndent(body.Actions, "", "  ")
+			jsonData, err := json.MarshalIndent(body.Actions, "", "  ")
+			if err != nil {
+				fmt.Printf("could not marshal json: %s\n", err)
+				return
+			}
 			// This is for the colored JSON output
 			var colorData map[string]interface{}
 			json.Unmarshal([]byte(jsonData), &colorData)
 			f := colorjson.NewFormatter()
 			f.Indent = 2
-			colorString, _ := f.Marshal(colorData)
+			colorString, err := f.Marshal(colorData)
+			if err != nil {
+				fmt.Printf("could not marshal data: %s\n", err)
+				return
+			}
 			fmt.Println(string(colorString))
 		}
 
@@ -617,7 +625,9 @@ func init() {
 	policyTestCmd.Flags().StringVarP(&policyName, "name", "n", "", "Policy Name")
 	policyTestCmd.MarkFlagRequired("name")
 	policyTestCmd.Flags().StringVarP(&policyTestEmail, "email", "e", "", "email address to test")
+	policyTestCmd.MarkFlagRequired("email")
 	policyTestCmd.Flags().StringVarP(&policyTestIpAddress, "ip", "i", "", "IP address to test")
+	policyTestCmd.MarkFlagRequired("ip")
 
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,8 @@ var (
 	socketID                string
 	tunnelID                string
 	policyName              string
+	policyTestEmail         string
+	policyTestIpAddress     string
 	policyDescription       string
 	policyFile              string
 	identityFile            string //deprecated

--- a/internal/api/models/policy.go
+++ b/internal/api/models/policy.go
@@ -33,17 +33,8 @@ type PolicyTest struct {
 }
 
 type PolicyTestRespone struct {
-	/*
-		Actions struct {
-			HTTP     []string `json:"http,omitempty"`
-			SSH      []string `json:"ssh,omitempty"`
-			TLS      []string `json:"tls,omitempty"`
-			DATABASE []string `json:"database,omitempty"`
-		} `json:"Actions,omitempty"`
-	*/
 	Actions map[string][]string `json:"Actions,omitempty"`
-
-	Info struct {
+	Info    struct {
 		Allowed []string `json:"allowed,omitempty"`
 		Failed  []string `json:"failed,omitempty"`
 	} `json:"Info,omitempty"`

--- a/internal/api/models/policy.go
+++ b/internal/api/models/policy.go
@@ -26,6 +26,29 @@ type Policy struct {
 	CreatedAt   time.Time  `json:"created_at"`
 }
 
+type PolicyTest struct {
+	Email     string `json:"email" binding:"required"`
+	IPAddress string `json:"ip_address" binding:"required"`
+	Time      string `json:"time" binding:"required"`
+}
+
+type PolicyTestRespone struct {
+	/*
+		Actions struct {
+			HTTP     []string `json:"http,omitempty"`
+			SSH      []string `json:"ssh,omitempty"`
+			TLS      []string `json:"tls,omitempty"`
+			DATABASE []string `json:"database,omitempty"`
+		} `json:"Actions,omitempty"`
+	*/
+	Actions map[string][]string `json:"Actions,omitempty"`
+
+	Info struct {
+		Allowed []string `json:"allowed,omitempty"`
+		Failed  []string `json:"failed,omitempty"`
+	} `json:"Info,omitempty"`
+}
+
 type PolicyData struct {
 	Version   string    `json:"version"`
 	Action    []string  `json:"action" mapstructure:"action"`


### PR DESCRIPTION
# Description

Policy tester option in CLI 
```
$ ./border0-cli policy test --name orgwide --email andree@border0.com --ip 206.214.246.9
Testing Policy: orgwide 8ebbcd53-bea4-4d8c-b3d9-80d35cfe2e99
✅ Policy Passed!

policy: "orgwide", Email address matched policy (andree@border0.com)
policy: "orgwide", IP address matched policy (206.214.246.96)
policy: "orgwide", Country code matched policy (CA)
policy: "orgwide", Date window matched policy (2023-11-15T06:36:21Z)
policy: "orgwide", Time window matched policy (06:36)

The following actions would be allowed:
{
  "http": [
    "*"
  ],
  "ssh": [
    "*"
  ],
  "tls": [
    "*"
  ]
}
```

```
$ ./border0-cli policy test --name orgwide --email andree@bla.xom --ip 1.2.3.4
Testing Policy: orgwide 8ebbcd53-bea4-4d8c-b3d9-80d35cfe2e99
⛔ Policy Failed

policy: "orgwide", Email address didn't match policy (andree@bla.xom)
policy: "orgwide", Country code didn't match policy (AU)
```

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
