### PR TITLE
[ME-2604] Revert vnc/rdp refactor code changes

### DIFF
--- a/cmd/client/tls/tls.go
+++ b/cmd/client/tls/tls.go
@@ -1,7 +1,6 @@
 package tls
 
 import (
-	"bufio"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -99,7 +98,7 @@ var clientTlsCmd = &cobra.Command{
 					}
 
 					log.Print("Connection established from ", lcon.RemoteAddr())
-					utils.Copy(conn, lcon)
+					utils.Copy(conn, lcon, lcon)
 				}()
 			}
 		} else {
@@ -115,7 +114,7 @@ var clientTlsCmd = &cobra.Command{
 				}
 			}
 
-			utils.Copy(conn, bufio.ReadWriter{Reader: bufio.NewReader(os.Stdin), Writer: bufio.NewWriter(os.Stdout)})
+			utils.Copy(conn, os.Stdin, os.Stdout)
 		}
 
 		return err

--- a/cmd/client/utils/copy.go
+++ b/cmd/client/utils/copy.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 )
 
-func Copy(a, b io.ReadWriter) {
-	toStdoutChan := copyStream(a, b)
-	toRemoteChan := copyStream(b, a)
+func Copy(conn net.Conn, in io.Reader, out io.Writer) {
+	toStdoutChan := copyStream(conn, out)
+	toRemoteChan := copyStream(in, conn)
 
 	select {
 	case <-toStdoutChan:

--- a/cmd/client/utils/local_proxy_and_client.go
+++ b/cmd/client/utils/local_proxy_and_client.go
@@ -111,7 +111,7 @@ func StartLocalProxyAndOpenClient(
 			}
 
 			log.Print("Connection established from ", lcon.RemoteAddr())
-			Copy(conn, lcon)
+			Copy(conn, lcon, lcon)
 		}()
 	}
 }


### PR DESCRIPTION
## [[ME-2604](https://mysocket.atlassian.net/browse/ME-2604)] Revert vnc/rdp refactor code changes

We think that using buffered reader/writers breaks `border0 client tls` for the raw SSH client flow.