### PR TITLE
feat(ME-2680): add wsproxy support for all client commands

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -141,7 +141,6 @@ func init() {
 	clientCmd.AddCommand(clientLoginCmd)
 	clientLoginCmd.Flags().StringVarP(&orgID, "org", "", "", "The border0 organization domain name (without .border0.io)")
 	clientLoginCmd.Flags().IntVarP(&port, "port", "p", 0, "Port number")
-
 	clientLoginCmd.AddCommand(clientLoginStatusCmd)
 
 	db.AddCommandsTo(clientCmd)

--- a/cmd/client/db/datagrip.go
+++ b/cmd/client/db/datagrip.go
@@ -63,8 +63,8 @@ var dataGripCmd = &cobra.Command{
 
 		connectionName := hostname
 
-		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
-			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
+		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled || wsProxy != "" {
+			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
 				return fmt.Errorf("could not start listener: %w", err)
 			}

--- a/cmd/client/db/db.go
+++ b/cmd/client/db/db.go
@@ -17,6 +17,14 @@ var (
 	hostname string
 	local    bool
 	port     int
+	wsProxy  string
+)
+
+var (
+	wsProxyToOriginHeader = map[string]string{
+		"wss://ws.border0.com/ws":         "https://client.border0.com",
+		"wss://ws.staging.border0.com/ws": "https://client.staging.border0.com",
+	}
 )
 
 func AddCommandsTo(client *cobra.Command) {
@@ -37,6 +45,7 @@ func AddCommandsTo(client *cobra.Command) {
 
 func addOneCommandTo(cmdToAdd, cmdAddedTo *cobra.Command) {
 	cmdToAdd.Flags().StringVarP(&hostname, "host", "", "", "Socket target host")
+	cmdToAdd.Flags().StringVarP(&wsProxy, "wsproxy", "w", "", "websocket proxy")
 	cmdAddedTo.AddCommand(cmdToAdd)
 }
 
@@ -59,7 +68,7 @@ var dbCmd = &cobra.Command{
 		hostname = pickedHost.Hostname()
 
 		if local {
-			proxy, err := sqlclientproxy.NewSqlClientProxy(logger.Logger, port, pickedHost)
+			proxy, err := sqlclientproxy.NewSqlClientProxy(logger.Logger, port, pickedHost, wsProxy)
 			if err != nil {
 				return fmt.Errorf("failed to start local listener: %w", err)
 			}
@@ -123,7 +132,7 @@ var dbCmd = &cobra.Command{
 		}
 
 		if dbClient == "local listener" {
-			proxy, err := sqlclientproxy.NewSqlClientProxy(logger.Logger, port, pickedHost)
+			proxy, err := sqlclientproxy.NewSqlClientProxy(logger.Logger, port, pickedHost, wsProxy)
 			if err != nil {
 				return fmt.Errorf("failed to start local listener: %w", err)
 			}

--- a/cmd/client/db/db.go
+++ b/cmd/client/db/db.go
@@ -20,13 +20,6 @@ var (
 	wsProxy  string
 )
 
-var (
-	wsProxyToOriginHeader = map[string]string{
-		"wss://ws.border0.com/ws":         "https://client.border0.com",
-		"wss://ws.staging.border0.com/ws": "https://client.staging.border0.com",
-	}
-)
-
 func AddCommandsTo(client *cobra.Command) {
 	addOneCommandTo(dbCmd, client)
 	addOneCommandTo(mysqlCmd, client)

--- a/cmd/client/db/dbeaver.go
+++ b/cmd/client/db/dbeaver.go
@@ -61,8 +61,8 @@ var dbeaverCmd = &cobra.Command{
 
 		connectionName := hostname
 
-		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
-			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
+		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled || wsProxy != "" {
+			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
 				return fmt.Errorf("could not start listener: %w", err)
 			}

--- a/cmd/client/db/mycli.go
+++ b/cmd/client/db/mycli.go
@@ -64,8 +64,8 @@ var mycliCmd = &cobra.Command{
 		defer persistPreference()
 		client.OnInterruptDo(persistPreference)
 
-		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
-			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
+		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled || wsProxy != "" {
+			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
 				fmt.Println("ERROR: could not setup listener:", err)
 				return err

--- a/cmd/client/db/mysql.go
+++ b/cmd/client/db/mysql.go
@@ -65,8 +65,8 @@ var mysqlCmd = &cobra.Command{
 		defer persistPreference()
 		client.OnInterruptDo(persistPreference)
 
-		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
-			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
+		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled || wsProxy != "" {
+			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
 				fmt.Println("ERROR: could not setup listener:", err)
 				return err

--- a/cmd/client/db/mysql_workbench.go
+++ b/cmd/client/db/mysql_workbench.go
@@ -61,8 +61,8 @@ var mysqlWorkbenchCmd = &cobra.Command{
 
 		connectionName := hostname
 
-		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
-			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
+		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled || wsProxy != "" {
+			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
 				fmt.Println("ERROR: could not setup listener:", err)
 				return err

--- a/cmd/client/db/pgcli.go
+++ b/cmd/client/db/pgcli.go
@@ -69,8 +69,8 @@ var pgcliCmd = &cobra.Command{
 		defer persistPreference()
 		client.OnInterruptDo(persistPreference)
 
-		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
-			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
+		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled || wsProxy != "" {
+			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
 				fmt.Println("ERROR: could not setup listener:", err)
 				return err

--- a/cmd/client/db/psql.go
+++ b/cmd/client/db/psql.go
@@ -72,8 +72,8 @@ var psqlCmd = &cobra.Command{
 		defer persistPreference()
 		client.OnInterruptDo(persistPreference)
 
-		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
-			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
+		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled || wsProxy != "" {
+			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
 				fmt.Println("ERROR: could not setup listener:", err)
 				return err

--- a/cmd/client/db/sqlcmd.go
+++ b/cmd/client/db/sqlcmd.go
@@ -64,8 +64,8 @@ var sqlcmdCmd = &cobra.Command{
 		defer persistPreference()
 		client.OnInterruptDo(persistPreference)
 
-		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
-			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
+		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled || wsProxy != "" {
+			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
 				return fmt.Errorf("could not start listener: %w", err)
 			}

--- a/cmd/client/db/ssms.go
+++ b/cmd/client/db/ssms.go
@@ -104,8 +104,8 @@ var ssmsCmd = &cobra.Command{
 		defer persistPreference()
 		client.OnInterruptDo(persistPreference)
 
-		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
-			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
+		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled || wsProxy != "" {
+			info.Port, err = client.StartConnectorAuthListener(hostname, info.Port, info.SetupTLSCertificate(), info.CaCertificate, 0, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
 				return fmt.Errorf("could not start listener: %w", err)
 			}

--- a/cmd/client/httpproxy/httpproxy.go
+++ b/cmd/client/httpproxy/httpproxy.go
@@ -20,6 +20,7 @@ var (
 	hostname      string
 	httpProxyPort int
 	numStreams    int
+	wsProxy       string
 )
 
 type SessionManager struct {
@@ -29,6 +30,7 @@ type SessionManager struct {
 	tlsConfig     *tls.Config
 	hostname      string
 	sessionsMutex sync.Mutex
+	wsProxy       string
 }
 
 // clientProxyCmd represents the client tls command
@@ -86,13 +88,13 @@ var clientProxyCmd = &cobra.Command{
 
 		for i := 0; i < numStreams; i++ {
 
-			_, session, logStream, err := sessionManager.createSession(&info, &tlsConfig, hostname)
+			_, session, logStream, err := sessionManager.createSession(&info, &tlsConfig, hostname, wsProxy)
 			if err != nil {
 				log.Fatalf("Failed to create upstream session: %v", err)
 			}
 			log.Printf("Upstream connection %d => Connected to %s:%d\n", i, hostname, info.Port)
 
-			sessionManager.addSession(session, logStream, &info, &tlsConfig, hostname)
+			sessionManager.addSession(session, logStream, &info, &tlsConfig, hostname, wsProxy)
 		}
 
 		// Now start the local listener on which we accept the traffic
@@ -124,7 +126,7 @@ var clientProxyCmd = &cobra.Command{
 
 // SessionManager is a simple struct that holds a slice of yamux sessions
 // here we can add and remove sessions as they are created and closed
-func (sm *SessionManager) addSession(session *yamux.Session, logStream *yamux.Stream, info *client.ResourceInfo, tlsConfig *tls.Config, hostname string) {
+func (sm *SessionManager) addSession(session *yamux.Session, logStream *yamux.Stream, info *client.ResourceInfo, tlsConfig *tls.Config, hostname, wsProxy string) {
 	sm.sessionsMutex.Lock()
 	defer sm.sessionsMutex.Unlock()
 	sm.sessions = append(sm.sessions, session)
@@ -132,15 +134,16 @@ func (sm *SessionManager) addSession(session *yamux.Session, logStream *yamux.St
 	sm.info = info
 	sm.tlsConfig = tlsConfig
 	sm.hostname = hostname
+	sm.wsProxy = wsProxy
 
 	go func() {
 		<-session.CloseChan() // Wait for the session to close
-		sm.removeSession(session, logStream)
+		sm.removeSession(session)
 	}()
 }
 
-func (sm *SessionManager) createSession(info *client.ResourceInfo, tlsConfig *tls.Config, hostname string) (net.Conn, *yamux.Session, *yamux.Stream, error) {
-	conn, err := establishConnection(info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, fmt.Sprintf("%s:%d", hostname, info.Port), tlsConfig, info.CaCertificate)
+func (sm *SessionManager) createSession(info *client.ResourceInfo, tlsConfig *tls.Config, hostname string, wsProxy string) (net.Conn, *yamux.Session, *yamux.Stream, error) {
+	conn, err := establishConnection(info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, fmt.Sprintf("%s:%d", hostname, info.Port), tlsConfig, info.CaCertificate, wsProxy)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -175,7 +178,7 @@ func (sm *SessionManager) createSession(info *client.ResourceInfo, tlsConfig *tl
 }
 
 // removeSession is a simple function that removes a session from the slice
-func (sm *SessionManager) removeSession(session *yamux.Session, logStream *yamux.Stream) {
+func (sm *SessionManager) removeSession(session *yamux.Session) {
 	sm.sessionsMutex.Lock()
 	defer sm.sessionsMutex.Unlock()
 	for i, s := range sm.sessions {
@@ -187,7 +190,7 @@ func (sm *SessionManager) removeSession(session *yamux.Session, logStream *yamux
 			log.Printf("attempting to reconnect to %s:%d\n", sm.hostname, sm.info.Port)
 
 			// Reconnect logic
-			_, session, logStream, err := sm.createSession(sm.info, sm.tlsConfig, sm.hostname)
+			_, session, logStream, err := sm.createSession(sm.info, sm.tlsConfig, sm.hostname, sm.wsProxy)
 			if err != nil {
 				log.Printf("Failed to create stream session: %v\n", err)
 				if len(sm.sessions) == 0 {
@@ -196,7 +199,7 @@ func (sm *SessionManager) removeSession(session *yamux.Session, logStream *yamux
 				return
 			}
 			// Add the new session back to the pool
-			sm.addSession(session, logStream, sm.info, sm.tlsConfig, sm.hostname)
+			sm.addSession(session, logStream, sm.info, sm.tlsConfig, sm.hostname, sm.wsProxy)
 
 			log.Printf("Reconnect succesfull. Pool size is now %d\n", len(sm.sessions))
 
@@ -237,14 +240,8 @@ func handleClientConnection(clientConn net.Conn, session *yamux.Session) {
 	io.Copy(stream, clientConn)
 }
 
-func establishConnection(connectorAuthenticationEnabled, end2EndEncryptionEnabled bool, addr string, tlsConfig *tls.Config, caCertificate *x509.Certificate) (conn net.Conn, err error) {
-	if connectorAuthenticationEnabled || end2EndEncryptionEnabled {
-		conn, err = client.Connect(addr, tlsConfig, tlsConfig.Certificates[0], caCertificate, connectorAuthenticationEnabled, end2EndEncryptionEnabled)
-	} else {
-		conn, err = tls.Dial("tcp", addr, tlsConfig)
-	}
-
-	return
+func establishConnection(connectorAuthenticationEnabled, end2EndEncryptionEnabled bool, addr string, tlsConfig *tls.Config, caCertificate *x509.Certificate, wsProxy string) (conn net.Conn, err error) {
+	return client.Connect(addr, true, tlsConfig, tlsConfig.Certificates[0], caCertificate, connectorAuthenticationEnabled, end2EndEncryptionEnabled, wsProxy)
 }
 
 func AddCommandsTo(client *cobra.Command) {
@@ -252,4 +249,5 @@ func AddCommandsTo(client *cobra.Command) {
 	clientProxyCmd.Flags().IntVarP(&httpProxyPort, "port", "p", 8080, "port number to listen on")
 	clientProxyCmd.Flags().IntVarP(&numStreams, "connections", "c", 1, "number of parallel connections to open to the Border0 service")
 	clientProxyCmd.Flags().StringVarP(&hostname, "service", "", "", "The Border0 service identifier")
+	clientProxyCmd.Flags().StringVarP(&wsProxy, "wsproxy", "", "", "The WebSocket proxy URL")
 }

--- a/cmd/client/rdp/rdp.go
+++ b/cmd/client/rdp/rdp.go
@@ -12,6 +12,7 @@ import (
 var (
 	hostname          string
 	localListenerPort int
+	wsProxy           string
 )
 
 // clientRdpCmd represents the client rdp command
@@ -33,7 +34,7 @@ var clientRdpCmd = &cobra.Command{
 			hostname = pickedHost.Hostname()
 		}
 
-		return utils.StartLocalProxyAndOpenClient(cmd, args, "rdp", hostname, localListenerPort)
+		return utils.StartLocalProxyAndOpenClient(cmd, args, "rdp", hostname, localListenerPort, wsProxy)
 	},
 }
 
@@ -42,4 +43,5 @@ func AddCommandsTo(client *cobra.Command) {
 
 	clientRdpCmd.Flags().StringVarP(&hostname, "service", "", "", "The Border0 service identifier")
 	clientRdpCmd.Flags().IntVarP(&localListenerPort, "local-listener-port", "l", 0, "Local listener port number")
+	clientRdpCmd.Flags().StringVarP(&wsProxy, "wsproxy", "w", "", "websocket proxy")
 }

--- a/cmd/client/ssh/ssh.go
+++ b/cmd/client/ssh/ssh.go
@@ -1,16 +1,11 @@
 package ssh
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -24,20 +19,12 @@ import (
 	"github.com/moby/term"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
-	"nhooyr.io/websocket"
 )
 
 var (
 	hostname     string
 	sshLoginName string
 	wsProxy      string
-)
-
-var (
-	wsProxyToOriginHeader = map[string]string{
-		"wss://ws.border0.com/ws":         "https://client.border0.com",
-		"wss://ws.staging.border0.com/ws": "https://client.staging.border0.com",
-	}
 )
 
 type HostDB struct {
@@ -154,57 +141,9 @@ var sshCmd = &cobra.Command{
 			RootCAs:      systemCertPool,
 		}
 
-		var conn *tls.Conn
-
-		if wsProxy != "" {
-			destination := struct {
-				DNSName string `json:"dnsname"`
-				Port    int    `json:"port"`
-			}{
-				DNSName: hostname,
-				Port:    info.Port,
-			}
-			destinationJson, err := json.Marshal(&destination)
-			if err != nil {
-				return fmt.Errorf("failed to marshal destination: %w", err)
-			}
-
-			parsedURL, err := url.Parse(wsProxy)
-			if err != nil {
-				return fmt.Errorf("failed to parse wsproxy url: %w", err)
-			}
-			parsedURL.RawQuery = url.Values{
-				"dst": []string{base64.StdEncoding.EncodeToString(destinationJson)},
-			}.Encode()
-
-			wsURL := parsedURL.String()
-
-			httpHeader := http.Header{}
-			if originHeader, ok := wsProxyToOriginHeader[wsProxy]; ok {
-				httpHeader.Set("Origin", originHeader)
-			}
-
-			ctx := context.Background()
-			wsConn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: httpHeader})
-			if err != nil {
-				return fmt.Errorf("failed to perform WebSocket handshake on %s: %w", wsURL, err)
-			}
-			defer wsConn.Close(websocket.StatusInternalError, "the sky is falling")
-			wsNetConn := websocket.NetConn(ctx, wsConn, websocket.MessageBinary)
-
-			conn = tls.Client(wsNetConn, &tlsConfig)
-		} else {
-			conn, err = tls.Dial("tcp", fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
-			if err != nil {
-				return fmt.Errorf("failed to connect to %s:%d: %w", hostname, info.Port, err)
-			}
-		}
-
-		if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
-			conn, err = client.ConnectWithConn(conn, certificate, info.CaCertificate, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
-			if err != nil {
-				return fmt.Errorf("failed to connect: %w", err)
-			}
+		conn, err := client.Connect(fmt.Sprintf("%s:%d", hostname, info.Port), true, &tlsConfig, certificate, info.CaCertificate, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
+		if err != nil {
+			return fmt.Errorf("failed to connect: %w", err)
 		}
 
 		home, err := util.GetUserHomeDir()

--- a/cmd/client/ssh/ssh.go
+++ b/cmd/client/ssh/ssh.go
@@ -44,7 +44,6 @@ func AddCommandsTo(client *cobra.Command) {
 	sshCmd.Flags().StringVarP(&sshLoginName, "username", "u", "", "Specifies the user to log in as on the remote machine(deprecated)")
 	sshCmd.Flags().StringVarP(&sshLoginName, "login", "l", "", "Same as username, specifies the user login to use on remote machine")
 	sshCmd.Flags().StringVarP(&wsProxy, "wsproxy", "w", "", "websocket proxy")
-	sshCmd.Flag("wsproxy").Hidden = true
 
 	client.AddCommand(keySignCmd)
 	keySignCmd.Flags().StringVarP(&hostname, "host", "", "", "The border0 target host")

--- a/cmd/client/utils/local_proxy_and_client.go
+++ b/cmd/client/utils/local_proxy_and_client.go
@@ -23,12 +23,13 @@ func openRDP(address string) error {
 
 	// Create temporary .rdp file
 	tmpDir := os.TempDir()
-	defer os.RemoveAll(tmpDir)
 
 	rdpFilePath := filepath.Join(tmpDir, "temp.rdp")
 	if err := os.WriteFile(rdpFilePath, rdpFileContents, 0644); err != nil {
 		return fmt.Errorf("failed to create RDP file: %w", err)
 	}
+
+	defer os.Remove(rdpFilePath)
 
 	// On MacOS we open the client twice... because
 	// Microsoft's Remote Desktop client refuses
@@ -50,6 +51,7 @@ func StartLocalProxyAndOpenClient(
 	protocol string,
 	hostname string,
 	localListenerPort int,
+	wsProxy string,
 ) error {
 	info, err := client.GetResourceInfo(logger.Logger, hostname)
 	if err != nil {
@@ -107,21 +109,9 @@ func StartLocalProxyAndOpenClient(
 		}
 
 		go func() {
-			conn, err := tls.Dial("tcp", fmt.Sprintf("%s:%d", hostname, info.Port), &tlsConfig)
+			conn, err := client.Connect(fmt.Sprintf("%s:%d", hostname, info.Port), true, &tlsConfig, certificate, info.CaCertificate, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
-				fmt.Printf("failed to connect to %s:%d: %s\n", hostname, info.Port, err)
-			}
-
-			if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
-				conn, err = client.ConnectWithConn(conn, certificate, info.CaCertificate, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
-				if err != nil {
-					if errors.Is(err, client.ErrHandshakeFailed) {
-						fmt.Printf("Error: %s. You may not be authorized for this socket. Speak to your Border0 administrator\n", err)
-						return
-					}
-					fmt.Printf("Failed to connect: %s\n", err)
-					return
-				}
+				fmt.Printf("failed to connect: %s\n", err)
 			}
 
 			log.Print("Connection established from ", lcon.RemoteAddr())

--- a/cmd/client/utils/local_proxy_and_client.go
+++ b/cmd/client/utils/local_proxy_and_client.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"log"
 	"net"

--- a/cmd/client/vnc/vnc.go
+++ b/cmd/client/vnc/vnc.go
@@ -12,6 +12,7 @@ import (
 var (
 	hostname          string
 	localListenerPort int
+	wsProxy           string
 )
 
 // clientVncCmd represents the client vnc command
@@ -33,7 +34,7 @@ var clientVncCmd = &cobra.Command{
 			hostname = pickedHost.Hostname()
 		}
 
-		return utils.StartLocalProxyAndOpenClient(cmd, args, "vnc", hostname, localListenerPort)
+		return utils.StartLocalProxyAndOpenClient(cmd, args, "vnc", hostname, localListenerPort, wsProxy)
 	},
 }
 
@@ -42,4 +43,5 @@ func AddCommandsTo(client *cobra.Command) {
 
 	clientVncCmd.Flags().StringVarP(&hostname, "service", "", "", "The Border0 service identifier")
 	clientVncCmd.Flags().IntVarP(&localListenerPort, "local-listener-port", "l", 0, "Local listener port number")
+	clientVncCmd.Flags().StringVarP(&wsProxy, "wsproxy", "w", "", "websocket proxy")
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -46,15 +46,9 @@ var (
 )
 
 const (
-	successURL = "https://www.border0.com/logged-in"
-	failURL    = "https://www.border0.com/fail-message"
-)
-
-var (
-	wsProxyToOriginHeader = map[string]string{
-		"wss://ws.border0.com/ws":         "https://client.border0.com",
-		"wss://ws.staging.border0.com/ws": "https://client.staging.border0.com",
-	}
+	successURL            = "https://www.border0.com/logged-in"
+	failURL               = "https://www.border0.com/fail-message"
+	wsProxyToOriginHeader = "https://client.border0.com"
 )
 
 func CheckIfTokenIsExpired(rawToken string) bool {
@@ -1035,9 +1029,7 @@ func ConnectWSProxy(proxyUrl string, addr string) (net.Conn, error) {
 	wsURL := parsedURL.String()
 
 	httpHeader := http.Header{}
-	if originHeader, ok := wsProxyToOriginHeader[proxyUrl]; ok {
-		httpHeader.Set("Origin", originHeader)
-	}
+	httpHeader.Set("Origin", wsProxyToOriginHeader)
 
 	ctx := context.TODO()
 	wsConn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: httpHeader})

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"encoding/pem"
@@ -19,11 +20,13 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,6 +38,7 @@ import (
 	"github.com/pavlo-v-chernykh/keystore-go/v4"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
+	"nhooyr.io/websocket"
 )
 
 var (
@@ -44,6 +48,13 @@ var (
 const (
 	successURL = "https://www.border0.com/logged-in"
 	failURL    = "https://www.border0.com/fail-message"
+)
+
+var (
+	wsProxyToOriginHeader = map[string]string{
+		"wss://ws.border0.com/ws":         "https://client.border0.com",
+		"wss://ws.staging.border0.com/ws": "https://client.staging.border0.com",
+	}
 )
 
 func CheckIfTokenIsExpired(rawToken string) bool {
@@ -841,7 +852,7 @@ func OnInterruptDo(action func()) {
 	}()
 }
 
-func StartConnectorAuthListener(hostname string, port int, certificate tls.Certificate, caCertificate *x509.Certificate, localPort int, connectorAuthenticationEnabled bool, endToEndEncryptionEnabled bool) (int, error) {
+func StartConnectorAuthListener(hostname string, port int, certificate tls.Certificate, caCertificate *x509.Certificate, localPort int, connectorAuthenticationEnabled bool, endToEndEncryptionEnabled bool, wsProxy string) (int, error) {
 	systemCertPool, err := x509.SystemCertPool()
 	if err != nil {
 		return 0, fmt.Errorf("failed to load system cert pool: %w", err)
@@ -869,7 +880,7 @@ func StartConnectorAuthListener(hostname string, port int, certificate tls.Certi
 			}
 
 			go func() {
-				conn, err := Connect(addr, tlsConfig, certificate, caCertificate, connectorAuthenticationEnabled, endToEndEncryptionEnabled)
+				conn, err := Connect(addr, false, tlsConfig, certificate, caCertificate, connectorAuthenticationEnabled, endToEndEncryptionEnabled, wsProxy)
 				if err != nil {
 					log.Fatalf("failed to connect: %s\n", err)
 				}
@@ -882,20 +893,36 @@ func StartConnectorAuthListener(hostname string, port int, certificate tls.Certi
 	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
-func Connect(addr string, tlsConfig *tls.Config, certificate tls.Certificate, caCert *x509.Certificate, connectorAuthenticationEnabled bool, endToEndEncryptionEnabled bool) (*tls.Conn, error) {
-	conn, err := tls.Dial("tcp", addr, tlsConfig)
-	if err != nil {
-		return nil, err
+func Connect(addr string, tlsNeeded bool, tlsConfig *tls.Config, certificate tls.Certificate, caCert *x509.Certificate, connectorAuthenticationEnabled bool, endToEndEncryptionEnabled bool, wsProxy string) (net.Conn, error) {
+	var conn net.Conn
+	if wsProxy != "" {
+		wsConn, err := ConnectWSProxy(wsProxy, addr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to ws proxy: %w", err)
+		}
+
+		conn = wsConn
+	} else {
+		netConn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+		if err != nil {
+			return nil, err
+		}
+		conn = netConn
 	}
 
-	if err := conn.Handshake(); err != nil {
-		return nil, fmt.Errorf("failed to handshake with proxy: %w", err)
+	if tlsNeeded || connectorAuthenticationEnabled || endToEndEncryptionEnabled {
+		tlsConn := tls.Client(conn, tlsConfig)
+		if err := tlsConn.Handshake(); err != nil {
+			return nil, fmt.Errorf("failed to handshake with proxy: %w", err)
+		}
+
+		conn = tlsConn
 	}
 
-	return ConnectWithConn(conn, certificate, caCert, connectorAuthenticationEnabled, endToEndEncryptionEnabled)
+	return connectWithConn(conn, certificate, caCert, connectorAuthenticationEnabled, endToEndEncryptionEnabled)
 }
 
-func ConnectWithConn(conn *tls.Conn, certificate tls.Certificate, caCert *x509.Certificate, connectorAuthenticationEnabled bool, endToEndEncryptionEnabled bool) (*tls.Conn, error) {
+func connectWithConn(conn net.Conn, certificate tls.Certificate, caCert *x509.Certificate, connectorAuthenticationEnabled bool, endToEndEncryptionEnabled bool) (net.Conn, error) {
 	if !connectorAuthenticationEnabled && !endToEndEncryptionEnabled {
 		return conn, nil
 	}
@@ -970,4 +997,55 @@ func handleConnection(src net.Conn, dst net.Conn) {
 	}()
 
 	<-chDone
+}
+
+func ConnectWSProxy(proxyUrl string, addr string) (net.Conn, error) {
+	hostname, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to split host and port: %w", err)
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert port to int: %w", err)
+	}
+
+	destination := struct {
+		DNSName string `json:"dnsname"`
+		Port    int    `json:"port"`
+	}{
+		DNSName: hostname,
+		Port:    port,
+	}
+
+	destinationJson, err := json.Marshal(&destination)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal destination: %w", err)
+	}
+
+	parsedURL, err := url.Parse(proxyUrl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse wsproxy url: %w", err)
+	}
+
+	parsedURL.RawQuery = url.Values{
+		"dst": []string{base64.StdEncoding.EncodeToString(destinationJson)},
+	}.Encode()
+
+	wsURL := parsedURL.String()
+
+	httpHeader := http.Header{}
+	if originHeader, ok := wsProxyToOriginHeader[proxyUrl]; ok {
+		httpHeader.Set("Origin", originHeader)
+	}
+
+	ctx := context.TODO()
+	wsConn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: httpHeader})
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform WebSocket handshake on %s: %w", wsURL, err)
+	}
+
+	wsNetConn := websocket.NetConn(ctx, wsConn, websocket.MessageBinary)
+
+	return wsNetConn, nil
 }

--- a/internal/client/sqlclientproxy/postgres.go
+++ b/internal/client/sqlclientproxy/postgres.go
@@ -24,7 +24,7 @@ type postgresClientProxy struct {
 	upstreamConfig *pgconn.Config
 }
 
-func newPostgresClientProxy(logger *zap.Logger, port int, resource models.ClientResource) (*postgresClientProxy, error) {
+func newPostgresClientProxy(logger *zap.Logger, port int, resource models.ClientResource, wsProxy string) (*postgresClientProxy, error) {
 	info, err := client.GetResourceInfo(logger, resource.Hostname())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get resource info")
@@ -61,6 +61,7 @@ func newPostgresClientProxy(logger *zap.Logger, port int, resource models.Client
 			info:      info,
 			resource:  resource,
 			tlsConfig: tlsConfig,
+			wsProxy:   wsProxy,
 		},
 		upstreamConfig: upstreamConfig,
 	}, nil
@@ -183,11 +184,7 @@ func (p *postgresClientProxy) handleClientStartup(c *pgproto3.Backend, conn net.
 }
 
 func (p *postgresClientProxy) Dialer(ctx context.Context, network, addr string) (net.Conn, error) {
-	if p.info.ConnectorAuthenticationEnabled || p.info.EndToEndEncryptionEnabled {
-		return client.Connect(addr, p.tlsConfig, p.tlsConfig.Certificates[0], p.info.CaCertificate, p.info.ConnectorAuthenticationEnabled, p.info.EndToEndEncryptionEnabled)
-	} else {
-		return net.DialTimeout("tcp", addr, 5*time.Second)
-	}
+	return client.Connect(addr, false, p.tlsConfig, p.tlsConfig.Certificates[0], p.info.CaCertificate, p.info.ConnectorAuthenticationEnabled, p.info.EndToEndEncryptionEnabled, p.wsProxy)
 }
 
 func (p *postgresClientProxy) handleClientAuthRequest(serverSession *pgproto3.Backend, serverParams map[string]string) error {

--- a/internal/client/sqlclientproxy/proxy.go
+++ b/internal/client/sqlclientproxy/proxy.go
@@ -18,16 +18,17 @@ type sqlClientProxy struct {
 	info      client.ResourceInfo
 	resource  models.ClientResource
 	tlsConfig *tls.Config
+	wsProxy   string
 }
 
-func NewSqlClientProxy(logger *zap.Logger, port int, resource models.ClientResource) (SqlClientProxy, error) {
+func NewSqlClientProxy(logger *zap.Logger, port int, resource models.ClientResource, wsProxy string) (SqlClientProxy, error) {
 	switch resource.DatabaseType {
 	case "mysql":
-		return newMysqlClientProxy(logger, port, resource)
+		return newMysqlClientProxy(logger, port, resource, wsProxy)
 	case "postgres":
-		return newPostgresClientProxy(logger, port, resource)
+		return newPostgresClientProxy(logger, port, resource, wsProxy)
 	case "mssql":
-		return newTcpProxy(logger, port, resource)
+		return newTcpProxy(logger, port, resource, wsProxy)
 	default:
 		return nil, fmt.Errorf("unsupported database type: %s", resource.DatabaseType)
 	}


### PR DESCRIPTION
# Description

add wsproxy support for all client commands
Fixes # (ME-2680)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with database, ssh, tls, proxy sockets. Some with e2ee disabled and enabled.
Not tested with VNC, RDP or VPN sockets, but those are built on top of tls.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
