### PR TITLE
ME-2674: support `--invite` in connector start command

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -391,6 +391,30 @@ func (a *Border0API) CreateConnector(
 	return &connector, nil
 }
 
+// CreateConnectorWithInstallToken is a connector v2 method, it creates a new border0 connector
+// and connector token from an install token (invite code)
+func (a *Border0API) CreateConnectorWithInstallToken(
+	ctx context.Context,
+	name string,
+	installToken string,
+) (*models.ConnectorWithInstallTokenResponse, error) {
+	payload := &models.ConnectorWithInstallTokenRequest{
+		Connector: models.Connector{
+			Name:                     name,
+			BuiltInSshServiceEnabled: true,
+		},
+		InstallToken: installToken,
+	}
+
+	var reply models.ConnectorWithInstallTokenResponse
+	err := a.Request(http.MethodPost, "connector/create_with_token", &reply, payload, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reply, nil
+}
+
 // ListConnectors lists an organization's connectors (v2)
 func (a *Border0API) ListConnectors(ctx context.Context) ([]models.Connector, error) {
 	var connectorList models.ConnectorList

--- a/internal/api/models/connector.go
+++ b/internal/api/models/connector.go
@@ -26,6 +26,20 @@ type Connector struct {
 	LastSeenAt                     *time.Time                              `json:"last_seen_at"`
 }
 
+// ConnectorWithInstallTokenRequest represents a request to create a Border0 connector and
+// connector token with an install token.
+type ConnectorWithInstallTokenRequest struct {
+	Connector
+	InstallToken string `json:"install_token"`
+}
+
+// ConnectorWithInstallTokenResponse represents a response from the request that created
+// a Border0 connector and connector token with an install token.
+type ConnectorWithInstallTokenResponse struct {
+	Connector      Connector      `json:"connector"`
+	ConnectorToken ConnectorToken `json:"connector_token"`
+}
+
 // ConnectorTokenRequest represents a request to create a token for a Border0 Connector.
 type ConnectorTokenRequest struct {
 	ConnectorId string `json:"connector_id,omitempty"`

--- a/internal/connector_v2/config/config.go
+++ b/internal/connector_v2/config/config.go
@@ -200,3 +200,8 @@ func unmarshalConfiguration(path string, config *Configuration) error {
 	// success!
 	return nil
 }
+
+// SetBorder0Token sets the connector token in the environment variable BORDER0_TOKEN
+func SetBorder0Token(token string) error {
+	return os.Setenv(envNameToken, token)
+}

--- a/internal/connector_v2/invite/invite.go
+++ b/internal/connector_v2/invite/invite.go
@@ -1,0 +1,80 @@
+package invite
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/borderzero/border0-cli/internal"
+	border0 "github.com/borderzero/border0-cli/internal/api"
+	"github.com/borderzero/border0-cli/internal/files"
+	"github.com/borderzero/border0-cli/internal/util"
+)
+
+// ExchangeForConnectorToken uses an invite code to create a new connector and connector token,
+// and then returns the connector token.
+func ExchangeForConnectorToken(ctx context.Context, inviteCode string) (connectorToken string, err error) {
+	// check if the connector token is already present in a file invite_<inviteCode> from the .border0 directory
+	// if it is, return it, this will make the invite code "reusable", so the user can run `border0 connector start`
+	// command again with the same --invite <inviteCode> flag, copied from portal's connector install page,
+	// for docker container use case.
+	connectorToken, err = readConnectorTokenFromFile(inviteCode)
+	if err != nil {
+		return "", err
+	}
+	if connectorToken != "" {
+		return connectorToken, nil
+	}
+
+	// connector token not yet writen to file, this is the first time the invite code is used, so we need to
+	// use the invite code to exchange for a connector token
+	border0Client := border0.NewAPI(border0.WithVersion(internal.Version))
+
+	hostname, err := util.GetFormattedHostname()
+	if err != nil {
+		return "", fmt.Errorf("failed to get system hostname: %w", err)
+	}
+
+	reply, err := border0Client.CreateConnectorWithInstallToken(ctx, hostname, inviteCode)
+	if err != nil {
+		return "", fmt.Errorf("failed to create connector with invite code: %w", err)
+	}
+	connectorToken = reply.ConnectorToken.Token
+
+	// write the connector token to a file invite_<inviteCode> in the .border0 directory, so it can be reused
+	// when the user runs `border0 connector start` again with the same --invite <inviteCode> flag
+	err = writeConnectorTokenToFile(inviteCode, connectorToken)
+	if err != nil {
+		return "", err
+	}
+
+	return connectorToken, nil
+}
+
+func readConnectorTokenFromFile(inviteCode string) (string, error) {
+	dotBorder0Dir, err := files.DotBorder0Dir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get .border0 directory: %w", err)
+	}
+	connectorTokenFile := filepath.Join(dotBorder0Dir, fmt.Sprintf("invite_%s", inviteCode))
+	if files.Exists(connectorTokenFile) {
+		connectorToken, err := files.ReadIntoString(connectorTokenFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to read connector token from file: %w", err)
+		}
+		return connectorToken, nil
+	}
+	return "", nil
+}
+
+func writeConnectorTokenToFile(inviteCode, connectorToken string) error {
+	dotBorder0Dir, err := files.DotBorder0Dir()
+	if err != nil {
+		return fmt.Errorf("failed to get .border0 directory: %w", err)
+	}
+	connectorTokenFile := filepath.Join(dotBorder0Dir, fmt.Sprintf("invite_%s", inviteCode))
+	if err := files.WriteStringToFile(connectorTokenFile, connectorToken); err != nil {
+		return fmt.Errorf("failed to write connector token to file: %w", err)
+	}
+	return nil
+}

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -1,0 +1,52 @@
+package files
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/borderzero/border0-cli/internal/util"
+)
+
+// DotBorder0Dir returns the path to the .border0 directory in the user's home directory.
+// If the directory does not exist, it will be created.
+func DotBorder0Dir() (string, error) {
+	home, err := util.GetUserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home dir: %w", err)
+	}
+
+	dotBorder0Dir := filepath.Join(home, ".border0")
+	if !Exists(dotBorder0Dir) {
+		// use 0700 to make sure the directory is only readable and writable by the user
+		if err := os.Mkdir(dotBorder0Dir, 0700); err != nil {
+			return "", fmt.Errorf("failed to create directory %s: %w", dotBorder0Dir, err)
+		}
+	}
+
+	return dotBorder0Dir, nil
+}
+
+// Exists returns true if the file or path exists.
+func Exists(fileOrPath string) bool {
+	_, err := os.Stat(fileOrPath)
+	return os.IsNotExist(err) == false
+}
+
+// ReadIntoString reads the file at the given path and returns its content as a string.
+func ReadIntoString(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+	return string(data), nil
+}
+
+// WriteStringToFile writes the given string data to the file at the given path.
+func WriteStringToFile(path, data string) error {
+	// use 0600 to make sure the file is only readable by the user
+	if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+		return fmt.Errorf("failed to write file %s: %w", path, err)
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

add new flag `--invite` to `border0 connector start` to support automatically creating connector and connector token from an invite code, and then use the returned connector token to start the connector process.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally with:

```shell
make build-all -j # build for all platforms in parallel
docker buildx build --platform linux/arm64 -t border0:test .
docker run -ti border0:test connector start --invite <invite_code>
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code