### PR TITLE
[ME-2711] Fix NPE in Client TLS/VNC/RDP

### DIFF
--- a/cmd/client/ssh/ssh.go
+++ b/cmd/client/ssh/ssh.go
@@ -142,6 +142,9 @@ var sshCmd = &cobra.Command{
 
 		conn, err := client.Connect(fmt.Sprintf("%s:%d", hostname, info.Port), true, &tlsConfig, certificate, info.CaCertificate, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 		if err != nil {
+			if errors.Is(err, client.ErrConnectorHandshakeFailed) || errors.Is(err, client.ErrProxyHandshakeFailed) {
+				return fmt.Errorf("failed to connect: %s. You may not be authorized for this socket. Speak to your Border0 administrator", err)
+			}
 			return fmt.Errorf("failed to connect: %w", err)
 		}
 

--- a/cmd/client/utils/local_proxy_and_client.go
+++ b/cmd/client/utils/local_proxy_and_client.go
@@ -111,6 +111,7 @@ func StartLocalProxyAndOpenClient(
 			conn, err := client.Connect(fmt.Sprintf("%s:%d", hostname, info.Port), true, &tlsConfig, certificate, info.CaCertificate, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
 				fmt.Printf("failed to connect: %s\n", err)
+				return
 			}
 
 			log.Print("Connection established from ", lcon.RemoteAddr())

--- a/cmd/client/utils/local_proxy_and_client.go
+++ b/cmd/client/utils/local_proxy_and_client.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -110,6 +111,10 @@ func StartLocalProxyAndOpenClient(
 		go func() {
 			conn, err := client.Connect(fmt.Sprintf("%s:%d", hostname, info.Port), true, &tlsConfig, certificate, info.CaCertificate, info.ConnectorAuthenticationEnabled, info.EndToEndEncryptionEnabled, wsProxy)
 			if err != nil {
+				if errors.Is(err, client.ErrConnectorHandshakeFailed) || errors.Is(err, client.ErrProxyHandshakeFailed) {
+					fmt.Printf("Error: %s. You may not be authorized for this socket. Speak to your Border0 administrator\n", err)
+					return
+				}
 				fmt.Printf("failed to connect: %s\n", err)
 				return
 			}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -42,7 +42,8 @@ import (
 )
 
 var (
-	ErrHandshakeFailed = errors.New("failed to authenticate against connector")
+	ErrProxyHandshakeFailed     = errors.New("failed to authenticate against Border0 proxy")
+	ErrConnectorHandshakeFailed = errors.New("failed to authenticate against connector")
 )
 
 const (
@@ -910,7 +911,7 @@ func Connect(addr string, tlsNeeded bool, tlsConfig *tls.Config, certificate tls
 	if tlsNeeded || connectorAuthenticationEnabled || endToEndEncryptionEnabled {
 		tlsConn := tls.Client(conn, tlsConfig)
 		if err := tlsConn.Handshake(); err != nil {
-			return nil, fmt.Errorf("failed to handshake with proxy: %w", err)
+			return nil, fmt.Errorf("%w: %v", ErrProxyHandshakeFailed, err)
 		}
 
 		conn = tlsConn
@@ -961,7 +962,7 @@ func connectWithConn(conn net.Conn, certificate tls.Certificate, caCert *x509.Ce
 
 	connectorConn := tls.Client(conn, tlsConfig)
 	if err := connectorConn.Handshake(); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrHandshakeFailed, err)
+		return nil, fmt.Errorf("%w: %v", ErrConnectorHandshakeFailed, err)
 	}
 
 	if endToEndEncryptionEnabled {


### PR DESCRIPTION
## [[ME-2711](https://mysocket.atlassian.net/browse/ME-2711)] Fix NPE in Client TLS/VNC/RDP

NPE:

```
$ border0 client rdp
? choose a host: shy-breeze-border0-demo.border0.io []
2024/03/18 13:09:17 Waiting for connections on localhost:61070...
failed to connect: failed to authenticate against connector: EOF
2024/03/18 13:09:17 Connection established from 127.0.0.1:61071
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x104f2b498]

goroutine 23 [running]:
github.com/borderzero/border0-cli/cmd/client/utils.copyStream.func1()
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:41 +0xc8
created by github.com/borderzero/border0-cli/cmd/client/utils.copyStream in goroutine 70
	/home/runner/work/border0-cli/border0-cli/cmd/client/utils/copy.go:24 +0xe0
```

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2711

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

[ME-2711]: https://mysocket.atlassian.net/browse/ME-2711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ