### PR TITLE
ME-2495: fix hostkey and certificate reading/storing

### DIFF
--- a/cmd/socket.go
+++ b/cmd/socket.go
@@ -336,7 +336,7 @@ var socketConnectProxyCmd = &cobra.Command{
 		if socket.EndToEndEncryptionEnabled {
 			certificate, err := util.GetEndToEndEncryptionCertificate(socket.Organization.ID, "")
 			if err != nil {
-				return fmt.Errorf("failed to get connector certificate: %w", err)
+				log.Printf("failed to get connector certificate: %s", err)
 			}
 
 			if certificate == nil {
@@ -390,8 +390,8 @@ var socketConnectProxyCmd = &cobra.Command{
 
 				certificate = &tlsCert
 
-				if err := util.StoreConnectorCertifcate(privKey, cert, orgID, ""); err != nil {
-					logger.Logger.Warn("failed to store certificate", zap.Error(err))
+				if err := util.StoreConnectorCertifcate(pem.EncodeToMemory(privKeyPem), cert, orgID, ""); err != nil {
+					log.Printf("failed to store certificate: %s", err)
 				}
 			}
 
@@ -470,7 +470,7 @@ var socketConnectVpnCmd = &cobra.Command{
 		if socket.EndToEndEncryptionEnabled {
 			certificate, err := util.GetEndToEndEncryptionCertificate(socket.Organization.ID, "")
 			if err != nil {
-				return fmt.Errorf("failed to get connector certificate: %w", err)
+				log.Printf("failed to get connector certificate: %s", err)
 			}
 
 			if certificate == nil {
@@ -524,8 +524,8 @@ var socketConnectVpnCmd = &cobra.Command{
 
 				certificate = &tlsCert
 
-				if err := util.StoreConnectorCertifcate(privKey, cert, orgID, ""); err != nil {
-					logger.Logger.Warn("failed to store certificate", zap.Error(err))
+				if err := util.StoreConnectorCertifcate(pem.EncodeToMemory(privKeyPem), cert, orgID, ""); err != nil {
+					log.Printf("failed to store certificate: %s", err)
 				}
 			}
 
@@ -687,7 +687,7 @@ var socketConnectCmd = &cobra.Command{
 		if socket.EndToEndEncryptionEnabled {
 			certificate, err := util.GetEndToEndEncryptionCertificate(socket.Organization.ID, "")
 			if err != nil {
-				return fmt.Errorf("failed to get connector certificate: %w", err)
+				log.Printf("failed to get connector certificate: %s", err)
 			}
 
 			if certificate == nil {
@@ -741,8 +741,8 @@ var socketConnectCmd = &cobra.Command{
 
 				certificate = &tlsCert
 
-				if err := util.StoreConnectorCertifcate(privKey, cert, orgID, ""); err != nil {
-					logger.Logger.Warn("failed to store certificate", zap.Error(err))
+				if err := util.StoreConnectorCertifcate(pem.EncodeToMemory(privKeyPem), cert, orgID, ""); err != nil {
+					log.Printf("failed to store certificate: %s", err)
 				}
 			}
 

--- a/internal/connector/core/core.go
+++ b/internal/connector/core/core.go
@@ -607,17 +607,19 @@ func (c *ConnectorCore) hostkey() (*gossh.Signer, error) {
 		return c.sshPrivateHostKey, nil
 	}
 
-	signer, err := util.Hostkey()
+	hostkeySigner, err := util.Hostkey()
 	if err != nil {
-		if signer == nil {
-			return nil, err
+		if hostkeySigner == nil {
+			return nil, fmt.Errorf("failed to get hostkey: %s", err)
 		} else {
 			c.logger.Warn("failed to store hostkey", zap.Error(err))
 		}
 	}
 
-	c.sshPrivateHostKey = signer
+	c.sshPrivateHostKey = hostkeySigner
+
 	return c.sshPrivateHostKey, nil
+
 }
 
 func (c *ConnectorCore) certificate(ctx context.Context, orgID string) (*tls.Certificate, error) {

--- a/internal/connector/core/core.go
+++ b/internal/connector/core/core.go
@@ -632,63 +632,66 @@ func (c *ConnectorCore) certificate(ctx context.Context, orgID string) (*tls.Cer
 
 	certificate, err := util.GetEndToEndEncryptionCertificate(orgID, "")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get connector certificate: %w", err)
+		c.logger.Warn("failed to get certificate", zap.Error(err))
 	}
 
-	if certificate == nil {
-		_, privKey, err := ed25519.GenerateKey(rand.Reader)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate private key: %w", err)
-		}
+	if certificate != nil {
+		c.connectorCertificate = certificate
+		return c.connectorCertificate, nil
+	}
 
-		csrTemplate := x509.CertificateRequest{
-			Subject:            pkix.Name{CommonName: "border0"},
-			SignatureAlgorithm: x509.PureEd25519,
-		}
+	_, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
 
-		csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csrTemplate, privKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create certificate request: %w", err)
-		}
+	csrTemplate := x509.CertificateRequest{
+		Subject:            pkix.Name{CommonName: "border0"},
+		SignatureAlgorithm: x509.PureEd25519,
+	}
 
-		csrPem := pem.Block{
-			Type:  "CERTIFICATE REQUEST",
-			Bytes: csrBytes,
-		}
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csrTemplate, privKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create certificate request: %w", err)
+	}
 
-		var name string
-		hostname, err := os.Hostname()
-		if err != nil {
-			name = "border0-cli"
-		} else {
-			name = hostname
-		}
+	csrPem := pem.Block{
+		Type:  "CERTIFICATE REQUEST",
+		Bytes: csrBytes,
+	}
 
-		cert, err := c.border0API.ServerOrgCertificate(ctx, name, pem.EncodeToMemory(&csrPem))
-		if err != nil {
-			return nil, fmt.Errorf("failed to get certificate: %w", err)
-		}
+	var name string
+	hostname, err := os.Hostname()
+	if err != nil {
+		name = "border0-cli"
+	} else {
+		name = hostname
+	}
 
-		privKeyBytes, err := x509.MarshalPKCS8PrivateKey(privKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal private key: %w", err)
-		}
+	cert, err := c.border0API.ServerOrgCertificate(ctx, name, pem.EncodeToMemory(&csrPem))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get certificate: %w", err)
+	}
 
-		privKeyPem := &pem.Block{
-			Type:  "PRIVATE KEY",
-			Bytes: privKeyBytes,
-		}
+	privKeyBytes, err := x509.MarshalPKCS8PrivateKey(privKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
 
-		tlsCert, err := tls.X509KeyPair(cert, pem.EncodeToMemory(privKeyPem))
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse certificate: %w", err)
-		}
+	privKeyPem := &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: privKeyBytes,
+	}
 
-		c.connectorCertificate = &tlsCert
+	tlsCert, err := tls.X509KeyPair(cert, pem.EncodeToMemory(privKeyPem))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate: %w", err)
+	}
 
-		if err := util.StoreConnectorCertifcate(privKey, cert, orgID, ""); err != nil {
-			c.logger.Warn("failed to store certificate", zap.Error(err))
-		}
+	c.connectorCertificate = &tlsCert
+
+	if err := util.StoreConnectorCertifcate(pem.EncodeToMemory(privKeyPem), cert, orgID, ""); err != nil {
+		c.logger.Warn("failed to store certificate", zap.Error(err))
 	}
 
 	return c.connectorCertificate, nil

--- a/internal/connector_v2/service.go
+++ b/internal/connector_v2/service.go
@@ -13,8 +13,6 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"os"
-	"os/user"
 	"strings"
 	"sync"
 	"time"
@@ -933,68 +931,16 @@ func (c *ConnectorService) hostkey() (*gossh.Signer, error) {
 		return c.sshPrivateHostKey, nil
 	}
 
-	var keyFilePath string
-	if _, err := os.Stat(serviceConfigPath + sshHostKeyFile); err == nil {
-		keyFilePath = serviceConfigPath + sshHostKeyFile
-	} else {
-		u, err := user.Current()
-		if err == nil {
-			if _, err := os.Stat(u.HomeDir + "/.border0/" + sshHostKeyFile); err == nil {
-				keyFilePath = u.HomeDir + "/.border0/" + sshHostKeyFile
-			}
-		}
-	}
-
-	if keyFilePath != "" {
-		keyBytes, err := os.ReadFile(keyFilePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read host key %s: %w", keyFilePath, err)
-		}
-
-		privateKey, err := gossh.ParsePrivateKey(keyBytes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse host key: %w", err)
-		}
-
-		c.sshPrivateHostKey = &privateKey
-		return c.sshPrivateHostKey, nil
-	}
-
-	_, privKey, err := ed25519.GenerateKey(rand.Reader)
+	hostkeySigner, err := b0Util.Hostkey()
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate host key: %w", err)
-	}
-
-	sshPrivKey, err := gossh.NewSignerFromKey(privKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert ed25519 key to ssh key: %w", err)
-	}
-
-	c.sshPrivateHostKey = &sshPrivKey
-
-	pkcs8Bytes, err := x509.MarshalPKCS8PrivateKey(privKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal private key to PKCS#8: %w", err)
-	}
-
-	privKeyPEM := &pem.Block{
-		Type:  "PRIVATE KEY",
-		Bytes: pkcs8Bytes,
-	}
-
-	serviceConfigPathErr := b0Util.StoreHostkey(pem.EncodeToMemory(privKeyPEM), serviceConfigPath, sshHostKeyFile)
-	if serviceConfigPathErr != nil {
-		u, err := user.Current()
-		if err != nil {
-			return nil, fmt.Errorf("failed to store the ssh hostkey file %w %w", err, serviceConfigPathErr)
-		}
-
-		err = b0Util.StoreHostkey(pem.EncodeToMemory(privKeyPEM), u.HomeDir+"/.border0/", sshHostKeyFile)
-		if err != nil {
-			c.logger.Warn("failed to store the ssh hostkey file", zap.Error(serviceConfigPathErr), zap.Error(err))
-			return c.sshPrivateHostKey, nil
+		if hostkeySigner == nil {
+			return nil, fmt.Errorf("failed to get hostkey: %s", err)
+		} else {
+			c.logger.Warn("failed to store hostkey", zap.Error(err))
 		}
 	}
+
+	c.sshPrivateHostKey = hostkeySigner
 
 	return c.sshPrivateHostKey, nil
 }

--- a/internal/connector_v2/service.go
+++ b/internal/connector_v2/service.go
@@ -971,7 +971,11 @@ func (c *ConnectorService) Certificate() (*tls.Certificate, error) {
 
 	c.connectorCertificate, err = b0Util.GetEndToEndEncryptionCertificate(orgID, connectorID)
 	if err != nil {
-		return nil, err
+		c.logger.Warn("failed to get end to end encryption certificate", zap.Error(err))
+	}
+
+	if c.connectorCertificate != nil {
+		return c.connectorCertificate, nil
 	}
 
 	_, privKey, err := ed25519.GenerateKey(rand.Reader)
@@ -1045,7 +1049,7 @@ func (c *ConnectorService) Certificate() (*tls.Certificate, error) {
 
 	c.connectorCertificate = &cert
 
-	if err := b0Util.StoreConnectorCertifcate(privKeyBytes, certificate, orgID, connectorID); err != nil {
+	if err := b0Util.StoreConnectorCertifcate(pem.EncodeToMemory(privKeyPem), certificate, orgID, connectorID); err != nil {
 		c.logger.Warn("failed to store the end to end encryption certificate", zap.Error(err))
 	}
 

--- a/internal/util/certificate.go
+++ b/internal/util/certificate.go
@@ -37,25 +37,24 @@ func GetEndToEndEncryptionCertificate(orgID, connectorID string) (*tls.Certifica
 		}
 	}
 
+	var userKeyFilePath, userCertFilePath string
 	u, err := user.Current()
 	if err == nil {
 		if _, err := os.Stat(u.HomeDir + "/.border0/" + privateKeyFile); err == nil {
-			keyFilePath = u.HomeDir + "/.border0/" + privateKeyFile
+			userKeyFilePath = u.HomeDir + "/.border0/" + privateKeyFile
 		}
 
 		if _, err := os.Stat(u.HomeDir + "/.border0/" + certificateFile); err == nil {
-			certFilePath = u.HomeDir + "/.border0/" + certificateFile
+			userCertFilePath = u.HomeDir + "/.border0/" + certificateFile
 		}
 	}
 
-	if keyFilePath != "" && certFilePath != "" {
-		if keyFilePath != "" && certFilePath != "" {
-			certificate, err2 := readCertificate(keyFilePath, certFilePath)
-			if err != nil {
-				errors = append(errors, err2)
-			} else {
-				return certificate, nil
-			}
+	if userKeyFilePath != "" && userCertFilePath != "" {
+		certificate, err := readCertificate(userKeyFilePath, userCertFilePath)
+		if err != nil {
+			errors = append(errors, err)
+		} else {
+			return certificate, nil
 		}
 	}
 

--- a/internal/util/hostkey.go
+++ b/internal/util/hostkey.go
@@ -19,32 +19,45 @@ const (
 
 // Hostkey returns the ssh signer for the connector host.
 func Hostkey() (*ssh.Signer, error) {
-	var keyFilePath string
+	var errors []error
+
 	if _, err := os.Stat(serviceConfigPath + sshHostKeyFile); err == nil {
-		keyFilePath = serviceConfigPath + sshHostKeyFile
-	} else {
-		u, err := user.Current()
-		if err == nil {
-			if _, err := os.Stat(u.HomeDir + "/.border0/" + sshHostKeyFile); err == nil {
-				keyFilePath = u.HomeDir + "/.border0/" + sshHostKeyFile
+		keyFilePath := serviceConfigPath + sshHostKeyFile
+		signer, err := signer(keyFilePath)
+		if err != nil {
+			errors = append(errors, err)
+		} else {
+			return signer, nil
+		}
+	}
+
+	u, err := user.Current()
+	if err == nil {
+		if _, err := os.Stat(u.HomeDir + "/.border0/" + sshHostKeyFile); err == nil {
+			keyFilePath := u.HomeDir + "/.border0/" + sshHostKeyFile
+			signer, err := signer(keyFilePath)
+			if err != nil {
+				errors = append(errors, err)
+			} else {
+				return signer, nil
 			}
 		}
 	}
 
-	if keyFilePath != "" {
-		keyBytes, err := os.ReadFile(keyFilePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read host key %s: %w", keyFilePath, err)
-		}
-
-		privateKey, err := ssh.ParsePrivateKey(keyBytes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse host key: %w", err)
-		}
-
-		return &privateKey, nil
+	// no existing host key found, generate a new one
+	signer, err := generateHostkey()
+	if err != nil {
+		errors = append(errors, err)
 	}
 
+	if len(errors) > 0 {
+		return signer, fmt.Errorf("%s", errors)
+	}
+
+	return signer, nil
+}
+
+func generateHostkey() (*ssh.Signer, error) {
 	_, privKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate host key: %w", err)
@@ -79,6 +92,20 @@ func Hostkey() (*ssh.Signer, error) {
 	}
 
 	return &sshPrivKey, nil
+}
+
+func signer(keyFilePath string) (*ssh.Signer, error) {
+	keyBytes, err := os.ReadFile(keyFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read host key %s: %w", keyFilePath, err)
+	}
+
+	privateKey, err := ssh.ParsePrivateKey(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse host key: %w", err)
+	}
+
+	return &privateKey, nil
 }
 
 func StoreHostkey(key []byte, path, filename string) error {


### PR DESCRIPTION
# Description

fix hostkey and certificate reading/storing
Fixes # (ME-2495)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally with non existing certificates and hostkeys, with invalid certificates in both `socket connect` mode and connector mode.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
