### PR TITLE
[ME-2408] Abstract/Refactor E2EE PublicKeyCallback Handler

### DIFF
--- a/internal/ssh/session/common/public_key_callback.go
+++ b/internal/ssh/session/common/public_key_callback.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/borderzero/border0-cli/internal/api/models"
+	"github.com/borderzero/border0-cli/internal/border0"
+	"golang.org/x/crypto/ssh"
+)
+
+// GetPublicKeyCallback returns a function to be provided as the PublicKeyCallback
+// field of an ssh.ServerConfig object. This function is invoked by the ssh server
+// in order to verify, among other things, that the certificate being provided by a
+// given ssh client is issued by the correct organization-wide certificate authority.
+func GetPublicKeyCallback(
+	orgWideCACertificate ssh.PublicKey,
+	border0ApiClient border0.Border0API,
+	socket *models.Socket,
+	e2eeMetadata *border0.E2EEncryptionMetadata,
+) func(ssh.ConnMetadata, ssh.PublicKey) (*ssh.Permissions, error) {
+	return func(metadata ssh.ConnMetadata, certificate ssh.PublicKey) (*ssh.Permissions, error) {
+		cert, ok := certificate.(*ssh.Certificate)
+		if !ok {
+			return nil, errors.New("can not cast certificate")
+		}
+
+		if orgWideCACertificate == nil {
+			return nil, errors.New("error: unable to validate certificate, no CA configured")
+		}
+
+		if !bytes.Equal(cert.SignatureKey.Marshal(), orgWideCACertificate.Marshal()) {
+			return nil, errors.New("error: invalid client certificate")
+		}
+
+		if e2eeMetadata.UserEmail != cert.KeyId {
+			return nil, errors.New("error: ssh certificate does not match tls certificate")
+		}
+
+		var certChecker ssh.CertChecker
+		if err := certChecker.CheckCert("mysocket_ssh_signed", cert); err != nil {
+			return nil, fmt.Errorf("error: invalid client certificate: %s", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		actions, _, err := border0ApiClient.Evaluate(ctx, socket, e2eeMetadata.ClientIP, e2eeMetadata.UserEmail, e2eeMetadata.SessionKey)
+		if err != nil {
+			return nil, fmt.Errorf("error: failed to authorize: %s", err)
+		}
+
+		if len(actions) == 0 {
+			return nil, errors.New("error: authorization failed")
+		}
+
+		return &ssh.Permissions{}, nil
+	}
+}

--- a/internal/ssh/session/common/recording.go
+++ b/internal/ssh/session/common/recording.go
@@ -1,4 +1,4 @@
-package session
+package common
 
 import (
 	"bytes"

--- a/internal/ssh/session/common/window_size.go
+++ b/internal/ssh/session/common/window_size.go
@@ -1,0 +1,10 @@
+package common
+
+import "encoding/binary"
+
+// ParseDims parses a message as width and height dimensions (4 bytes each).
+func ParseDims(b []byte) (uint32, uint32) {
+	w := binary.BigEndian.Uint32(b)
+	h := binary.BigEndian.Uint32(b[4:])
+	return w, h
+}

--- a/internal/ssh/session/docker_exec_session.go
+++ b/internal/ssh/session/docker_exec_session.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 	"github.com/borderzero/border0-cli/internal/api/models"
 	"github.com/borderzero/border0-cli/internal/border0"
 	sshConfig "github.com/borderzero/border0-cli/internal/ssh/config"
+	"github.com/borderzero/border0-cli/internal/ssh/session/common"
 	"github.com/borderzero/border0-go/lib/types/set"
 	"github.com/borderzero/border0-go/lib/types/slice"
 	"github.com/docker/docker/api/types"
@@ -85,8 +85,12 @@ func (s *dockerExecSessionHandler) Proxy(conn net.Conn) {
 		}
 		dockerSess.e2eeMetadata = e2EEncryptionConn.Metadata
 		dockerSess.logger = dockerSess.logger.With(zap.String("session_key", dockerSess.e2eeMetadata.SessionKey))
-		// set the ssh server config's callback to the method on the dockerExecSession
-		dockerSess.sshServerConfig.PublicKeyCallback = dockerSess.publicKeyCallback
+		dockerSess.sshServerConfig.PublicKeyCallback = common.GetPublicKeyCallback(
+			s.proxyConfig.OrgSshCA,
+			s.proxyConfig.Border0API,
+			s.proxyConfig.Socket,
+			e2EEncryptionConn.Metadata,
+		)
 	}
 
 	// accept SSH connection from Border0 proxy
@@ -154,7 +158,7 @@ func (s *dockerExecSession) handleChannels(ctx context.Context) error {
 				// handled mostly for the benefit of session recordings
 				case req.Type == "pty-req":
 					termLen := req.Payload[3]
-					w, h := parseDims(req.Payload[termLen+4:])
+					w, h := common.ParseDims(req.Payload[termLen+4:])
 					s.sshWidth = int(w)
 					s.sshHeight = int(h)
 					if req.WantReply {
@@ -162,7 +166,7 @@ func (s *dockerExecSession) handleChannels(ctx context.Context) error {
 					}
 				// handled mostly for the benefit of session recordings
 				case req.Type == "window-change":
-					w, h := parseDims(req.Payload)
+					w, h := common.ParseDims(req.Payload)
 					s.sshWidth = int(w)
 					s.sshHeight = int(h)
 					if req.WantReply {
@@ -200,7 +204,7 @@ func (s *dockerExecSession) handleChannel(
 	if s.proxyConfig.IsRecordingEnabled() {
 		pwc := NewPipeWriteChannel(channel)
 		channel = pwc
-		r := NewRecording(s.logger, pwc.reader, s.proxyConfig.Socket.SocketID, s.e2eeMetadata.SessionKey, s.proxyConfig.Border0API, s.sshWidth, s.sshHeight)
+		r := common.NewRecording(s.logger, pwc.reader, s.proxyConfig.Socket.SocketID, s.e2eeMetadata.SessionKey, s.proxyConfig.Border0API, s.sshWidth, s.sshHeight)
 		if err := r.Record(); err != nil {
 			channel.Write([]byte("An error occured. Try again later..."))
 			s.logger.Error("failed to record session", zap.Error(err))
@@ -364,44 +368,4 @@ func (s *dockerExecSession) askForTarget(ctx context.Context, channel ssh.Channe
 	}
 
 	return ids[index], nil
-}
-
-// FIXME: make generic, ssm uses the exact same code
-func (s *dockerExecSession) publicKeyCallback(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
-	cert, ok := key.(*ssh.Certificate)
-	if !ok {
-		return nil, errors.New("can not cast certificate")
-	}
-
-	if s.proxyConfig.OrgSshCA == nil {
-		return nil, errors.New("error: unable to validate certificate, no CA configured")
-	}
-
-	if bytes.Equal(cert.SignatureKey.Marshal(), s.proxyConfig.OrgSshCA.Marshal()) {
-	} else {
-		return nil, errors.New("error: invalid client certificate")
-	}
-
-	if s.e2eeMetadata.UserEmail != cert.KeyId {
-		return nil, errors.New("error: ssh certificate does not match tls certificate")
-	}
-
-	var certChecker ssh.CertChecker
-	if err := certChecker.CheckCert("mysocket_ssh_signed", cert); err != nil {
-		return nil, fmt.Errorf("error: invalid client certificate: %s", err)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	actions, _, err := s.proxyConfig.Border0API.Evaluate(ctx, s.proxyConfig.Socket, s.e2eeMetadata.ClientIP, s.e2eeMetadata.UserEmail, s.e2eeMetadata.SessionKey)
-	if err != nil {
-		return nil, fmt.Errorf("error: failed to authorize: %s", err)
-	}
-
-	if len(actions) == 0 {
-		return nil, errors.New("error: authorization failed")
-	}
-
-	return &ssh.Permissions{}, nil
 }

--- a/internal/ssh/session/session.go
+++ b/internal/ssh/session/session.go
@@ -1,16 +1,9 @@
 package session
 
 import (
-	"encoding/binary"
 	"net"
 )
 
 type SessionHandler interface {
 	Proxy(conn net.Conn)
-}
-
-func parseDims(b []byte) (uint32, uint32) {
-	w := binary.BigEndian.Uint32(b)
-	h := binary.BigEndian.Uint32(b[4:])
-	return w, h
 }


### PR DESCRIPTION
## [[ME-2408](https://mysocket.atlassian.net/browse/ME-2408)] Abstract/Refactor E2EE PublicKeyCallback Handler

Extract generic public key callback handler code into a generic function to-be-shared by all implementations of the `SessionHandler` interface.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2408

## Type of change

REFACTOR

# How Has This Been Tested?

Tested all socket types continue to operate normally with a modified version of the connector locally.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2408]: https://mysocket.atlassian.net/browse/ME-2408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ