### PR TITLE
[ME-2388] EKS Support in AWS Installer

### DIFF
--- a/internal/connector_v2/install/aws.go
+++ b/internal/connector_v2/install/aws.go
@@ -140,6 +140,7 @@ func enableAwsDiscoveryPluginsForConnector(
 	for _, pluginType := range []string{
 		connector.PluginTypeAwsEc2Discovery,
 		connector.PluginTypeAwsEcsDiscovery,
+		connector.PluginTypeAwsEksDiscovery,
 		connector.PluginTypeAwsRdsDiscovery,
 	} {
 		pluginConfig, err := border0Client.GetDefaultPluginConfiguration(ctx, pluginType)

--- a/internal/connector_v2/install/aws_cfn_template.go
+++ b/internal/connector_v2/install/aws_cfn_template.go
@@ -75,6 +75,16 @@ Resources:
                   - 'ecs:ListTaskDefinitions'
                   - 'ecs:ListTasks'
                 Resource: '*'
+        # EKS ReadOnly Policy for EKS discovery
+        - PolicyName: AmazonEKSReadOnlyAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'eks:ListClusters'
+                  - 'eks:DescribeCluster'
+                Resource: '*'
         # SSM Parameter ReadOnly access to the SSM parameter of the connector's token.
         - PolicyName: AccessToBorder0TokenSsmParameter
           PolicyDocument:

--- a/internal/ssh/session/kubectl_exec_session.go
+++ b/internal/ssh/session/kubectl_exec_session.go
@@ -255,8 +255,8 @@ func (s *kubectlExecSession) getKubeconfig(ctx context.Context) (*rest.Config, e
 		// retrieve k8s bearer token
 		token, err := iamAuthTokenGenerator.GetWithOptions(&token.GetTokenOptions{
 			ClusterID:   s.proxyConfig.KubectlExecProxy.AwsEksClusterName,
-			Region:      "eu-west-2", // OK if empty
-			Session:     session,     // have to pass it or else default credential chain is used
+			Region:      s.proxyConfig.AwsConfig.Region, // OK if empty
+			Session:     session,                        // have to pass it or else default credential chain is used
 			SessionName: fmt.Sprintf("border0-k8s-%d", time.Now().UnixNano()),
 		})
 		if err != nil {


### PR DESCRIPTION
## [[ME-2388](https://mysocket.atlassian.net/browse/ME-2388)] EKS Support in AWS Installer

- Enable the EKS discovery plugin in the aws installer
- Fix a bug hardcoding region of eks cluster to eu-west-2
- Add IAM permissions for EKS to the AWS connector installer cfn stack template

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2388

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested using the aws installer with the new template.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code


[ME-2388]: https://mysocket.atlassian.net/browse/ME-2388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ