### PR TITLE
[ME-2365] Improved Device Auth Code Retry Logic

### DIFF
--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -550,6 +550,11 @@ func GetDeviceAuthorization(sessionToken string) (*models.SessionTokenForm, erro
 	if err != nil {
 		return nil, errors.New("failed to decode device auth response")
 	}
+
+	if form.Token == "" || form.State == "not_authorized" {
+		return nil, ErrUnauthorized
+	}
+
 	return &form, nil
 }
 


### PR DESCRIPTION
## [[ME-2365](https://mysocket.atlassian.net/browse/ME-2365)] Improved Device Auth Code Retry Logic

Improves the logic for retries with the OAuth2 Device Authorization Flow. Done as a result of suggestions from @steiler in https://github.com/srl-labs/containerlab/pull/1768

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2365

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested building the CLI locally and logging in.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2365]: https://mysocket.atlassian.net/browse/ME-2365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ