### PR TITLE
ME-2632 Dynamic Port allocation for RDP and VNC

### DIFF
--- a/cmd/client/rdp/rdp.go
+++ b/cmd/client/rdp/rdp.go
@@ -41,5 +41,5 @@ func AddCommandsTo(client *cobra.Command) {
 	client.AddCommand(clientRdpCmd)
 
 	clientRdpCmd.Flags().StringVarP(&hostname, "service", "", "", "The Border0 service identifier")
-	clientRdpCmd.Flags().IntVarP(&localListenerPort, "local-listener-port", "l", 3389, "Local listener port number")
+	clientRdpCmd.Flags().IntVarP(&localListenerPort, "local-listener-port", "l", 0, "Local listener port number")
 }

--- a/cmd/client/utils/local_proxy_and_client.go
+++ b/cmd/client/utils/local_proxy_and_client.go
@@ -77,7 +77,15 @@ func StartLocalProxyAndOpenClient(
 	if err != nil {
 		log.Fatalln("Error: Unable to start local TLS listener.")
 	}
-	log.Print("Waiting for connections...")
+
+	// if the user didn't specify a local listener port, we used 0 to let the OS pick a port
+	// we need to update the localListenerAddress to reflect the actual port chosen by the OS
+	if localListenerPort == 0 {
+		allocatedPort := l.Addr().(*net.TCPAddr).Port
+		localListenerAddress = fmt.Sprintf("localhost:%d", allocatedPort)
+	}
+
+	log.Print("Waiting for connections on ", localListenerAddress, "...")
 
 	go func() {
 		var err error
@@ -87,7 +95,7 @@ func StartLocalProxyAndOpenClient(
 			err = open.Run(fmt.Sprintf("%s://%s", protocol, localListenerAddress))
 		}
 		if err != nil {
-			log.Print(fmt.Sprintf("Failed to open system's %s client: %v", protocol, err))
+			log.Printf("Failed to open system's %s client: %v", protocol, err)
 		}
 	}()
 

--- a/cmd/client/vnc/vnc.go
+++ b/cmd/client/vnc/vnc.go
@@ -41,5 +41,5 @@ func AddCommandsTo(client *cobra.Command) {
 	client.AddCommand(clientVncCmd)
 
 	clientVncCmd.Flags().StringVarP(&hostname, "service", "", "", "The Border0 service identifier")
-	clientVncCmd.Flags().IntVarP(&localListenerPort, "local-listener-port", "l", 5900, "Local listener port number")
+	clientVncCmd.Flags().IntVarP(&localListenerPort, "local-listener-port", "l", 0, "Local listener port number")
 }


### PR DESCRIPTION
# Description

will allocate a port dynamically, so users doesn't have to (but still can) provide a listener port
so you can just type in border0 client rdp and select the socket

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
