### PR TITLE
[ME-2692] Verbose Logs Option for VPN

### DIFF
--- a/internal/connector_v2/service.go
+++ b/internal/connector_v2/service.go
@@ -841,7 +841,7 @@ func (c *ConnectorService) Listen(socket *border0.Socket) {
 		// options defined locally (not in socket config).
 		// these may move to socket config gradually.
 		localServerOpts := []vpnlib.ServerOption{
-			vpnlib.WithServerLogUndeliverable(os.Getenv("VPN_LOG_UNDELIVERABLE_PK") == "true"),
+			vpnlib.WithServerVerboseLogs(os.Getenv("VPN_VERBOSE_LOGS") == "true"),
 		}
 
 		if err := vpnlib.RunServer(


### PR DESCRIPTION
## [[ME-2692](https://mysocket.atlassian.net/browse/ME-2692)] Verbose Logs Option for VPN

Including more log types in the existing log suppression mechanism for VPN server related logs.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2692

### Testing

Tested on MacOS and Debian VPN servers

[ME-2692]: https://mysocket.atlassian.net/browse/ME-2692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ