### PR TITLE
[ME-2373] Handle Initialization of AWS EKS Discovery Plugins

### DIFF
--- a/internal/connector_v2/plugin/plugin.go
+++ b/internal/connector_v2/plugin/plugin.go
@@ -33,6 +33,8 @@ func NewPlugin(
 		return newAwsEc2DiscoveryPlugin(ctx, logger, pluginId, config.AwsEc2DiscoveryPluginConfiguration)
 	case connector.PluginTypeAwsEcsDiscovery:
 		return newAwsEcsDiscoveryPlugin(ctx, logger, pluginId, config.AwsEcsDiscoveryPluginConfiguration)
+	case connector.PluginTypeAwsEksDiscovery:
+		return newAwsEksDiscoveryPlugin(ctx, logger, pluginId, config.AwsEksDiscoveryPluginConfiguration)
 	case connector.PluginTypeAwsRdsDiscovery:
 		return newAwsRdsDiscoveryPlugin(ctx, logger, pluginId, config.AwsRdsDiscoveryPluginConfiguration)
 	case connector.PluginTypeKubernetesDiscovery:


### PR DESCRIPTION
## [[ME-2373](https://mysocket.atlassian.net/browse/ME-2373)] Handle Initialization of AWS EKS Discovery Plugins

Handle AWS EKS discoverer requests from the API in the connector.

Fixes # (issue):
- https://mysocket.atlassian.net/browse/ME-2373

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Ran the modified connector code locally and created an AWS EKS discovery plugin via the API and saw the connector act as expected.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2373]: https://mysocket.atlassian.net/browse/ME-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ