### PR TITLE
feat(ME-2378): add tls mssql support and  aws IAM auth and gcp cloudsql proxy support for sqlserver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -208,4 +208,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/microsoft/go-mssqldb v1.6.0 => github.com/borderzero/go-mssqldb v1.6.1
+replace github.com/microsoft/go-mssqldb v1.6.0 => github.com/borderzero/go-mssqldb v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/borderzero/border0-proto v1.0.19 h1:2L/cg/f7kZpbqxSdx28wsMO/r5ZzDmoD1
 github.com/borderzero/border0-proto v1.0.19/go.mod h1:BhNopgYg3o/p5bYLVcKYISS4S49Ci6iAWNCbQpTzzqs=
 github.com/borderzero/discovery v0.1.30 h1:7FQB/wH6Q5GLiX9B2UbbP3qMzpvSvQPFJr+eqwsGcD4=
 github.com/borderzero/discovery v0.1.30/go.mod h1:gyp4pGzlzzVz3Xr7+cMDqkzWAhKO+MlNcdgY95J86rQ=
-github.com/borderzero/go-mssqldb v1.6.1 h1:SSxizUxa8SbJge6s05UomtLIZfQ++XVB/r3srdkLV3Y=
-github.com/borderzero/go-mssqldb v1.6.1/go.mod h1:00mDtPbeQCRGC1HwOOR5K/gr30P1NcEG0vx6Kbv2aJU=
+github.com/borderzero/go-mssqldb v1.6.2 h1:XuTotditOiezp7KVBIZ3C60SXdNKPn5fmLQiVu6JXTs=
+github.com/borderzero/go-mssqldb v1.6.2/go.mod h1:00mDtPbeQCRGC1HwOOR5K/gr30P1NcEG0vx6Kbv2aJU=
 github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=
 github.com/brianvoe/gofakeit v3.18.0+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=

--- a/internal/sqlauthproxy/mssql.go
+++ b/internal/sqlauthproxy/mssql.go
@@ -7,7 +7,10 @@ import (
 	"net"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	"github.com/borderzero/border0-cli/internal/border0"
+	"github.com/borderzero/border0-cli/internal/util"
 	"github.com/borderzero/border0-go/lib/types/pointer"
 	mssql "github.com/microsoft/go-mssqldb"
 	"github.com/microsoft/go-mssqldb/msdsn"
@@ -17,14 +20,26 @@ import (
 
 type mssqlHandler struct {
 	Config
-	UpstreamConfig msdsn.Config
-	server         *mssql.Server
+	UpstreamConfig  msdsn.Config
+	server          *mssql.Server
+	awsCredentials  aws.CredentialsProvider
+	upstreamAddress string
 }
 
 func newMssqlHandler(c Config) (*mssqlHandler, error) {
 	config, err := msdsn.Parse(fmt.Sprintf("sqlserver://%s:%s@%s:%d", c.Username, c.Password, c.Hostname, c.Port))
 	if err != nil {
 		return nil, err
+	}
+
+	upstreamAddress := net.JoinHostPort(c.Hostname, fmt.Sprintf("%d", c.Port))
+	var awsCredentials aws.CredentialsProvider
+	if c.RdsIam {
+		cfg, err := util.GetAwsConfig(context.Background(), c.AwsRegion, c.AwsCredentials)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize AWS client: %v", err)
+		}
+		awsCredentials = cfg.Credentials
 	}
 
 	if c.UpstreamTLS {
@@ -77,10 +92,20 @@ func newMssqlHandler(c Config) (*mssqlHandler, error) {
 	}
 
 	return &mssqlHandler{
-		Config:         c,
-		UpstreamConfig: config,
-		server:         server,
+		Config:          c,
+		UpstreamConfig:  config,
+		server:          server,
+		awsCredentials:  awsCredentials,
+		upstreamAddress: upstreamAddress,
 	}, nil
+}
+
+type gcpDialer struct {
+	DialContextFunc func(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+func (d gcpDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	return d.DialContextFunc(ctx, network, addr)
 }
 
 func (h mssqlHandler) handleClient(c net.Conn) {
@@ -96,9 +121,27 @@ func (h mssqlHandler) handleClient(c net.Conn) {
 	}
 
 	h.UpstreamConfig.Database = login.Database
+	var tokenProvider func(ctx context.Context) (string, error)
+
+	if h.RdsIam {
+		tokenProvider = func(ctx context.Context) (string, error) {
+			authToken, err := auth.BuildAuthToken(ctx, h.upstreamAddress, h.AwsRegion, h.Username, h.awsCredentials)
+			if err != nil {
+				h.Logger.Error("failed to create authentication token", zap.Error(err))
+				return "", err
+
+			}
+			return authToken, nil
+		}
+	}
+
+	var dialer mssql.Dialer
+	if h.DialerFunc != nil {
+		dialer = gcpDialer{DialContextFunc: h.DialerFunc}
+	}
 
 	// connect upstream
-	upstreamConn, err := mssql.NewClient(ctx, h.UpstreamConfig)
+	upstreamConn, err := mssql.NewClient(ctx, h.UpstreamConfig, tokenProvider, dialer)
 	if err != nil {
 		h.Logger.Error("failed to connect upstream", zap.Error(err))
 		return

--- a/internal/sqlauthproxy/mssql.go
+++ b/internal/sqlauthproxy/mssql.go
@@ -57,8 +57,6 @@ func newMssqlHandler(c Config) (*mssqlHandler, error) {
 			}
 			config.TLSConfig.RootCAs = caPool
 			config.TLSConfig.ServerName = c.Hostname
-		} else {
-			config.TLSConfig.InsecureSkipVerify = true
 		}
 
 		if len(c.UpstreamCertBlock) > 0 && len(c.UpstreamKeyBlock) > 0 {

--- a/vendor/github.com/microsoft/go-mssqldb/proxy.go
+++ b/vendor/github.com/microsoft/go-mssqldb/proxy.go
@@ -634,8 +634,18 @@ func writeLoginAck(l loginAckStruct) []byte {
 	return data
 }
 
-func NewClient(ctx context.Context, params msdsn.Config) (*Client, error) {
+func NewClient(ctx context.Context, params msdsn.Config, tokenProvider func(ctx context.Context) (string, error), dialer Dialer) (*Client, error) {
 	c := newConnector(params, driverInstanceNoProcess)
+
+	if tokenProvider != nil {
+		c.fedAuthRequired = true
+		c.fedAuthLibrary = FedAuthLibrarySecurityToken
+		c.securityTokenProvider = tokenProvider
+	}
+
+	if dialer != nil {
+		c.Dialer = dialer
+	}
 
 	conn, err := c.Connect(ctx)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -568,7 +568,7 @@ github.com/mdp/qrterminal
 # github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 ## explicit
 github.com/mgutz/ansi
-# github.com/microsoft/go-mssqldb v1.6.0 => github.com/borderzero/go-mssqldb v1.6.1
+# github.com/microsoft/go-mssqldb v1.6.0 => github.com/borderzero/go-mssqldb v1.6.2
 ## explicit; go 1.17
 github.com/microsoft/go-mssqldb
 github.com/microsoft/go-mssqldb/aecmk


### PR DESCRIPTION
# Description

add tls mssql support
Fixes # (ME-2378)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

tested in staging

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
