### PR TITLE
[ME-2685] Graceful Socket Exit on Context Cancellation

### DIFF
--- a/internal/border0/socket.go
+++ b/internal/border0/socket.go
@@ -13,6 +13,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -854,6 +855,9 @@ func Serve(logger *zap.Logger, l net.Listener, hostname string, port int) error 
 	for {
 		rconn, err := l.Accept()
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
 			return fmt.Errorf("failed to accept connection: %s", err)
 		}
 


### PR DESCRIPTION
## [[ME-2685](https://mysocket.atlassian.net/browse/ME-2685)] Graceful Socket Exit on Context Cancellation

Giving the base socket object the same treatment as SQL + SSH. See https://github.com/borderzero/border0-cli/pull/327 for more detail.

The bug did not exist here.. but this change basically just makes an unnecessary error message go away:

```
{"level":"error","ts":"2024-03-13T22:08:53-07:00","msg":"proxy failed","socket_id":"37c774ba-b1ab-4d5c-b492-172ece20319e","socket":"37c774ba-b1ab-4d5c-b492-172ece20319e","error":"failed to accept connection: context canceled"}
```

[ME-2685]: https://mysocket.atlassian.net/browse/ME-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ