### PR TITLE
[ME-2604] Add 'border0 client vnc' and 'border0 client rdp' commands

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/borderzero/border0-cli/client/preference"
 	"github.com/borderzero/border0-cli/cmd/client/db"
+	"github.com/borderzero/border0-cli/cmd/client/rdp"
 	clientTls "github.com/borderzero/border0-cli/cmd/client/tls"
+	"github.com/borderzero/border0-cli/cmd/client/vnc"
 	"github.com/borderzero/border0-cli/cmd/logger"
 
 	"github.com/borderzero/border0-cli/cmd/client/hosts"
@@ -146,6 +148,8 @@ func init() {
 	hosts.AddCommandsTo(clientCmd)
 	ssh.AddCommandsTo(clientCmd)
 	clientTls.AddCommandsTo(clientCmd)
+	rdp.AddCommandsTo(clientCmd)
+	vnc.AddCommandsTo(clientCmd)
 	vpn.AddCommandsTo(clientCmd)
 	httpproxy.AddCommandsTo(clientCmd)
 }

--- a/cmd/client/rdp/rdp.go
+++ b/cmd/client/rdp/rdp.go
@@ -1,0 +1,45 @@
+package rdp
+
+import (
+	"fmt"
+
+	"github.com/borderzero/border0-cli/cmd/client/utils"
+	"github.com/borderzero/border0-cli/internal/client"
+	"github.com/borderzero/border0-cli/internal/enum"
+	"github.com/spf13/cobra"
+)
+
+var (
+	hostname          string
+	localListenerPort int
+)
+
+// clientRdpCmd represents the client rdp command
+var clientRdpCmd = &cobra.Command{
+	Use:               "rdp",
+	Short:             "Connect to an RDP socket",
+	ValidArgsFunction: client.AutocompleteHost,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			hostname = args[0]
+		}
+
+		if hostname == "" {
+			pickedHost, err := client.PickHost(hostname, enum.TLSSocket)
+			if err != nil {
+				return fmt.Errorf("failed to pick host: %v", err)
+			}
+			hostname = pickedHost.Hostname()
+		}
+
+		return utils.StartLocalProxyAndOpenClient(cmd, args, "rdp", hostname, localListenerPort)
+	},
+}
+
+func AddCommandsTo(client *cobra.Command) {
+	client.AddCommand(clientRdpCmd)
+
+	clientRdpCmd.Flags().StringVarP(&hostname, "service", "", "", "The Border0 service identifier")
+	clientRdpCmd.Flags().IntVarP(&localListenerPort, "local-listener-port", "l", 3389, "Local listener port number")
+}

--- a/cmd/client/utils/copy.go
+++ b/cmd/client/utils/copy.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"io"
+	"log"
+	"net"
+	"strings"
+)
+
+func Copy(a, b io.ReadWriter) {
+	toStdoutChan := copyStream(a, b)
+	toRemoteChan := copyStream(b, a)
+
+	select {
+	case <-toStdoutChan:
+	case <-toRemoteChan:
+	}
+}
+
+// Performs copy operation between streams: os and tcp streams
+func copyStream(src io.Reader, dst io.Writer) <-chan int {
+	buf := make([]byte, 1024)
+	syncChannel := make(chan int)
+	go func() {
+		defer func() {
+			if con, ok := dst.(net.Conn); ok {
+				con.Close()
+			}
+			syncChannel <- 0 // Notify that processing is finished
+		}()
+		for {
+			var nBytes int
+			var err error
+			nBytes, err = src.Read(buf)
+			if err != nil {
+				if err != io.EOF && !strings.Contains(err.Error(), "use of closed network connection") {
+					log.Printf("Read error: %s\n", err)
+				}
+				break
+			}
+			_, err = dst.Write(buf[0:nBytes])
+			if err != nil {
+				log.Fatalf("Write error: %s\n", err)
+			}
+		}
+	}()
+	return syncChannel
+}

--- a/cmd/client/utils/local_proxy_and_client.go
+++ b/cmd/client/utils/local_proxy_and_client.go
@@ -1,0 +1,114 @@
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/borderzero/border0-cli/cmd/logger"
+	"github.com/borderzero/border0-cli/internal/client"
+	"github.com/skratchdot/open-golang/open"
+	"github.com/spf13/cobra"
+)
+
+func openRDP(address string) error {
+	rdpFileContents := []byte(fmt.Sprintf("full address:s:%s\nprompt for credentials:i:1", address))
+
+	// Create temporary .rdp file
+	tmpDir := os.TempDir()
+	defer os.RemoveAll(tmpDir)
+
+	rdpFilePath := filepath.Join(tmpDir, "temp.rdp")
+	if err := os.WriteFile(rdpFilePath, rdpFileContents, 0644); err != nil {
+		return fmt.Errorf("failed to create RDP file: %w", err)
+	}
+
+	// We open the client twice... because
+	// Microsoft's Remote Desktop client refuses
+	// to configure a new machine if the app is not
+	// already open.
+	open.Run(rdpFilePath)
+	time.Sleep(time.Second * 1)
+	return open.Run(rdpFilePath)
+}
+
+// StartLocalProxyAndOpenClient starts a local listener on the given
+// local port and opens the system's default client application
+// for specified protocol.
+func StartLocalProxyAndOpenClient(
+	cmd *cobra.Command,
+	args []string,
+	protocol string,
+	hostname string,
+	localListenerPort int,
+) error {
+	info, err := client.GetResourceInfo(logger.Logger, hostname)
+	if err != nil {
+		return fmt.Errorf("failed to get certificate: %v", err)
+	}
+
+	certificate := tls.Certificate{
+		Certificate: [][]byte{info.Certficate.Raw},
+		PrivateKey:  info.PrivateKey,
+	}
+
+	systemCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		log.Fatalf("failed to get system cert pool: %v", err.Error())
+	}
+
+	tlsConfig := tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		RootCAs:      systemCertPool,
+		ServerName:   hostname,
+	}
+
+	localListenerAddress := fmt.Sprintf("localhost:%d", localListenerPort)
+
+	l, err := net.Listen("tcp", localListenerAddress)
+	if err != nil {
+		log.Fatalln("Error: Unable to start local TLS listener.")
+	}
+	log.Print("Waiting for connections...")
+
+	go func() {
+		var err error
+		if protocol == "rdp" {
+			err = openRDP(localListenerAddress)
+		} else {
+			err = open.Run(fmt.Sprintf("%s://%s", protocol, localListenerAddress))
+		}
+		if err != nil {
+			log.Print(fmt.Sprintf("Failed to open system's %s client: %v", protocol, err))
+		}
+	}()
+
+	for {
+		lcon, err := l.Accept()
+		if err != nil {
+			log.Fatalf("Listener: Accept Error: %s\n", err)
+		}
+
+		go func() {
+			conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
+			if err != nil {
+				fmt.Printf("failed to connect to %s:%d: %s\n", hostname, info.Port, err)
+			}
+
+			if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
+				conn, err = client.ConnectWithConn(conn, certificate, info.CaCertificate, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
+				if err != nil {
+					fmt.Printf("failed to connect: %s\n", err)
+				}
+			}
+
+			log.Print("Connection established from ", lcon.RemoteAddr())
+			Copy(conn, lcon)
+		}()
+	}
+}

--- a/cmd/client/vnc/vnc.go
+++ b/cmd/client/vnc/vnc.go
@@ -1,0 +1,45 @@
+package vnc
+
+import (
+	"fmt"
+
+	"github.com/borderzero/border0-cli/cmd/client/utils"
+	"github.com/borderzero/border0-cli/internal/client"
+	"github.com/borderzero/border0-cli/internal/enum"
+	"github.com/spf13/cobra"
+)
+
+var (
+	hostname          string
+	localListenerPort int
+)
+
+// clientVncCmd represents the client vnc command
+var clientVncCmd = &cobra.Command{
+	Use:               "vnc",
+	Short:             "Connect to a VNC socket",
+	ValidArgsFunction: client.AutocompleteHost,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) > 0 {
+			hostname = args[0]
+		}
+
+		if hostname == "" {
+			pickedHost, err := client.PickHost(hostname, enum.TLSSocket)
+			if err != nil {
+				return fmt.Errorf("failed to pick host: %v", err)
+			}
+			hostname = pickedHost.Hostname()
+		}
+
+		return utils.StartLocalProxyAndOpenClient(cmd, args, "vnc", hostname, localListenerPort)
+	},
+}
+
+func AddCommandsTo(client *cobra.Command) {
+	client.AddCommand(clientVncCmd)
+
+	clientVncCmd.Flags().StringVarP(&hostname, "service", "", "", "The Border0 service identifier")
+	clientVncCmd.Flags().IntVarP(&localListenerPort, "local-listener-port", "l", 5900, "Local listener port number")
+}


### PR DESCRIPTION
## [[ME-2604](https://mysocket.atlassian.net/browse/ME-2604)] Add 'border0 client vnc' and 'border0 client rdp' commands

Just adding a couple of commands to make it easier to deal with vnc/rdp services behind vanilla TCP (a.k.a. TLS) sockets.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2604

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested locally for both VNC and RDP services.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2604]: https://mysocket.atlassian.net/browse/ME-2604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ