### PR TITLE
fix(ME-2654): fix command execution with pty for connector built-in ssh server (ansible fix)

### DIFF
--- a/internal/ssh/server/server.go
+++ b/internal/ssh/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
@@ -189,6 +188,6 @@ func GetShell(user *user.User) (string, error) {
 
 func execCmd(s ssh.Session, cmd exec.Cmd, uid, gid uint64, username string) {
 	pty, winCh, isPty := s.Pty()
-	exitCode := ExecCmd(context.TODO(), s, s.RawCommand(), pty.Term, isPty, winCh, cmd, uid, gid, username)
+	exitCode := ExecCmd(s.Context(), s, s.RawCommand(), pty.Term, isPty, winCh, cmd, uid, gid, username)
 	s.Exit(exitCode)
 }

--- a/internal/ssh/server/server.go
+++ b/internal/ssh/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"errors"
@@ -188,6 +189,6 @@ func GetShell(user *user.User) (string, error) {
 
 func execCmd(s ssh.Session, cmd exec.Cmd, uid, gid uint64, username string) {
 	pty, winCh, isPty := s.Pty()
-	exitCode := ExecCmd(s, s.RawCommand(), pty.Term, isPty, winCh, cmd, uid, gid, username)
+	exitCode := ExecCmd(context.TODO(), s, s.RawCommand(), pty.Term, isPty, winCh, cmd, uid, gid, username)
 	s.Exit(exitCode)
 }

--- a/internal/ssh/server/server_unix.go
+++ b/internal/ssh/server/server_unix.go
@@ -90,20 +90,8 @@ func ExecCmd(ctx context.Context, channel gossh.Channel, command string, ptyTerm
 			}
 		}()
 
-		go func() {
-			_, err := io.Copy(f, channel)
-			if err != nil {
-				log.Println("stdin copy failed: ", err)
-			}
-		}()
-
-		go func() {
-			_, err := io.Copy(channel, f)
-			if err != nil && err != io.EOF {
-				log.Println("stdout copy failed: ", err)
-			}
-		}()
-
+		go io.Copy(f, channel)
+		go io.Copy(channel, f)
 		done := make(chan error, 1)
 
 		go func() {


### PR DESCRIPTION
# Description

fix command execution with pty for connector built-in ssh server (ansible fix)

Fixes # (ME-2654)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with:
* Ansible
* ansible without ControlMaster
* ansible with pipelining
* echo "ls -l" | ssh -tt ..
*  ssh -tt .. ls -l
*  ssh -tt .. wrongcommand
*  ssh with normal session

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
