### PR TITLE
[ME-2710] Support for Service Account Tokens

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -120,12 +120,12 @@ var clientLoginStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Check login status, see if token is still valid",
 	Run: func(cmd *cobra.Command, args []string) {
-		valid, _, email, err := client.IsExistingClientTokenValid("")
+		valid, _, identity, err := client.IsExistingClientTokenValid("")
 		if !valid {
 			fmt.Println(err)
 			fmt.Println("Please login again: border0 client login")
 		} else {
-			fmt.Println("Token Valid, logged in as " + email)
+			fmt.Println("Token Valid, logged in as " + identity)
 		}
 	},
 }

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -1,0 +1,67 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARR    ANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/borderzero/border0-cli/internal"
+	"github.com/borderzero/border0-cli/internal/api"
+	"github.com/jedib0t/go-pretty/table"
+
+	"github.com/spf13/cobra"
+)
+
+// whoamiCmd represents the whoami command
+var whoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "show authenticated identity details",
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		border0API := api.NewAPI(api.WithVersion(internal.Version))
+		details, err := border0API.Whoami(cmd.Context())
+		if err != nil {
+			return fmt.Errorf("failed to get authenticated identity details: %v", err)
+		}
+
+		ta := table.NewWriter()
+
+		ta.AppendRow(table.Row{"ORGANIZATION", details["organization"]})
+		ta.AppendRow(table.Row{"IDENTITY TYPE", details["type"]})
+		ta.AppendRow(table.Row{"IDENTITY NAME", details["name"]})
+		ta.AppendRow(table.Row{"IDENTITY ID", details["id"]})
+		ta.AppendRow(table.Row{"IDENTITY ROLE", details["role"]})
+
+		delete(details, "organization")
+		delete(details, "type")
+		delete(details, "name")
+		delete(details, "id")
+		delete(details, "role")
+
+		for k, v := range details {
+			ta.AppendRow(table.Row{strings.ToUpper(strings.ReplaceAll(k, "_", " ")), v})
+		}
+		ta.SetStyle(table.StyleLight)
+		fmt.Printf("%s\n", ta.Render())
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(whoamiCmd)
+}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -792,3 +792,14 @@ func (a *Border0API) ServerOrgCertificate(ctx context.Context, name string, csr 
 
 	return []byte(signSshOrgCertificateResponse.Certificate), nil
 }
+
+func (a *Border0API) Whoami(ctx context.Context) (map[string]any, error) {
+	m := map[string]any{}
+
+	err := a.Request(http.MethodGet, "iam/whoami", &m, nil, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}


### PR DESCRIPTION
## [[ME-2710](https://mysocket.atlassian.net/browse/ME-2710)] Support for Service Account Tokens

Adds support for service account tokens. Service account tokens have a long lifetime, potentially infinite. If the token itself doesnt have an `exp` claim then we won't ask the user to log in as long as it also has a `service_account_id` claim.

(Obviously there is server side logic to handle this in terms of authentication, what we are changing here is just the client side logic to determine if the user should be prompted to log in or not).

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2710

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested using service identity tokens as client tokens and admin tokens. Also tested with human auth and legacy token auth.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

[ME-2710]: https://mysocket.atlassian.net/browse/ME-2710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ