### PR TITLE
[ME-2657] Run VPN Server as Connector Socket

### DIFF
--- a/cmd/client/vpn/vpn.go
+++ b/cmd/client/vpn/vpn.go
@@ -47,7 +47,7 @@ var clientVpnCmd = &cobra.Command{
 		defer cancel()
 
 		if hostname == "" {
-			pickedHost, err := client.PickHost(hostname, enum.TLSSocket)
+			pickedHost, err := client.PickHost(hostname, enum.VPNSocket)
 			if err != nil {
 				return fmt.Errorf("failed to pick host: %v", err)
 			}

--- a/internal/api/models/socket.go
+++ b/internal/api/models/socket.go
@@ -74,7 +74,6 @@ type ConnectorLocalData struct {
 	Kerberos                       bool
 
 	// vpn sockets
-	IsVpn            bool
 	DHCPPoolSubnet   string
 	AdvertisedRoutes []string
 }

--- a/internal/border0/socket.go
+++ b/internal/border0/socket.go
@@ -161,6 +161,10 @@ func NewSocket(ctx context.Context, border0API api.API, nameOrID string, logger 
 	}, nil
 }
 
+func (s *Socket) GetContext() context.Context {
+	return s.context
+}
+
 func NewSocketFromConnectorAPI(ctx context.Context, border0API Border0API, socket models.Socket, org *models.Organization, logger *zap.Logger, certificate *tls.Certificate) (*Socket, error) {
 	newCtx, cancel := context.WithCancel(context.Background())
 

--- a/internal/connector_v2/upstreamdata/vpn.go
+++ b/internal/connector_v2/upstreamdata/vpn.go
@@ -11,7 +11,6 @@ func (u *UpstreamDataBuilder) buildUpstreamDataForVpnService(s *models.Socket, c
 	if config == nil {
 		return fmt.Errorf("got vpn service with no vpn service configuration")
 	}
-	s.ConnectorLocalData.IsVpn = true
 	s.ConnectorLocalData.AdvertisedRoutes = config.AdvertisedRoutes
 	s.ConnectorLocalData.DHCPPoolSubnet = config.DHCPPoolSubnet
 	return nil

--- a/internal/enum/socket_types.go
+++ b/internal/enum/socket_types.go
@@ -9,4 +9,5 @@ const (
 	TLSSocket      = "tls"
 	VNCSocket      = "vnc"
 	RDPSocket      = "rdp"
+	VPNSocket      = "vpn"
 )

--- a/internal/vpnlib/vpnlib.go
+++ b/internal/vpnlib/vpnlib.go
@@ -31,7 +31,7 @@ type ControlMessage struct {
 	ClientIp   string   `json:"client_ip"`
 	ServerIp   string   `json:"server_ip"`
 	SubnetSize uint8    `json:"subnet_size"`
-	Routes     []string `json:"routes"` // CIDRs
+	Routes     []string `json:"routes,omitempty"` // CIDRs
 }
 
 // Build encodes a control message to ready-to-send bytes.


### PR DESCRIPTION
## [[ME-2657](https://mysocket.atlassian.net/browse/ME-2657)] Run VPN Server as Connector Socket

VPN sockets in the connector.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2657

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

It has been tested in MacOS and Debian

https://github.com/borderzero/border0-cli/assets/16856511/8ec572b0-ca0f-4dd9-9097-ae2dda97a335

> Note that the token in the video above is revoked ;) 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2657]: https://mysocket.atlassian.net/browse/ME-2657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ