### PR TITLE
[ME-2318] Checkout Code Just Once for Build+Release

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -16,16 +16,32 @@ on:
       - go.sum
 
 jobs:
-  build:
-    name: Build CLI
+  checkout_code:
+    name: Checkout Code
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: ["windows-amd64", "windows-arm64", "linux-amd64", "linux-arm64", "linux-arm", "linux-armv6", "linux-386", "darwin-amd64", "darwin-arm64", "openbsd-amd64"]
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Cache code
+        uses: actions/cache@v3
+        with:
+          path: .
+          key: ${{ github.run_id }}
+
+  build:
+    name: Build CLI
+    needs: checkout_code
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [windows-amd64, windows-arm64, linux-amd64, linux-arm64, linux-arm, linux-armv6, linux-386, darwin-amd64, darwin-arm64, openbsd-amd64]
+    steps:
+      - name: Download cached code
+        uses: actions/cache@v3
+        with:
+          path: .
+          key: ${{ github.run_id }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
## [[ME-2318](https://mysocket.atlassian.net/browse/ME-2318)] Checkout Code Just Once for Build+Release

We are downloading the code once per platform, this changes it to do it just once, and pass it to the N platform-specific builds via the cache. The cache key is the workflow run id (unique per workflow execution).

We do this because github will throttle network bandwidth if a workflow downloads too much data. If we download the repo 10 times we've seen our download speed go from 30+ Mbps to 150 Kbps

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2318

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Triggered a Build and Release job from this branch.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2318]: https://mysocket.atlassian.net/browse/ME-2318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ