### PR TITLE
[ME-2727] Extend AWS Connector Installer to Use Invite Codes

### DIFF
--- a/cmd/connector.go
+++ b/cmd/connector.go
@@ -319,7 +319,7 @@ func connectorInstallAws(cmd *cobra.Command) {
 	}()
 
 	loginCmd.Run(cmd, []string{})
-	if err := install.RunCloudInstallWizardForAWS(ctx, internal.Version); err != nil {
+	if err := install.RunCloudInstallWizardForAWS(ctx, inviteCode, internal.Version); err != nil {
 		fmt.Printf("\nError: %s\n", err)
 		os.Exit(1)
 	}
@@ -452,6 +452,7 @@ func init() {
 	connectorInstallCmd.Flags().BoolVarP(&aws, "aws", "", false, "true to run the connector installation wizard for AWS")
 	connectorInstallCmd.Flags().BoolVarP(&daemonOnly, "daemon-only", "d", false, "Install the daemon only, do not create connector")
 	connectorInstallCmd.Flags().StringVarP(&token, "token", "t", "", "Border0 token for use by the installed connector")
+	connectorInstallCmd.Flags().StringVarP(&inviteCode, "invite", "i", "", "invite code for installing the connector")
 	connectorInstallCmd.Flags().BoolVar(&qr, "qr", false, "Print a QR code for authenticating with a mobile device")
 	connectorInstallCmd.Flags().MarkHidden("qr")
 

--- a/internal/connector_v2/install/aws.go
+++ b/internal/connector_v2/install/aws.go
@@ -18,6 +18,7 @@ import (
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	border0 "github.com/borderzero/border0-cli/internal/api"
+	"github.com/borderzero/border0-cli/internal/connector_v2/invite"
 	"github.com/borderzero/border0-go/lib/types/set"
 	"github.com/borderzero/border0-go/lib/types/slice"
 	"github.com/borderzero/border0-go/types/connector"
@@ -52,8 +53,8 @@ var (
 )
 
 // RunCloudInstallWizardForAWS runs the connector cloud install wizard for AWS.
-func RunCloudInstallWizardForAWS(ctx context.Context, cliVersion string) error {
-	fmt.Println(fmt.Sprintf("%s\n", banner))
+func RunCloudInstallWizardForAWS(ctx context.Context, inviteCode, cliVersion string) error {
+	fmt.Printf("%s\n\n", banner)
 
 	runId := fmt.Sprintf("border0-aws-connector-%d", time.Now().Unix())
 
@@ -80,36 +81,61 @@ func RunCloudInstallWizardForAWS(ctx context.Context, cliVersion string) error {
 		return fmt.Errorf("failed to prompt for AWS VPC Subnet ID: %v", err)
 	}
 
-	border0ConnectorName, err := getUniqueConnectorName(ctx, cliVersion, "aws-connector")
-	if err != nil {
-		return fmt.Errorf("failed to determine unique name for connector: %v", err)
+	connectorID := ""
+	connectorToken := ""
+	ssmParameter := ""
+
+	// when --invite is provided, exchange the invite code for a connector token,
+	// and then set the token in the environment variable
+	if inviteCode != "" {
+		border0TokenSsmParameter, err := promptForBorder0TokenSsmParameterPath(ctx, cfg, fmt.Sprintf("border0-%s-token", inviteCode))
+		if err != nil {
+			return fmt.Errorf("failed to prompt for AWS SSM Parameter path for Border0 token: %v", err)
+		}
+		ssmParameter = border0TokenSsmParameter
+
+		id, token, err := invite.ExchangeForAwsConnectorToken(ctx, "aws-connector", inviteCode)
+		if err != nil {
+			return fmt.Errorf("failed to exchange invite code for Border0 token: %v", err)
+		}
+		connectorID = id
+		connectorToken = token
+	} else {
+		border0ConnectorName, err := getUniqueConnectorName(ctx, cliVersion, "aws-connector")
+		if err != nil {
+			return fmt.Errorf("failed to determine unique name for connector: %v", err)
+		}
+
+		border0TokenSsmParameter, err := promptForBorder0TokenSsmParameterPath(ctx, cfg, fmt.Sprintf("border0-%s-token", border0ConnectorName))
+		if err != nil {
+			return fmt.Errorf("failed to prompt for AWS SSM Parameter path for Border0 token: %v", err)
+		}
+		ssmParameter = border0TokenSsmParameter
+
+		border0Connector, err := createNewBorder0Connector(ctx, border0ConnectorName, "AWS Cloud-Install Border0 Connector", cliVersion, false)
+		if err != nil {
+			return fmt.Errorf("failed to create new Border0 connector: %v", err)
+		}
+
+		border0Token, err := generateNewBorder0ConnectorToken(ctx, border0Connector.ConnectorID, cliVersion, fmt.Sprintf("%s-token", maxString(runId, 50)))
+		if err != nil {
+			return fmt.Errorf("failed to create new Border0 token: %v", err)
+		}
+
+		connectorID = border0Connector.ConnectorID
+		connectorToken = border0Token.Token
 	}
 
-	border0TokenSsmParameter, err := promptForBorder0TokenSsmParameterPath(ctx, cfg, fmt.Sprintf("border0-%s-token", border0ConnectorName))
-	if err != nil {
-		return fmt.Errorf("failed to prompt for AWS SSM Parameter path for Border0 token: %v", err)
-	}
-
-	border0Connector, err := createNewBorder0Connector(ctx, border0ConnectorName, "AWS Cloud-Install Border0 Connector", cliVersion, false)
-	if err != nil {
-		return fmt.Errorf("failed to create new Border0 connector: %v", err)
-	}
-
-	if err = enableAwsDiscoveryPluginsForConnector(ctx, border0Connector.ConnectorID, cliVersion); err != nil {
+	if err = enableAwsDiscoveryPluginsForConnector(ctx, connectorID, cliVersion); err != nil {
 		// we don't fail here on purpose
 		fmt.Printf("warning: failed to enable AWS plugins: %v\n", err)
-	}
-
-	border0Token, err := generateNewBorder0ConnectorToken(ctx, border0Connector.ConnectorID, cliVersion, fmt.Sprintf("%s-token", maxString(runId, 50)))
-	if err != nil {
-		return fmt.Errorf("failed to create new Border0 token: %v", err)
 	}
 
 	err = saveBorder0TokenInSsmParameterStore(
 		ctx,
 		cfg,
-		border0Token.Token,
-		border0TokenSsmParameter,
+		connectorToken,
+		ssmParameter,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to store new Border0 token in AWS SSM: %v", err)
@@ -121,7 +147,7 @@ func RunCloudInstallWizardForAWS(ctx context.Context, cliVersion string) error {
 		runId,
 		vpcId,
 		subnetId,
-		border0TokenSsmParameter,
+		ssmParameter,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create connector resources in AWS: %v", err)

--- a/internal/connector_v2/invite/invite.go
+++ b/internal/connector_v2/invite/invite.go
@@ -51,6 +51,24 @@ func ExchangeForConnectorToken(ctx context.Context, inviteCode string) (connecto
 	return connectorToken, nil
 }
 
+// ExchangeForAwsConnectorToken uses an invite code to create a new connector and connector token.
+// It excludes some of the behaviour of the ExchangeForConnectorToken because we are getting a connector
+// token for a *remote* machine, not the *local* machine.
+func ExchangeForAwsConnectorToken(ctx context.Context, name, inviteCode string) (connectorID, connectorToken string, err error) {
+	// connector token not yet writen to file, this is the first time the invite code is used, so we need to
+	// use the invite code to exchange for a connector token
+	border0Client := border0.NewAPI(border0.WithVersion(internal.Version))
+
+	reply, err := border0Client.CreateConnectorWithInstallToken(ctx, name, inviteCode)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create connector with invite code: %w", err)
+	}
+	connectorID = reply.Connector.ConnectorID
+	connectorToken = reply.ConnectorToken.Token
+
+	return connectorID, connectorToken, nil
+}
+
 func readConnectorTokenFromFile(inviteCode string) (string, error) {
 	dotBorder0Dir, err := files.DotBorder0Dir()
 	if err != nil {


### PR DESCRIPTION
## [[ME-2727](https://mysocket.atlassian.net/browse/ME-2727)] Extend AWS Connector Installer to Use Invite Codes

Extends the AWS connector installer to allow for invite codes.

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2727

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

[ME-2727]: https://mysocket.atlassian.net/browse/ME-2727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ