### PR TITLE
fix(ME-2653): don't use login cmd if no pty is requested

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/borderzero/border0-cli
 
 go 1.22
 
+toolchain go1.22.0
+
 require (
 	cloud.google.com/go/cloudsqlconn v1.2.4
 	github.com/ActiveState/termtest/conpty v0.5.0

--- a/internal/ssh/server/server_unix.go
+++ b/internal/ssh/server/server_unix.go
@@ -47,7 +47,7 @@ func ExecCmd(channel gossh.Channel, command string, ptyTerm string, isPty bool, 
 		}
 		cmd.Args = append(cmd.Args, "-c", command)
 	} else {
-		if euid == 0 && loginCmd != "" {
+		if euid == 0 && loginCmd != "" && isPty {
 			cmd.Path = loginCmd
 			if hasBusyBoxLogin(loginCmd) {
 				cmd.Args = []string{loginCmd, "-p", "-h", "Border0", "-f", username}


### PR DESCRIPTION
# Description

don't use login cmd if no pty is requested
Fixes # (ME-2653)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with local build.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
