### PR TITLE
[ME-2685] Fix Infinite Connection Accept in SSH/SQL Proxies

### DIFF
--- a/internal/sqlauthproxy/handler.go
+++ b/internal/sqlauthproxy/handler.go
@@ -2,6 +2,7 @@ package sqlauthproxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -71,6 +72,9 @@ func Serve(l net.Listener, config Config) error {
 	for {
 		rconn, err := l.Accept()
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
 			config.Logger.Error("failed to accept connection", zap.Error(err))
 			continue
 		}

--- a/internal/ssh/proxy.go
+++ b/internal/ssh/proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"net"
 
@@ -98,6 +99,9 @@ func Proxy(l net.Listener, c config.ProxyConfig) error {
 	for {
 		conn, err := l.Accept()
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
 			c.Logger.Error("sshauthproxy: failed to accept connection", zap.Error(err))
 			continue
 		}


### PR DESCRIPTION
## [[ME-2685](https://mysocket.atlassian.net/browse/ME-2685)] Fix Infinite Connection Accept in SSH/SQL Proxies

Respect context cancellation in socket connection acceptance.
This addresses a goroutine leak bug which was aggravated recently by adding context cancellations.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2685

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on MacOS and Debian.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

[ME-2685]: https://mysocket.atlassian.net/browse/ME-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ