### PR TITLE
[ME-2691] VPN: Bail On No Sudo

### DIFF
--- a/cmd/client/vpn/vpn.go
+++ b/cmd/client/vpn/vpn.go
@@ -16,6 +16,7 @@ import (
 	"github.com/borderzero/border0-cli/cmd/logger"
 	"github.com/borderzero/border0-cli/internal/client"
 	"github.com/borderzero/border0-cli/internal/enum"
+	"github.com/borderzero/border0-cli/internal/util"
 	"github.com/borderzero/border0-cli/internal/vpnlib"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/spf13/cobra"
@@ -47,6 +48,10 @@ var clientVpnCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
 			hostname = args[0]
+		}
+
+		if !util.RunningAsAdministrator() {
+			return errors.New("command must be ran as system administrator")
 		}
 
 		if hostname == "" {

--- a/cmd/socket.go
+++ b/cmd/socket.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -431,6 +432,10 @@ var socketConnectVpnCmd = &cobra.Command{
 	ValidArgsFunction: AutocompleteSocket,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logger := logger.Logger
+
+		if !util.RunningAsAdministrator() {
+			return errors.New("command must be ran as system administrator in order to connect vpn sockets")
+		}
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/internal/vpnlib/server.go
+++ b/internal/vpnlib/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"runtime"
 
+	"github.com/borderzero/border0-cli/internal/util"
 	"go.uber.org/zap"
 )
 
@@ -43,6 +44,10 @@ func RunServer(
 	config := &serverConfig{verbose: false}
 	for _, opt := range opts {
 		opt(config)
+	}
+
+	if !util.RunningAsAdministrator() {
+		return errors.New("connector must be running as system administrator in order to manage vpn sockets")
 	}
 
 	// Create an IP pool that will be used to assign IPs to clients


### PR DESCRIPTION
## [[ME-2691](https://mysocket.atlassian.net/browse/ME-2691)] VPN: Bail On No Sudo

Bail if VPN client, socket connect vpn, or connector with vpn socket is not running as system administrator.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2691

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested in MacOS and Debian

Testing bail when connector not root

```
┌──(scr1pt3r㉿pwnbox)-[~/go/src/github.com/borderzero/border0-cli]
└─$ ./border0 connector start
{"level":"info","ts":"2024-03-14T16:16:25-07:00","msg":"using config file in the service config directory","config_path":"/etc/border0/border0.yaml"}
{"level":"info","ts":"2024-03-14T16:16:25-07:00","msg":"reading the config","config_path":"/etc/border0/border0.yaml"}
{"level":"info","ts":"2024-03-14T16:16:25-07:00","msg":"starting the connector service"}
{"level":"info","ts":"2024-03-14T16:16:25-07:00","msg":"connecting to connector server","server":"capi.border0.com:443"}
{"level":"info","ts":"2024-03-14T16:16:26-07:00","msg":"initializing socket","socket":"0e0a517d-a3d9-4f4b-8122-36a4fa65f6d0"}
Welcome to Border0.com
odd-shadow - vpn://odd-shadow-olympus.border0.io

=======================================================
Logs
=======================================================
{"level":"error","ts":"2024-03-14T16:16:26-07:00","msg":"vpn service failed","socket_id":"0e0a517d-a3d9-4f4b-8122-36a4fa65f6d0","socket":"0e0a517d-a3d9-4f4b-8122-36a4fa65f6d0","error":"connector must be running as system administrator in order to manage vpn sockets"}
^C
```

Testing bail when socket connect not as root

```
┌──(scr1pt3r㉿pwnbox)-[~/go/src/github.com/borderzero/border0-cli]
└─$ ./border0 socket connect vpn
Error: command must be ran as system administrator in order to connect vpn sockets
```

Testing bail when vpn client not root

```
┌──(scr1pt3r㉿pwnbox)-[~/go/src/github.com/borderzero/border0-cli]
└─$ ./border0 client vpn
Error: command must be ran as system administrator
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


[ME-2691]: https://mysocket.atlassian.net/browse/ME-2691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ