### PR TITLE
ME-2781 RFC2460: VPN socket MTU

### DIFF
--- a/internal/vpnlib/iputil.go
+++ b/internal/vpnlib/iputil.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	ipv4HeaderLengthBytes = 20
+	ipv6HeaderLengthBytes = 40
 )
 
 func cidrToUsableIPs(cidr string) ([]string, uint8, error) {
@@ -50,6 +51,17 @@ func validateIPv4(packet []byte) error {
 	ipVersion := (packet[0] & 0xF0) >> 4
 	if ipVersion != 4 {
 		return fmt.Errorf("packet header advertises non IPv4, version: %d", ipVersion)
+	}
+	return nil
+}
+
+func validateIPv6(packet []byte) error {
+	if len(packet) < ipv6HeaderLengthBytes {
+		return fmt.Errorf("packet too short for IPv6")
+	}
+	ipVersion := (packet[0] & 0xF0) >> 4
+	if ipVersion != 6 {
+		return fmt.Errorf("packet header advertises non IPv6, version: %d", ipVersion)
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

Updating vpn socket MTU 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
root@au-rpi0w:/home/pi# ip -s -d link sho dev tun0
4: tun0: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1380 qdisc pfifo_fast state UNKNOWN mode DEFAULT group default qlen 500
    link/none  promiscuity 0  allmulti 0 minmtu 68 maxmtu 65535 
    tun type tun pi off vnet_hdr off persist off addrgenmode random numtxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 
    RX:  bytes packets errors dropped  missed   mcast           
        372886    1743      0       0       0       0 
    TX:  bytes packets errors dropped carrier collsns           
        437512    2105      0       0       0       0 
root@au-rpi0w:/home/pi# tcpdump  -ln -i tun0 icmp -c 2
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on tun0, link-type RAW (Raw IP), snapshot length 262144 bytes
19:54:09.044535 IP 10.0.0.5 > 192.168.254.254: ICMP echo request, id 24, seq 50, length 1360
19:54:09.044773 IP 192.168.254.254 > 10.0.0.5: ICMP echo reply, id 24, seq 50, length 1360
2 packets captured
2 packets received by filter
0 packets dropped by kernel
```
on the origin
```
greg@XPS15:~$ ping 192.168.254.254 -M do -s 1352 -c 2
PING 192.168.254.254 (192.168.254.254) 1352(1380) bytes of data.
1360 bytes from 192.168.254.254: icmp_seq=1 ttl=64 time=60.2 ms
1360 bytes from 192.168.254.254: icmp_seq=2 ttl=64 time=56.4 ms

--- 192.168.254.254 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 56.379/58.298/60.217/1.919 ms
greg@XPS15:~$ ping 192.168.254.254 -M do -s 1353 -c 2
PING 192.168.254.254 (192.168.254.254) 1353(1381) bytes of data.
ping: local error: message too long, mtu=1380
ping: local error: message too long, mtu=1380

--- 192.168.254.254 ping statistics ---
2 packets transmitted, 0 received, +2 errors, 100% packet loss, time 1017ms

```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
