### PR TITLE
[ME-2681] Fix Panic on RDP/VNC Unauthorized

### DIFF
--- a/cmd/client/rdp/rdp.go
+++ b/cmd/client/rdp/rdp.go
@@ -26,8 +26,7 @@ var clientRdpCmd = &cobra.Command{
 		}
 
 		if hostname == "" {
-			// TODO(devs): Remove TLSSocket once we have exposed CRUD for RDP sockets in the admin portal.
-			pickedHost, err := client.PickHost(hostname, enum.RDPSocket, enum.TLSSocket)
+			pickedHost, err := client.PickHost(hostname, enum.RDPSocket)
 			if err != nil {
 				return fmt.Errorf("failed to pick host: %v", err)
 			}

--- a/cmd/client/utils/local_proxy_and_client.go
+++ b/cmd/client/utils/local_proxy_and_client.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -114,7 +115,12 @@ func StartLocalProxyAndOpenClient(
 			if info.ConnectorAuthenticationEnabled || info.EndToEndEncryptionEnabled {
 				conn, err = client.ConnectWithConn(conn, certificate, info.CaCertificate, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled)
 				if err != nil {
-					fmt.Printf("failed to connect: %s\n", err)
+					if errors.Is(err, client.ErrHandshakeFailed) {
+						fmt.Printf("Error: %s. You may not be authorized for this socket. Speak to your Border0 administrator\n", err)
+						return
+					}
+					fmt.Printf("Failed to connect: %s\n", err)
+					return
 				}
 			}
 

--- a/cmd/client/vnc/vnc.go
+++ b/cmd/client/vnc/vnc.go
@@ -26,8 +26,7 @@ var clientVncCmd = &cobra.Command{
 		}
 
 		if hostname == "" {
-			// TODO(devs): Remove TLSSocket once we have exposed CRUD for VNC sockets in the admin portal.
-			pickedHost, err := client.PickHost(hostname, enum.VNCSocket, enum.TLSSocket)
+			pickedHost, err := client.PickHost(hostname, enum.VNCSocket)
 			if err != nil {
 				return fmt.Errorf("failed to pick host: %v", err)
 			}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -37,6 +37,10 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+var (
+	ErrHandshakeFailed = errors.New("failed to authenticate against connector")
+)
+
 const (
 	successURL = "https://www.border0.com/logged-in"
 	failURL    = "https://www.border0.com/fail-message"
@@ -933,7 +937,7 @@ func ConnectWithConn(conn *tls.Conn, certificate tls.Certificate, caCert *x509.C
 
 	connectorConn := tls.Client(conn, tlsConfig)
 	if err := connectorConn.Handshake(); err != nil {
-		return nil, fmt.Errorf("failed to authenticate to connector: %w", err)
+		return nil, fmt.Errorf("%w: %v", ErrHandshakeFailed, err)
 	}
 
 	if endToEndEncryptionEnabled {


### PR DESCRIPTION
# [[ME-2681](https://mysocket.atlassian.net/browse/ME-2681)] Fix Panic on RDP/VNC Unauthorized

Reported by internal QA:

```
✘-1 ~/go/src/github.com/borderzero/border0-cli [ME-2681_vnc_panic_fix|✔]
08:04 $ border0 client vnc
? choose a host: kali-real-vnc-olympus.border0.io []
2024/03/13 08:04:47 Waiting for connections on localhost:63708...
failed to connect: failed to authenticate to connector: EOF
2024/03/13 08:04:48 Connection established from 127.0.0.1:63709
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1028d1248]

goroutine 16 [running]:
crypto/tls.(*Conn).Close(0x108468220?)
	/opt/hostedtoolcache/go/1.22.0/x64/src/crypto/tls/conn.go:1404 +0x18
github.com/borderzero/border0-cli/cmd/client/utils.copyStream.func1.1()
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:27 +0x54
github.com/borderzero/border0-cli/cmd/client/utils.copyStream.func1()
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:46 +0x210
created by github.com/borderzero/border0-cli/cmd/client/utils.copyStream in goroutine 58
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:24 +0xe0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1028d176c]

goroutine 15 [running]:
crypto/tls.(*Conn).handshakeContext(0x0?, {0x106809440?, 0x1085bd360?})
	/opt/hostedtoolcache/go/1.22.0/x64/src/crypto/tls/conn.go:1500 +0x2c
crypto/tls.(*Conn).HandshakeContext(...)
	/opt/hostedtoolcache/go/1.22.0/x64/src/crypto/tls/conn.go:1493
crypto/tls.(*Conn).Handshake(...)
	/opt/hostedtoolcache/go/1.22.0/x64/src/crypto/tls/conn.go:1477
crypto/tls.(*Conn).Read(0x0, {0x140004cac00, 0x400, 0x0?})
	/opt/hostedtoolcache/go/1.22.0/x64/src/crypto/tls/conn.go:1357 +0x4c
github.com/borderzero/border0-cli/cmd/client/utils.copyStream.func1()
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:34 +0xb4
created by github.com/borderzero/border0-cli/cmd/client/utils.copyStream in goroutine 58
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:24 +0xe0
```

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2681

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Before:

```
✘-1 ~/go/src/github.com/borderzero/border0-cli [ME-2681_vnc_panic_fix|✔]
08:04 $ border0 client vnc
? choose a host: kali-real-vnc-olympus.border0.io []
2024/03/13 08:04:47 Waiting for connections on localhost:63708...
failed to connect: failed to authenticate to connector: EOF
2024/03/13 08:04:48 Connection established from 127.0.0.1:63709
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1028d1248]

goroutine 16 [running]:
crypto/tls.(*Conn).Close(0x108468220?)
	/opt/hostedtoolcache/go/1.22.0/x64/src/crypto/tls/conn.go:1404 +0x18
github.com/borderzero/border0-cli/cmd/client/utils.copyStream.func1.1()
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:27 +0x54
github.com/borderzero/border0-cli/cmd/client/utils.copyStream.func1()
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:46 +0x210
created by github.com/borderzero/border0-cli/cmd/client/utils.copyStream in goroutine 58
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:24 +0xe0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1028d176c]

goroutine 15 [running]:
crypto/tls.(*Conn).handshakeContext(0x0?, {0x106809440?, 0x1085bd360?})
	/opt/hostedtoolcache/go/1.22.0/x64/src/crypto/tls/conn.go:1500 +0x2c
crypto/tls.(*Conn).HandshakeContext(...)
	/opt/hostedtoolcache/go/1.22.0/x64/src/crypto/tls/conn.go:1493
crypto/tls.(*Conn).Handshake(...)
	/opt/hostedtoolcache/go/1.22.0/x64/src/crypto/tls/conn.go:1477
crypto/tls.(*Conn).Read(0x0, {0x140004cac00, 0x400, 0x0?})
	/opt/hostedtoolcache/go/1.22.0/x64/src/crypto/tls/conn.go:1357 +0x4c
github.com/borderzero/border0-cli/cmd/client/utils.copyStream.func1()
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:34 +0xb4
created by github.com/borderzero/border0-cli/cmd/client/utils.copyStream in goroutine 58
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:24 +0xe0
```

After:

```
✔ ~/go/src/github.com/borderzero/border0-cli [ME-2681_vnc_panic_fix|✚ 1]
08:13 $ ./border0 client vnc
? choose a host: kali-real-vnc-olympus.border0.io []
2024/03/13 08:13:21 Waiting for connections on localhost:63812...
Error: failed to authenticate against connector: EOF. You may not be authorized for this socket. Speak to your Border0 administrator
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

[ME-2681]: https://mysocket.atlassian.net/browse/ME-2681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ