### PR TITLE
ME-2777: trigger AWX-EE build after border0 release

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -383,3 +383,20 @@ jobs:
               workflow_id: 'bump_version_and_create_pr.yml',
               ref: 'main'
             })
+
+  # trigger AWX-EE build
+  trigger-awx-ee-build:
+    needs: [cloudfront-cache, release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger AWX-EE build
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.BORDERZERO_GH_ACCESS_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'borderzero',
+              repo: 'awx-ee',
+              workflow_id: 'build-awx-ee.yml',
+              ref: 'main'
+            })


### PR DESCRIPTION
# Description

We need to trigger AWX-EE build after border0 release to keep the public facing software in sync

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A - trigger for external repo build 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
