### PR TITLE
[ME-2652] Add support for tcp sockets

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -24,7 +24,7 @@ import (
 	"github.com/borderzero/border0-cli/client/preference"
 	"github.com/borderzero/border0-cli/cmd/client/db"
 	"github.com/borderzero/border0-cli/cmd/client/rdp"
-	clientTls "github.com/borderzero/border0-cli/cmd/client/tls"
+	"github.com/borderzero/border0-cli/cmd/client/tcp"
 	"github.com/borderzero/border0-cli/cmd/client/vnc"
 	"github.com/borderzero/border0-cli/cmd/logger"
 
@@ -147,7 +147,7 @@ func init() {
 	db.AddCommandsTo(clientCmd)
 	hosts.AddCommandsTo(clientCmd)
 	ssh.AddCommandsTo(clientCmd)
-	clientTls.AddCommandsTo(clientCmd)
+	tcp.AddCommandsTo(clientCmd)
 	rdp.AddCommandsTo(clientCmd)
 	vnc.AddCommandsTo(clientCmd)
 	vpn.AddCommandsTo(clientCmd)

--- a/internal/connector_v2/upstreamdata/tcp.go
+++ b/internal/connector_v2/upstreamdata/tcp.go
@@ -1,0 +1,22 @@
+package upstreamdata
+
+import (
+	"fmt"
+
+	"github.com/borderzero/border0-cli/internal/api/models"
+	"github.com/borderzero/border0-go/types/service"
+)
+
+func (u *UpstreamDataBuilder) buildUpstreamDataForTcpService(s *models.Socket, config *service.TcpServiceConfiguration) error {
+	if config == nil {
+		return fmt.Errorf("got tcp service with no tcp service configuration")
+	}
+
+	hostname, port := config.Hostname, int(config.Port)
+	s.ConnectorData.TargetHostname = hostname
+	s.ConnectorData.Port = port
+	s.TargetHostname = hostname
+	s.TargetPort = port
+
+	return nil
+}

--- a/internal/connector_v2/upstreamdata/top_level.go
+++ b/internal/connector_v2/upstreamdata/top_level.go
@@ -41,6 +41,8 @@ func (u *UpstreamDataBuilder) Build(s *models.Socket, config service.Configurati
 		return u.buildUpstreamDataForHttpService(s, config.HttpServiceConfiguration)
 	case service.ServiceTypeSsh:
 		return u.buildUpstreamDataForSshService(s, config.SshServiceConfiguration)
+	case service.ServiceTypeTcp:
+		return u.buildUpstreamDataForTcpService(s, config.TcpServiceConfiguration)
 	case service.ServiceTypeTls:
 		return u.buildUpstreamDataForTlsService(s, config.TlsServiceConfiguration)
 	case service.ServiceTypeVnc:


### PR DESCRIPTION
## [[ME-2652](https://mysocket.atlassian.net/browse/ME-2652)] Add support for tcp sockets (client and connector v2)

Adds support for "tcp" sockets and backwards compatibility with TLS sockets (e.g. TLS sockets will show up under tcp command)

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2652

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally... note I can still list tls sockets with the tcp command

```
12:11 $ ./border0 client tcp
? choose a host:  [Use arrows to move, type to filter]
> word-server-olympus.border0.io []
  kali-vnc-olympus.border0.io []
  adrianos-laptop-vnc-olympus.border0.io []
  echo-olympus.border0.io [Authenticated TCP socket playground with Border0 sandbox server.]
  purple-cake-olympus.border0.io []
```

and can still list tls sockets with tls command

```
12:11 $ ./border0 client tls
? choose a host:  [Use arrows to move, type to filter]
> word-server-olympus.border0.io []
  kali-vnc-olympus.border0.io []
  adrianos-laptop-vnc-olympus.border0.io []
  echo-olympus.border0.io [Authenticated TCP socket playground with Border0 sandbox server.]
  purple-cake-olympus.border0.io []
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2652]: https://mysocket.atlassian.net/browse/ME-2652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ