### PR TITLE
[ME-2770] Support for Update Service Account

### DIFF
--- a/cmd/serviceaccount/cmd_serviceaccount_token_create.go
+++ b/cmd/serviceaccount/cmd_serviceaccount_token_create.go
@@ -29,7 +29,7 @@ func getServiceAccountTokenCreateCmdHandler() func(cmd *cobra.Command, args []st
 		}
 
 		if name == "" {
-			util.FailPretty("name is a required flag")
+			util.FailPretty("service-account-name is a required flag")
 		}
 		if tokenName == "" {
 			util.FailPretty("token-name is a required flag")

--- a/cmd/serviceaccount/cmd_serviceaccount_update.go
+++ b/cmd/serviceaccount/cmd_serviceaccount_update.go
@@ -1,0 +1,79 @@
+package serviceaccount
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	border0 "github.com/borderzero/border0-cli/internal/http"
+	"github.com/jedib0t/go-pretty/table"
+
+	"github.com/borderzero/border0-cli/internal/util"
+	"github.com/spf13/cobra"
+)
+
+func getServiceAccountUpdateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update",
+		Short: "update a service account in an organization",
+		Run:   getServiceAccountUpdateCmdHandler(),
+	}
+}
+
+func getServiceAccountUpdateCmdHandler() func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		client, err := border0.NewClient()
+		if err != nil {
+			util.FailPretty("failed to get Border0 API client: %s", err)
+		}
+
+		if name == "" {
+			util.FailPretty("name is a required flag")
+		}
+
+		var resp serviceAccountSummary
+		if err = client.Request(http.MethodGet, fmt.Sprintf("organizations/iam/service_accounts/%s", name), &resp, nil); err != nil {
+			util.FailPretty("failed to get service account: %s", err)
+		}
+
+		if description != "" {
+			resp.Description = description
+		}
+		if active != "" {
+			if strings.ToLower(active) == "true" {
+				resp.Active = true
+			}
+			if strings.ToLower(active) == "false" {
+				resp.Active = false
+			}
+		}
+		if role != "" {
+			resp.Role = role
+		}
+
+		var putresp serviceAccountSummary
+		if err = client.Request(http.MethodPut, fmt.Sprintf("organizations/iam/service_accounts/%s", name), &putresp, resp); err != nil {
+			util.FailPretty("failed to update service account %s: %s", name, err)
+		}
+		resp = putresp
+
+		if jsonOutput {
+			jsonBytes, err := json.Marshal(resp)
+			if err != nil {
+				util.FailPretty("failed to marshal response as json: %s", err)
+			}
+			fmt.Println(string(jsonBytes))
+			return
+		}
+
+		serviceAccountTable := table.NewWriter()
+		serviceAccountTable.AppendRow(table.Row{"Name", resp.Name})
+		serviceAccountTable.AppendRow(table.Row{"Role", resp.Role})
+		serviceAccountTable.AppendRow(table.Row{"Active", resp.Active})
+		serviceAccountTable.AppendRow(table.Row{"Description", resp.Description})
+		serviceAccountTable.AppendRow(table.Row{"Created At", resp.CreatedAt})
+		serviceAccountTable.AppendRow(table.Row{"Updated At", resp.UpdatedAt})
+		fmt.Println(serviceAccountTable.Render())
+	}
+}

--- a/cmd/serviceaccount/common.go
+++ b/cmd/serviceaccount/common.go
@@ -6,6 +6,7 @@ var (
 	tokenName    string
 	description  string
 	role         string
+	active       string
 	lifetimeDays int
 	jsonOutput   bool
 )

--- a/cmd/serviceaccount/root_serviceaccount.go
+++ b/cmd/serviceaccount/root_serviceaccount.go
@@ -18,6 +18,13 @@ func GetServiceAccountCmdRoot() *cobra.Command {
 	svcAccountCreateCmd.Flags().StringVarP(&role, "role", "r", "", "service account role e.g. 'client', 'member', 'admin'")
 	svcAccountCreateCmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "print json output")
 
+	svcAccountUpdateCmd := getServiceAccountUpdateCmd()
+	svcAccountUpdateCmd.Flags().StringVarP(&name, "name", "n", "", "service account name")
+	svcAccountUpdateCmd.Flags().StringVarP(&description, "description", "d", "", "service account description")
+	svcAccountUpdateCmd.Flags().StringVarP(&role, "role", "r", "", "service account role e.g. 'client', 'member', 'admin'")
+	svcAccountUpdateCmd.Flags().StringVarP(&active, "active", "a", "", "service account status (true for active, false for inactive)")
+	svcAccountUpdateCmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "print json output")
+
 	svcAccountDeleteCmd := getServiceAccountDeleteCmd()
 	svcAccountDeleteCmd.Flags().StringVarP(&name, "name", "n", "", "service account name")
 
@@ -29,6 +36,7 @@ func GetServiceAccountCmdRoot() *cobra.Command {
 		svcAccountShowCmd,
 		svcAccountListCmd,
 		svcAccountCreateCmd,
+		svcAccountUpdateCmd,
 		svcAccountDeleteCmd,
 		GetServiceAccountTokenCmdRoot(),
 	)

--- a/cmd/serviceaccount/root_serviceaccounttoken.go
+++ b/cmd/serviceaccount/root_serviceaccounttoken.go
@@ -6,7 +6,7 @@ import (
 
 func GetServiceAccountTokenCmdRoot() *cobra.Command {
 	svcAccountTokenCreateCmd := getServiceAccountTokenCreateCmd()
-	svcAccountTokenCreateCmd.Flags().StringVarP(&name, "name", "n", "", "service account name")
+	svcAccountTokenCreateCmd.Flags().StringVarP(&name, "service-account-name", "s", "", "service account name")
 	svcAccountTokenCreateCmd.Flags().StringVarP(&tokenName, "token-name", "t", "cli-token", "service account token name")
 	svcAccountTokenCreateCmd.Flags().IntVarP(&lifetimeDays, "lifetime-days", "d", 365, "service account token lifetime days (0 for no expiry)")
 	svcAccountTokenCreateCmd.Flags().BoolVarP(&jsonOutput, "json", "j", false, "print json output")


### PR DESCRIPTION
## [[ME-2770](https://mysocket.atlassian.net/browse/ME-2770)] Support for Update Service Account

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context

Fixes # (issue)
- https://mysocket.atlassian.net/browse/ME-2770

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with the locally built version of the CLI:

```
✔ ~/go/src/github.com/borderzero/border0-cli [ME-2770_add_update_svc_account|✔]
12:44 $ ./border0 organization service-account list
+--------------------------+--------+--------+-------------+----------------------+----------------------+
| NAME                     | ROLE   | ACTIVE | DESCRIPTION | CREATED AT           | UPDATED AT           |
+--------------------------+--------+--------+-------------+----------------------+----------------------+
| adrianos-service-account | client | true   | whatever    | 2024-04-02T18:14:56Z | 2024-04-02T19:30:40Z |
+--------------------------+--------+--------+-------------+----------------------+----------------------+

✔ ~/go/src/github.com/borderzero/border0-cli [ME-2770_add_update_svc_account|✔]
12:44 $ ./border0 organization service-account update --name adrianos-service-account --role admin --active false --description new-description
+-------------+--------------------------+
| Name        | adrianos-service-account |
| Role        | admin                    |
| Active      | false                    |
| Description | new-description          |
| Created At  | 2024-04-02T18:14:56Z     |
| Updated At  | 2024-04-02T19:44:54Z     |
+-------------+--------------------------+
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

[ME-2770]: https://mysocket.atlassian.net/browse/ME-2770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ